### PR TITLE
Fixes podspec file to point to correct dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Note: This will only link the react-native-google-cast library. You'll still nee
 
 - Setup your Podfile like it is described in the [react-native documentation](https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies).
 
-- Add `pod 'google-cast-sdk', '~> 3'` to your `Podfile`. Alternatively, you can try SDK v4 by using `pod 'google-cast-sdk', '4.3.0'` (see setup below).
-
 - Add `pod 'react-native-google-cast', path: '../node_modules/react-native-google-cast/ios/'` to your `Podfile`
 
 - Run `pod install`

--- a/ios/react-native-google-cast.podspec
+++ b/ios/react-native-google-cast.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'RNGoogleCast/**/*.{h,m}'
 
   s.dependency      'React'
-  s.dependency      'google-cast-sdk', '>= 3'
+  s.dependency      'google-cast-sdk', '~> 3'
 end


### PR DESCRIPTION
Use the correct fuzzy dependency operator for the google-cast-sdk in the Podfile which results in not needing to manually ad the google-cast-sdk dependency to the Podfile by users of the library.