### PR TITLE
[bug][Android] More NPE protection for casting operations

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -20,6 +20,7 @@ import com.google.android.gms.cast.Cast;
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaMetadata;
+import com.google.android.gms.cast.MediaStatus;
 import com.google.android.gms.cast.framework.CastContext;
 import com.google.android.gms.cast.framework.CastSession;
 import com.google.android.gms.cast.framework.SessionManager;
@@ -114,8 +115,7 @@ public class GoogleCastModule
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
-                RemoteMediaClient remoteMediaClient =
-                        mCastSession.getRemoteMediaClient();
+                RemoteMediaClient remoteMediaClient = mCastSession.getRemoteMediaClient();
                 if (remoteMediaClient == null) {
                     return;
                 }
@@ -280,7 +280,12 @@ public class GoogleCastModule
             getReactApplicationContext().runOnUiQueueThread(new Runnable() {
                 @Override
                 public void run() {
-                    mCastSession.getRemoteMediaClient().play();
+                    RemoteMediaClient client = mCastSession.getRemoteMediaClient();
+                    if (client == null) {
+                        return;
+                    }
+
+                    client.play();
                 }
             });
         }
@@ -292,7 +297,12 @@ public class GoogleCastModule
             getReactApplicationContext().runOnUiQueueThread(new Runnable() {
                 @Override
                 public void run() {
-                    mCastSession.getRemoteMediaClient().pause();
+                    RemoteMediaClient client = mCastSession.getRemoteMediaClient();
+                    if (client == null) {
+                        return;
+                    }
+
+                    client.pause();
                 }
             });
         }
@@ -304,7 +314,12 @@ public class GoogleCastModule
             getReactApplicationContext().runOnUiQueueThread(new Runnable() {
                 @Override
                 public void run() {
-                    mCastSession.getRemoteMediaClient().stop();
+                    RemoteMediaClient client = mCastSession.getRemoteMediaClient();
+                    if (client == null) {
+                        return;
+                    }
+
+                    client.stop();
                 }
             });
         }
@@ -316,7 +331,12 @@ public class GoogleCastModule
             getReactApplicationContext().runOnUiQueueThread(new Runnable() {
                 @Override
                 public void run() {
-                    mCastSession.getRemoteMediaClient().seek(position * 1000);
+                    RemoteMediaClient client = mCastSession.getRemoteMediaClient();
+                    if (client == null) {
+                        return;
+                    }
+
+                    client.seek(position * 1000);
                 }
             });
         }
@@ -387,6 +407,19 @@ public class GoogleCastModule
 
     protected CastSession getCastSession() {
         return mCastSession;
+    }
+    
+    protected @Nullable MediaStatus getMediaStatus() {
+        if (mCastSession == null) {
+            return null;
+        }
+
+        RemoteMediaClient client = mCastSession.getRemoteMediaClient();
+        if (client == null) {
+            return null;
+        }
+
+        return client.getMediaStatus();
     }
 
     protected void runOnUiQueueThread(Runnable runnable) {

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastRemoteMediaClientListener.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastRemoteMediaClientListener.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
+import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaStatus;
 import com.google.android.gms.cast.framework.media.RemoteMediaClient;
 
@@ -23,9 +24,7 @@ public class GoogleCastRemoteMediaClientListener
     module.runOnUiQueueThread(new Runnable() {
       @Override
       public void run() {
-        MediaStatus mediaStatus =
-            module.getCastSession().getRemoteMediaClient().getMediaStatus();
-
+        MediaStatus mediaStatus = module.getMediaStatus();
         if (mediaStatus == null) {
           return;
         }
@@ -66,8 +65,11 @@ public class GoogleCastRemoteMediaClientListener
     map.putInt("idleReason", mediaStatus.getIdleReason());
     map.putBoolean("muted", mediaStatus.isMute());
     map.putInt("streamPosition", (int)(mediaStatus.getStreamPosition() / 1000));
-    map.putInt("streamDuration",
-               (int)(mediaStatus.getMediaInfo().getStreamDuration() / 1000));
+
+    MediaInfo info = mediaStatus.getMediaInfo();
+    if (info != null) {
+      map.putInt("streamDuration", (int) (info.getStreamDuration() / 1000));
+    }
 
     WritableMap message = Arguments.createMap();
     message.putMap("mediaStatus", map);
@@ -94,9 +96,7 @@ public class GoogleCastRemoteMediaClientListener
     module.runOnUiQueueThread(new Runnable() {
       @Override
       public void run() {
-        MediaStatus mediaStatus =
-            module.getCastSession().getRemoteMediaClient().getMediaStatus();
-
+        MediaStatus mediaStatus = module.getMediaStatus();
         if (mediaStatus == null) {
           return;
         }

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastSessionManagerListener.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastSessionManagerListener.java
@@ -2,6 +2,7 @@ package com.reactnative.googlecast;
 
 import com.google.android.gms.cast.framework.CastSession;
 import com.google.android.gms.cast.framework.SessionManagerListener;
+import com.google.android.gms.cast.framework.media.RemoteMediaClient;
 
 public class GoogleCastSessionManagerListener
     implements SessionManagerListener<CastSession> {
@@ -67,11 +68,14 @@ public class GoogleCastSessionManagerListener
     module.runOnUiQueueThread(new Runnable() {
       @Override
       public void run() {
-        remoteMediaClientListener =
-            new GoogleCastRemoteMediaClientListener(module);
-        castSession.getRemoteMediaClient().addListener(
-            remoteMediaClientListener);
-        castSession.getRemoteMediaClient().addProgressListener(remoteMediaClientListener, 1000);
+        RemoteMediaClient client = castSession.getRemoteMediaClient();
+        if (client == null) {
+          return;
+        }
+
+        remoteMediaClientListener = new GoogleCastRemoteMediaClientListener(module);
+        client.addListener(remoteMediaClientListener);
+        client.addProgressListener(remoteMediaClientListener, 1000);
       }
     });
   }


### PR DESCRIPTION
Sometimes when the chromecast device has not yet received media info from the stream it is returned as null from the client. This can lead to NPEs during multiple operations (usually when dealing with MediaStatus). The remote client itself can sometimes be returned as null from the session, usually when the device has disconnected but the session has not been marked as ended by the SDK yet. In both cases we add extra NPE protection that will result in no-ops if the required objects are null.