### PR TITLE
Add proper search path to fix the issue #51 where GoogleCast.h cannot be found

### DIFF
--- a/ios/RNGoogleCast.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleCast.xcodeproj/project.pbxproj
@@ -208,11 +208,12 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Pods/google-cast-sdk/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(PROJECT_DIR)/../../../ios/**",
+					"$(SRCROOT)/../../../ios/Pods/google-cast-sdk/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -224,11 +225,12 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Pods/google-cast-sdk/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(PROJECT_DIR)/../../../ios/**",
+					"$(SRCROOT)/../../../ios/Pods/google-cast-sdk/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Hey, the current search path setting seems to have some problem. Once I install the library, it won't compile in Xcode, complaining the  GoogleCast.h cannot be found. I have added the proper search path in this commit. I tested it and It works for me under Xcode 10 and iOS 12. 