### PR TITLE
FIX RN>=0.47.0. Removing @override

### DIFF
--- a/android/src/main/java/com/googlecast/GoogleCastPackage.java
+++ b/android/src/main/java/com/googlecast/GoogleCastPackage.java
@@ -26,7 +26,6 @@ public class GoogleCastPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Removed @Override on method createJSModules in GoogleCastPackage.java to support RN>=0.47.0

In this PR we are just removing the `@override` in order to still support older versions of RN.