### PR TITLE
Add optional contentType config to castMedia()

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ GoogleCast.castMedia({
     'A large and lovable rabbit deals with three tiny bullies, led by a flying squirrel, who are determined to squelch his happiness.',
   studio: 'Blender Foundation',
   streamDuration: 596, // seconds
+  contentType: "video/mp4", // Optional, default is "video/mp4"
   playPosition: 10, // seconds
 })
 ```

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -147,8 +147,13 @@ public class GoogleCastModule
     MediaInfo.Builder builder =
         new MediaInfo.Builder(params.getString("mediaUrl"))
             .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
-            .setContentType("videos/mp4")
             .setMetadata(movieMetadata);
+
+    if (params.hasKey("contentType") && params.getString("contentType") != null) {
+      builder = builder.setContentType(params.getString("contentType"));
+    } else {
+      builder = builder.setContentType("video/mp4");
+    }
 
     if (params.hasKey("duration")) {
       builder = builder.setStreamDuration(params.getInt("duration"));

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -141,6 +141,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   NSString *studio = [RCTConvert NSString:params[@"studio"]];
   NSString *imageUrl = [RCTConvert NSString:params[@"imageUrl"]];
   NSString *posterUrl = [RCTConvert NSString:params[@"posterUrl"]];
+  NSString *contentType = [RCTConvert NSString:params[@"contentType"]];
   double streamDuration = [RCTConvert double:params[@"streamDuration"]];
   double playPosition = [RCTConvert double:params[@"playPosition"]];
 
@@ -158,6 +159,9 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   if (studio) {
     [metadata setString:studio forKey:kGCKMetadataKeyStudio];
   }
+  if (!contentType) {
+    contentType = @"video/mp4"
+  }
 
   [metadata addImage:[[GCKImage alloc]
                          initWithURL:[[NSURL alloc] initWithString:imageUrl]
@@ -173,7 +177,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   GCKMediaInformation *mediaInfo =
       [[GCKMediaInformation alloc] initWithContentID:mediaUrl
                                           streamType:GCKMediaStreamTypeBuffered
-                                         contentType:@"video/mp4"
+                                         contentType:contentType
                                             metadata:metadata
                                       streamDuration:streamDuration
                                          mediaTracks:nil


### PR DESCRIPTION
Default value remains "video/mp4", but now consumers can specify the
appropriate content type for URL that they provide (e.g., "audio/mpeg").