### PR TITLE
BPLAT-10154 | Fix of cannot resume channel connection on iOS

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -120,6 +120,7 @@ RCT_EXPORT_METHOD(initChannel: (NSString *)namespace
   dispatch_async(dispatch_get_main_queue(), ^{
     GCKGenericChannel *channel = [[GCKGenericChannel alloc] initWithNamespace:namespace];
     channel.delegate = self;
+    [self->castSession removeChannel:channels[namespace]];
     self->channels[namespace] = channel;
     [self->castSession addChannel:channel];
     resolve(@(YES));


### PR DESCRIPTION
fix: Clear channel before initChannel to ensure the channel connection on resume

https://jira.aminocom.com/browse/BPLAT-10154