### PR TITLE
New Methods Android

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.util.Log;
-
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -22,42 +22,46 @@ import com.google.android.gms.cast.framework.SessionManager;
 import com.google.android.gms.cast.framework.SessionManagerListener;
 import com.google.android.gms.cast.framework.media.RemoteMediaClient;
 import com.google.android.gms.common.images.WebImage;
-
+import static com.reactnative.googlecast.GoogleCastPackage.NAMESPACE;
+import static com.reactnative.googlecast.GoogleCastPackage.metadata;
 import java.util.HashMap;
 import java.util.Map;
 
 public class GoogleCastModule
-    extends ReactContextBaseJavaModule implements LifecycleEventListener {
+        extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
   @VisibleForTesting public static final String REACT_CLASS = "RNGoogleCast";
 
   protected static final String SESSION_STARTING = "GoogleCast:SessionStarting";
   protected static final String SESSION_STARTED = "GoogleCast:SessionStarted";
   protected static final String SESSION_START_FAILED =
-      "GoogleCast:SessionStartFailed";
+          "GoogleCast:SessionStartFailed";
   protected static final String SESSION_SUSPENDED =
-      "GoogleCast:SessionSuspended";
+          "GoogleCast:SessionSuspended";
   protected static final String SESSION_RESUMING = "GoogleCast:SessionResuming";
   protected static final String SESSION_RESUMED = "GoogleCast:SessionResumed";
   protected static final String SESSION_ENDING = "GoogleCast:SessionEnding";
   protected static final String SESSION_ENDED = "GoogleCast:SessionEnded";
+  protected static final String MESSAGE_RECEIVED = "GoogleCast:MessageReceived";
 
   protected static final String MEDIA_STATUS_UPDATED =
-      "GoogleCast:MediaStatusUpdated";
+          "GoogleCast:MediaStatusUpdated";
   protected static final String MEDIA_PLAYBACK_STARTED =
-      "GoogleCast:MediaPlaybackStarted";
+          "GoogleCast:MediaPlaybackStarted";
   protected static final String MEDIA_PLAYBACK_ENDED =
-      "GoogleCast:MediaPlaybackEnded";
+          "GoogleCast:MediaPlaybackEnded";
   protected static final String MEDIA_PROGRESS_UPDATED =
-      "GoogleCast:MediaProgressUpdated";
+          "GoogleCast:MediaProgressUpdated";
 
   private CastSession mCastSession;
   private SessionManagerListener<CastSession> mSessionManagerListener;
+  String namespace;
 
   public GoogleCastModule(ReactApplicationContext reactContext) {
     super(reactContext);
     reactContext.addLifecycleEventListener(this);
     setupCastListener();
+    namespace = metadata(NAMESPACE, "", reactContext);
   }
 
   @Override
@@ -77,6 +81,7 @@ public class GoogleCastModule
     constants.put("SESSION_RESUMED", SESSION_RESUMED);
     constants.put("SESSION_ENDING", SESSION_ENDING);
     constants.put("SESSION_ENDED", SESSION_ENDED);
+    constants.put("MESSAGE_RECEIVED", MESSAGE_RECEIVED);
 
     constants.put("MEDIA_STATUS_UPDATED", MEDIA_STATUS_UPDATED);
     constants.put("MEDIA_PLAYBACK_STARTED", MEDIA_PLAYBACK_STARTED);
@@ -89,8 +94,8 @@ public class GoogleCastModule
   protected void emitMessageToRN(String eventName,
                                  @Nullable WritableMap params) {
     getReactApplicationContext()
-        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-        .emit(eventName, params);
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(eventName, params);
   }
 
   @ReactMethod
@@ -103,7 +108,7 @@ public class GoogleCastModule
       @Override
       public void run() {
         RemoteMediaClient remoteMediaClient =
-            mCastSession.getRemoteMediaClient();
+                mCastSession.getRemoteMediaClient();
         if (remoteMediaClient == null) {
           return;
         }
@@ -125,40 +130,40 @@ public class GoogleCastModule
 
   private MediaInfo buildMediaInfo(ReadableMap params) {
     MediaMetadata movieMetadata =
-        new MediaMetadata(MediaMetadata.MEDIA_TYPE_MOVIE);
+            new MediaMetadata(MediaMetadata.MEDIA_TYPE_MOVIE);
 
     if (params.hasKey("title") && params.getString("title") != null) {
       movieMetadata.putString(MediaMetadata.KEY_TITLE,
-                              params.getString("title"));
+              params.getString("title"));
     }
 
     if (params.hasKey("subtitle") && params.getString("subtitle") != null) {
       movieMetadata.putString(MediaMetadata.KEY_SUBTITLE,
-                              params.getString("subtitle"));
+              params.getString("subtitle"));
     }
 
     if (params.hasKey("studio") && params.getString("studio") != null) {
       movieMetadata.putString(MediaMetadata.KEY_STUDIO,
-                              params.getString("studio"));
+              params.getString("studio"));
     }
 
     if (params.hasKey("imageUrl") && params.getString("imageUrl") != null) {
       movieMetadata.addImage(
-          new WebImage(Uri.parse(params.getString("imageUrl"))));
+              new WebImage(Uri.parse(params.getString("imageUrl"))));
     }
 
     if (params.hasKey("posterUrl") && params.getString("posterUrl") != null) {
       movieMetadata.addImage(
-          new WebImage(Uri.parse(params.getString("posterUrl"))));
+              new WebImage(Uri.parse(params.getString("posterUrl"))));
     }
 
     MediaInfo.Builder builder =
-        new MediaInfo.Builder(params.getString("mediaUrl"))
-            .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
-            .setMetadata(movieMetadata);
+            new MediaInfo.Builder(params.getString("mediaUrl"))
+                    .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+                    .setMetadata(movieMetadata);
 
     if (params.hasKey("contentType") &&
-        params.getString("contentType") != null) {
+            params.getString("contentType") != null) {
       builder = builder.setContentType(params.getString("contentType"));
     } else {
       builder = builder.setContentType("video/mp4");
@@ -177,7 +182,7 @@ public class GoogleCastModule
       @Override
       public void run() {
         CastContext castContext =
-            CastContext.getSharedInstance(getReactApplicationContext());
+                CastContext.getSharedInstance(getReactApplicationContext());
         promise.resolve(castContext.getCastState() - 1);
       }
     });
@@ -237,8 +242,8 @@ public class GoogleCastModule
       @Override
       public void run() {
         SessionManager sessionManager =
-            CastContext.getSharedInstance(getReactApplicationContext())
-                .getSessionManager();
+                CastContext.getSharedInstance(getReactApplicationContext())
+                        .getSessionManager();
         sessionManager.endCurrentSession(stopCasting);
         promise.resolve(true);
       }
@@ -249,7 +254,7 @@ public class GoogleCastModule
   public void launchExpandedControls() {
     ReactApplicationContext context = getReactApplicationContext();
     Intent intent =
-        new Intent(context, GoogleCastExpandedControlsActivity.class);
+            new Intent(context, GoogleCastExpandedControlsActivity.class);
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     context.startActivity(intent);
   }
@@ -261,10 +266,15 @@ public class GoogleCastModule
   @ReactMethod
   public void sendMessage(final String namespace, final String message) {
     if (mCastSession != null) {
+      final String defaultNameSpace = this.namespace;
       getReactApplicationContext().runOnUiQueueThread(new Runnable() {
         @Override
         public void run() {
-          mCastSession.sendMessage(namespace, message);
+          if(namespace.isEmpty()){
+            mCastSession.sendMessage(defaultNameSpace, message);
+          }else{
+            mCastSession.sendMessage(namespace, message);
+          }
         }
       });
     }
@@ -291,10 +301,10 @@ public class GoogleCastModule
       @Override
       public void run() {
         SessionManager sessionManager =
-            CastContext.getSharedInstance(getReactApplicationContext())
-                .getSessionManager();
+                CastContext.getSharedInstance(getReactApplicationContext())
+                        .getSessionManager();
         sessionManager.addSessionManagerListener(mSessionManagerListener,
-                                                 CastSession.class);
+                CastSession.class);
       }
     });
   }
@@ -305,10 +315,10 @@ public class GoogleCastModule
       @Override
       public void run() {
         SessionManager sessionManager =
-            CastContext.getSharedInstance(getReactApplicationContext())
-                .getSessionManager();
+                CastContext.getSharedInstance(getReactApplicationContext())
+                        .getSessionManager();
         sessionManager.removeSessionManagerListener(mSessionManagerListener,
-                                                    CastSession.class);
+                CastSession.class);
       }
     });
   }

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -258,6 +258,33 @@ public class GoogleCastModule
     mSessionManagerListener = new GoogleCastSessionManagerListener(this);
   }
 
+  @ReactMethod
+  public void sendMessage(final String namespace, final String message) {
+    if (mCastSession != null) {
+      getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+        @Override
+        public void run() {
+          mCastSession.sendMessage(namespace, message);
+        }
+      });
+    }
+  }
+
+  @ReactMethod
+  public void getCurrentDevice(final Promise promise) {
+    getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+      @Override
+      public void run() {
+        WritableMap map = Arguments.createMap();
+        map.putString("id:", mCastSession.getCastDevice().getDeviceId());
+        map.putString("version:", mCastSession.getCastDevice().getDeviceVersion());
+        map.putString("name:", mCastSession.getCastDevice().getFriendlyName());
+        map.putString("model:", mCastSession.getCastDevice().getModelName());
+        promise.resolve(map);
+      }
+    });
+  }
+
   @Override
   public void onHostResume() {
     getReactApplicationContext().runOnUiQueueThread(new Runnable() {

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastPackage.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastPackage.java
@@ -1,16 +1,27 @@
 package com.reactnative.googlecast;
 
+import android.content.pm.PackageManager;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class GoogleCastPackage implements ReactPackage {
+  static final String NAMESPACE = "com.chromecastreactnative.NAMESPACE";
+
+  static String metadata(String key, String defaultValue, ReactApplicationContext reactContext) {
+    try {
+      return reactContext.getPackageManager()
+              .getApplicationInfo(reactContext.getPackageName(), PackageManager.GET_META_DATA)
+              .metaData.getString(key, defaultValue);
+    } catch (PackageManager.NameNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   @Override
   public List<NativeModule>

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastSessionManagerListener.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastSessionManagerListener.java
@@ -1,10 +1,16 @@
 package com.reactnative.googlecast;
 
+import android.util.Log;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.google.android.gms.cast.Cast;
+import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.framework.CastSession;
 import com.google.android.gms.cast.framework.SessionManagerListener;
+import java.io.IOException;
 
 public class GoogleCastSessionManagerListener
-    implements SessionManagerListener<CastSession> {
+        implements SessionManagerListener<CastSession> {
   private GoogleCastModule module;
   private GoogleCastRemoteMediaClientListener remoteMediaClientListener;
 
@@ -22,6 +28,7 @@ public class GoogleCastSessionManagerListener
   public void onSessionResumed(CastSession session, boolean wasSuspended) {
     onApplicationConnected(session);
     module.emitMessageToRN(GoogleCastModule.SESSION_RESUMED, null);
+    setMessageReceivedCallbacks(session);
   }
 
   @Override
@@ -34,6 +41,7 @@ public class GoogleCastSessionManagerListener
   public void onSessionStarted(CastSession session, String sessionId) {
     onApplicationConnected(session);
     module.emitMessageToRN(GoogleCastModule.SESSION_STARTED, null);
+    setMessageReceivedCallbacks(session);
   }
 
   @Override
@@ -68,13 +76,36 @@ public class GoogleCastSessionManagerListener
       @Override
       public void run() {
         remoteMediaClientListener =
-            new GoogleCastRemoteMediaClientListener(module);
+                new GoogleCastRemoteMediaClientListener(module);
         castSession.getRemoteMediaClient().addListener(
-            remoteMediaClientListener);
+                remoteMediaClientListener);
         castSession.getRemoteMediaClient().addProgressListener(remoteMediaClientListener, 1000);
       }
     });
   }
 
   private void onApplicationDisconnected() { module.setCastSession(null); }
+
+  private void setMessageReceivedCallbacks(CastSession session) {
+    try {
+      if (module.namespace != null)
+        session.setMessageReceivedCallbacks(
+                module.namespace,
+                new CastMessageReceivedCallback());
+    } catch (IOException e) {
+      Log.e("tagOnSetReceiver", "Cast channel creation failed: ", e);
+    }
+  }
+
+  private class CastMessageReceivedCallback implements Cast.MessageReceivedCallback {
+    @Override
+    public void onMessageReceived(CastDevice castDevice, String namespace, String message) {
+      Log.d("tagOnMessage", "onMessageReceived: " + namespace + " / " + message);
+      WritableMap map = Arguments.createMap();
+      map.putString("namespace", namespace);
+      map.putString("message", message);
+
+      module.emitMessageToRN(GoogleCastModule.MESSAGE_RECEIVED, map);
+    }
+  }
 }

--- a/index.js
+++ b/index.js
@@ -82,7 +82,12 @@ export default {
   sendMessage(namespace: string, message: string) {
     return GoogleCast.sendMessage(message, namespace)
   },
-
+  sendMessage(namespace: string, message: string) {
+    return GoogleCast.sendMessage(namespace, message)
+  },
+  getCurrentDevice() {
+    return GoogleCast.getCurrentDevice()
+  },
   // TODO use the same native event interface instead of hacking it here
   EventEmitter:
     Platform.OS === 'ios'

--- a/index.js
+++ b/index.js
@@ -75,19 +75,18 @@ export default {
   },
   launchExpandedControls: GoogleCast.launchExpandedControls,
   showIntroductoryOverlay: GoogleCast.showIntroductoryOverlay,
-
   initChannel(namespace: string) {
     return GoogleCast.initChannel(namespace)
   },
   sendMessage(namespace: string, message: string) {
-    return GoogleCast.sendMessage(message, namespace)
-  },
-  sendMessage(namespace: string, message: string) {
-    return GoogleCast.sendMessage(namespace, message)
+    return message === undefined 
+      ? GoogleCast.sendMessage("", namespace) 
+      : GoogleCast.sendMessage(namespace, message);
   },
   getCurrentDevice() {
     return GoogleCast.getCurrentDevice()
   },
+  
   // TODO use the same native event interface instead of hacking it here
   EventEmitter:
     Platform.OS === 'ios'
@@ -102,6 +101,7 @@ export default {
   SESSION_RESUMED: GoogleCast.SESSION_RESUMED,
   SESSION_ENDING: GoogleCast.SESSION_ENDING,
   SESSION_ENDED: GoogleCast.SESSION_ENDED,
+  MESSAGE_RECEIVED: GoogleCast.MESSAGE_RECEIVED,
 
   MEDIA_STATUS_UPDATED: GoogleCast.MEDIA_STATUS_UPDATED,
   MEDIA_PLAYBACK_STARTED: GoogleCast.MEDIA_PLAYBACK_STARTED,


### PR DESCRIPTION
                                    Add new  implements Android


Now we need add on AndroidManifest.xml
```
<meta-data
    android:name="com.chromecastreactnative.NAMESPACE"
    android:value="urn:x-cast: ..." /> 
```

//Example Message Receiver
```
GoogleCast.EventEmitter.addListener(GoogleCast.MESSAGE_RECEIVED, message => {
     console.warn(message);
});
```

==========******* Modification on Send Message *******==========
Now I get "namespace default" namespace of <meta-data > declared in AndroidManifest 

//Example
`sendMessage(namespace, message);`  //send message for receiver of namespace param...

`sendMessage(message); ` //send only message I get namespace of manifest and send receiver
 
 
//Exemple getCurrentDevice
```
GoogleCast.getCurrentDevice().then(state =>
    console.log(state)
);
```