### PR TITLE
Add showCastPicker method to show the cast picker dialog without the button

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ GoogleCast.castMedia({
 - `GoogleCast.endSession(stopCasting)`
 - `GoogleCast.initChannel('urn:x-cast:...')` - initialize custom channel for communication with Cast receiver app. Once you do this, you can subscribe to `CHANNEL_*` events.
 - `GoogleCast.sendMessage('urn:x-cast:...', message)` - send message over the custom channel
+- `GoogleCast.showCastPicker()` - Custom method to manually pop the cast options picker. Not needed if you implement the button.
 
 ## Components
 

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
@@ -20,6 +20,7 @@ public class GoogleCastButtonManager
 
   public static final String REACT_CLASS = "RNGoogleCastButton";
   private Integer mColor = null;
+  private static MediaRouteButton googleCastButtonManagerInstance;
 
   @Override
   public String getName() {
@@ -31,6 +32,8 @@ public class GoogleCastButtonManager
     CastContext castContext = CastContext.getSharedInstance(context);
 
     final MediaRouteButton button = new ColorableMediaRouteButton(context);
+    googleCastButtonManagerInstance = button;
+
     CastButtonFactory.setUpMediaRouteButton(context, button);
 
     updateButtonState(button, castContext.getCastState());
@@ -43,6 +46,10 @@ public class GoogleCastButtonManager
     });
 
     return button;
+  }
+
+  public static MediaRouteButton getGoogleCastButtonManagerInstance() {
+    return googleCastButtonManagerInstance;
   }
 
   @ReactProp(name = "tintColor", customType = "Color")

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
@@ -20,6 +20,7 @@ public class GoogleCastButtonManager
 
   public static final String REACT_CLASS = "RNGoogleCastButton";
   private Integer mColor = null;
+  private MediaRouteButton button = null;
 
   @Override
   public String getName() {
@@ -30,7 +31,7 @@ public class GoogleCastButtonManager
   public MediaRouteButton createViewInstance(ThemedReactContext context) {
     CastContext castContext = CastContext.getSharedInstance(context);
 
-    final MediaRouteButton button = new ColorableMediaRouteButton(context);
+    button = new ColorableMediaRouteButton(context);
     CastButtonFactory.setUpMediaRouteButton(context, button);
 
     updateButtonState(button, castContext.getCastState());
@@ -51,6 +52,11 @@ public class GoogleCastButtonManager
       return;
     button.applyTint(color);
     mColor = color;
+  }
+
+  @ReactMethod
+  public void openRouteSelector() {
+    button.performClick();
   }
 
   private void updateButtonState(MediaRouteButton button, int state) {

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
@@ -20,7 +20,6 @@ public class GoogleCastButtonManager
 
   public static final String REACT_CLASS = "RNGoogleCastButton";
   private Integer mColor = null;
-  private MediaRouteButton button = null;
 
   @Override
   public String getName() {
@@ -31,7 +30,7 @@ public class GoogleCastButtonManager
   public MediaRouteButton createViewInstance(ThemedReactContext context) {
     CastContext castContext = CastContext.getSharedInstance(context);
 
-    button = new ColorableMediaRouteButton(context);
+    final MediaRouteButton button = new ColorableMediaRouteButton(context);
     CastButtonFactory.setUpMediaRouteButton(context, button);
 
     updateButtonState(button, castContext.getCastState());
@@ -52,11 +51,6 @@ public class GoogleCastButtonManager
       return;
     button.applyTint(color);
     mColor = color;
-  }
-
-  @ReactMethod
-  public void openRouteSelector() {
-    button.performClick();
   }
 
   private void updateButtonState(MediaRouteButton button, int state) {

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -28,6 +28,7 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient;
 import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.common.images.WebImage;
+import com.reactnative.googlecast.GoogleCastButtonManager;
 
 import org.json.JSONObject;
 import java.io.IOException;
@@ -103,6 +104,17 @@ public class GoogleCastModule
         getReactApplicationContext()
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);
+    }
+
+    @ReactMethod
+    public void showCastPicker() {
+        getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                GoogleCastButtonManager.getGoogleCastButtonManagerInstance().performClick();
+                Log.e(REACT_CLASS, "showCastPicker... ");
+            }
+        });
     }
 
     @ReactMethod

--- a/index.js
+++ b/index.js
@@ -92,6 +92,9 @@ export default {
   sendMessage(namespace: string, message: string) {
     return GoogleCast.sendMessage(message, namespace)
   },
+  showCastPicker(){
+    GoogleCast.showCastPicker()
+  },
 
   // TODO use the same native event interface instead of hacking it here
   EventEmitter:

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -106,6 +106,12 @@ RCT_EXPORT_METHOD(launchExpandedControls) {
   });
 }
 
+RCT_EXPORT_METHOD(showCastPicker) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+[GCKCastContext.sharedInstance presentCastDialog];
+});
+}
+
 RCT_EXPORT_METHOD(showIntroductoryOverlay) {
   dispatch_async(dispatch_get_main_queue(), ^{
     [GCKCastContext.sharedInstance presentCastInstructionsViewControllerOnce];
@@ -148,12 +154,12 @@ RCT_EXPORT_METHOD(sendMessage: (NSString *)message
                   resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject) {
   GCKCastChannel *channel = channels[namespace];
-  
+
   if (!channel) {
     NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:GCKErrorCodeChannelNotConnected userInfo:nil];
     return reject(@"no_channel", [NSString stringWithFormat:@"Channel for namespace %@ does not exist. Did you forget to call initChannel?", namespace], error);
   }
-  
+
   NSError *error;
   [channel sendTextMessage:message error:&error];
   if (error != nil) {
@@ -310,10 +316,10 @@ RCT_EXPORT_METHOD(seek : (int)playPosition) {
     playbackStarted = false;
     playbackEnded = false;
   }
-  
+
   double position = mediaStatus.streamPosition;
   double duration = mediaStatus.mediaInformation.streamDuration;
-  
+
   NSDictionary *status = @{
     @"playerState": @(mediaStatus.playerState),
     @"idleReason": @(mediaStatus.idleReason),
@@ -338,7 +344,7 @@ RCT_EXPORT_METHOD(seek : (int)playPosition) {
     [progressTimer invalidate];
     progressTimer = nil;
   }
-  
+
   if (!playbackStarted && mediaStatus.playerState == GCKMediaPlayerStatePlaying) {
     [self sendEventWithName:MEDIA_PLAYBACK_STARTED body:@{@"mediaStatus":status}];
     playbackStarted = true;


### PR DESCRIPTION
We had need to open the cast picker dialog without the need to use the button. This is working and tested live in our app and allows us to open the picker with a simple method.