### PR TITLE
Add Media Tracks support for iOS

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -224,8 +224,9 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   }
     
   GCKMediaTextTrackStyle *textTrackStyle = [GCKMediaTextTrackStyle createDefault];
-  [textTrackStyle setForegroundColor:[[GCKColor alloc] initWithCSSString:@"#FFEB3B"]];
-  [textTrackStyle setFontFamily:@"serif"];
+  [textTrackStyle setForegroundColor:[[GCKColor alloc] initWithCSSString:@"#ffffff"]];
+  [textTrackStyle setBackgroundColor:[[GCKColor alloc] initWithCSSString:@"#0c1519b8"]];
+  [textTrackStyle setFontFamily:@"arial"];
   styleChangeRequest = [castSession.remoteMediaClient setTextTrackStyle:textTrackStyle];
     
   NSMutableArray *tracks = [[NSMutableArray alloc] init];
@@ -253,7 +254,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                   metadata:metadata
                                   streamDuration:streamDuration
                                   mediaTracks:tracks
-                                  textTrackStyle:nil
+                                  textTrackStyle:textTrackStyle
                                   customData:customData];
   // Cast the video.
   if (castSession) {

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -189,6 +189,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   NSString *posterUrl = [RCTConvert NSString:params[@"posterUrl"]];
   NSString *contentType = [RCTConvert NSString:params[@"contentType"]];
   NSDictionary *customData = [RCTConvert NSDictionary:params[@"customData"]];
+  NSArray *mediaTracks = [RCTConvert NSArray:params[@"mediaTracks"]];
   double streamDuration = [RCTConvert double:params[@"streamDuration"]];
   double playPosition = [RCTConvert double:params[@"playPosition"]];
 
@@ -222,46 +223,38 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                 height:720]];
   }
     
-    GCKMediaTextTrackStyle *textTrackStyle = [GCKMediaTextTrackStyle createDefault];
-    [textTrackStyle setForegroundColor:[[GCKColor alloc] initWithCSSString:@"#FFEB3B"]];
-    [textTrackStyle setFontFamily:@"serif"];
-    styleChangeRequest = [castSession.remoteMediaClient setTextTrackStyle:textTrackStyle];
+  GCKMediaTextTrackStyle *textTrackStyle = [GCKMediaTextTrackStyle createDefault];
+  [textTrackStyle setForegroundColor:[[GCKColor alloc] initWithCSSString:@"#FFEB3B"]];
+  [textTrackStyle setFontFamily:@"serif"];
+  styleChangeRequest = [castSession.remoteMediaClient setTextTrackStyle:textTrackStyle];
     
+  NSMutableArray *tracks = [[NSMutableArray alloc] init];
+  for(id track in mediaTracks) {
+      
+      NSNumber* ID = [track valueForKey:@"id"];
+      int trackId = [ID intValue];
+        
+      GCKMediaTrack *lang =
+      [[GCKMediaTrack alloc] initWithIdentifier:trackId
+                                contentIdentifier:track[@"uri"]
+                                contentType:track[@"type"]
+                                type:GCKMediaTrackTypeText
+                                textSubtype:GCKMediaTextTrackSubtypeCaptions
+                                name:track[@"title"]
+                                languageCode:track[@"language"]
+                                customData:nil];
+      [tracks addObject:lang];
+   }
     
-    NSString *en = @"https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt";
-    NSString *es = @"https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_es.vtt";
-    
-    GCKMediaTrack *enLang =
-    [[GCKMediaTrack alloc] initWithIdentifier:1
-                            contentIdentifier:en
-                                  contentType:@"text/vtt"
-                                         type:GCKMediaTrackTypeText
-                                  textSubtype:GCKMediaTextTrackSubtypeCaptions
-                                         name:@"English"
-                                 languageCode:@"en"
-                                   customData:nil];
-    
-    GCKMediaTrack *esLang =
-    [[GCKMediaTrack alloc] initWithIdentifier:2
-                            contentIdentifier:es
-                                  contentType:@"text/vtt"
-                                         type:GCKMediaTrackTypeText
-                                  textSubtype:GCKMediaTextTrackSubtypeCaptions
-                                         name:@"Spanish"
-                                 languageCode:@"es"
-                                   customData:nil];
-    
-    NSArray *tracks = @[enLang, esLang];
-    
-  GCKMediaInformation *mediaInfo =
+   GCKMediaInformation *mediaInfo =
       [[GCKMediaInformation alloc] initWithContentID:mediaUrl
-                                          streamType:GCKMediaStreamTypeBuffered
-                                         contentType:contentType
-                                            metadata:metadata
-                                      streamDuration:streamDuration
-                                         mediaTracks:tracks
-                                      textTrackStyle:captionsTrack
-                                          customData:customData];
+                                  streamType:GCKMediaStreamTypeBuffered
+                                  contentType:contentType
+                                  metadata:metadata
+                                  streamDuration:streamDuration
+                                  mediaTracks:tracks
+                                  textTrackStyle:nil
+                                  customData:customData];
   // Cast the video.
   if (castSession) {
     [castSession.remoteMediaClient loadMedia:mediaInfo

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -222,22 +222,36 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                 height:720]];
   }
     
-  GCKMediaTextTrackStyle *textTrackStyle = [GCKMediaTextTrackStyle createDefault];
-    [textTrackStyle setForegroundColor:[[GCKColor alloc] initWithCSSString:@"#FF000080"]];
+    GCKMediaTextTrackStyle *textTrackStyle = [GCKMediaTextTrackStyle createDefault];
+    [textTrackStyle setForegroundColor:[[GCKColor alloc] initWithCSSString:@"#FFEB3B"]];
     [textTrackStyle setFontFamily:@"serif"];
     styleChangeRequest = [castSession.remoteMediaClient setTextTrackStyle:textTrackStyle];
     
-  GCKMediaTrack *captionsTrack =
+    
+    NSString *en = @"https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt";
+    NSString *es = @"https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_es.vtt";
+    
+    GCKMediaTrack *enLang =
     [[GCKMediaTrack alloc] initWithIdentifier:1
-                            contentIdentifier:@"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/DesigningForGoogleCast-en.vtt"
+                            contentIdentifier:en
                                   contentType:@"text/vtt"
                                          type:GCKMediaTrackTypeText
                                   textSubtype:GCKMediaTextTrackSubtypeCaptions
-                                         name:@"English Captions 3"
+                                         name:@"English"
                                  languageCode:@"en"
                                    customData:nil];
     
-    NSArray *tracks = @[captionsTrack];
+    GCKMediaTrack *esLang =
+    [[GCKMediaTrack alloc] initWithIdentifier:2
+                            contentIdentifier:es
+                                  contentType:@"text/vtt"
+                                         type:GCKMediaTrackTypeText
+                                  textSubtype:GCKMediaTextTrackSubtypeCaptions
+                                         name:@"Spanish"
+                                 languageCode:@"es"
+                                   customData:nil];
+    
+    NSArray *tracks = @[enLang, esLang];
     
   GCKMediaInformation *mediaInfo =
       [[GCKMediaInformation alloc] initWithContentID:mediaUrl

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -220,13 +220,26 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                  width:480
                                 height:720]];
   }
+    
+  GCKMediaTrack *captionsTrack =
+    [[GCKMediaTrack alloc] initWithIdentifier:1
+                            contentIdentifier:@"https://gist.github.com/chdemko/5356310#file-example-vtt"
+                                  contentType:@"text/vtt"
+                                         type:GCKMediaTrackTypeText
+                                  textSubtype:GCKMediaTextTrackSubtypeCaptions
+                                         name:@"English Captions"
+                                 languageCode:@"en"
+                                   customData:nil];
+    
+    NSArray *tracks = @[captionsTrack];
+    
   GCKMediaInformation *mediaInfo =
       [[GCKMediaInformation alloc] initWithContentID:mediaUrl
                                           streamType:GCKMediaStreamTypeBuffered
                                          contentType:contentType
                                             metadata:metadata
                                       streamDuration:streamDuration
-                                         mediaTracks:nil
+                                         mediaTracks:tracks
                                       textTrackStyle:nil
                                           customData:customData];
   // Cast the video.


### PR DESCRIPTION
## Add Media Tracks support for iOS.

## Example:

```
  GoogleCast.castMedia({
     mediaTracks: [
        {
          id: 1,
          uri: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt',
          type: 'text/vtt',
          title: 'English',
          language: 'en'
        },
        {
          id: 2,
          uri: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_es.vtt',
          type: 'text/vtt',
          title: 'Spanish',
          language: 'es'
        },
        {
          id: 3,
          uri: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_fr.vtt',
          type: 'text/vtt',
          title: 'French',
          language: 'fr'
        }
    ],
    textTrackStyle: {
        textColor: '#ffffff',
        backgroundColor: '#0c1519b8',
        fontFamily: 'arial'
      }
     // rest of props...
  });
```

<img width="423" alt="Screenshot 2019-12-08 at 20 32 58" src="https://user-images.githubusercontent.com/4986411/70394923-02571000-19fa-11ea-844e-1739e9f8f591.png">