### PR TITLE
Add toggleSubtitles method for iOS

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.h
+++ b/ios/RNGoogleCast/RNGoogleCast.h
@@ -20,6 +20,8 @@ static NSString *const CHANNEL_MESSAGE_RECEIVED = @"GoogleCast:ChannelMessageRec
 static NSString *const CHANNEL_CONNECTED = @"GoogleCast:ChannelConnected";
 static NSString *const CHANNEL_DISCONNECTED = @"GoogleCast:ChannelDisconnected";
 
+static NSString *const DEFAULT_SUBTITLES_LANGUAGE = @"en";
+
 @interface RNGoogleCast
     : RCTEventEmitter <RCTBridgeModule, GCKCastDeviceStatusListener,
                        GCKSessionManagerListener, GCKRemoteMediaClientListener,


### PR DESCRIPTION
This is the iOS part of toggleSubstitles method. Usage is the same as Android:

GoogleCast.toggleSubtitles(enabled, languageCode)

- Enables/Disables closed captions for the video. Enabling subtitles only results in them showing if the stream contains a caption track in the requested language.
- Param: enabled - Required. True to enable, False to disable capions
- Param: languageCode - Optional, used for finding the right captions track in the stream. If not provided the default value of en will be used (for English).