### PR TITLE
Constrain play-services-cast-framework version to 16.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '+')}"
     implementation "com.android.support:mediarouter-v7:${safeExtGet('supportLibVersion', '+')}"
-    implementation "com.google.android.gms:play-services-cast-framework:${safeExtGet('castFrameworkVersion', '+')}"
+    implementation "com.google.android.gms:play-services-cast-framework:${safeExtGet('castFrameworkVersion', '16.2.0')}"
 }


### PR DESCRIPTION
With the latest firebase/gcm release (https://developers.google.com/android/guides/releases), the latest version (`+`) now brings in androidx dependencies. react-native won't be ready for androidx until 0.60 so constraint the play-services-cast-framework version to 16.2.0 (the latest pre-androidx version)