### PR TITLE
Implement +(BOOL)requiresMainQueueSetup method to silence warnings from RN

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -19,6 +19,10 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
 - (instancetype)init {
   self = [super init];
   channels = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
We were getting the below warning in the logs when we added `react-native-google-cast` to our project. 

I implemented the `+(BOOL)requiresMainQueueSetup` method to return `NO` based on the documentation from RN: https://facebook.github.io/react-native/docs/native-modules-ios#implementing-requiresmainqueuesetup



```
2019-07-22 11:03:48.622360+0200[89799:36304199] Module RNGoogleCast requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
2019-07-22 11:03:48.630 [warn][tid:main][RCTModuleData.mm:67] Module Orientation requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```