### PR TITLE
RN47.0 has removed `createJSModules` method

### DIFF
--- a/android/src/main/java/com/googlecast/GoogleCastPackage.java
+++ b/android/src/main/java/com/googlecast/GoogleCastPackage.java
@@ -26,7 +26,6 @@ public class GoogleCastPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Hi,

RN47.0 has removed createJSModule method from ReactPackage.java. In order to make it work on Android with RN47.0, I have removed @overide annotation from GoogleCastPackage.java class.

Can you please merge and release so that we can seamlessly use this library on RN47.0 and above

Please let me know in case any changes are required

Thanks,
Pranav