### PR TITLE
Add set playback rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ GoogleCast.castMedia({
 - `GoogleCast.pause()`
 - `GoogleCast.seek(playPosition)` - jump to position in seconds from the beginning of the stream
 - `GoogleCast.setVolume(volume)`
+- `GoogleCast.setPlaybackRate(rate)`
 - `GoogleCast.stop()`
 - `GoogleCast.endSession(stopCasting)`
 - `GoogleCast.initChannel('urn:x-cast:...')` - initialize custom channel for communication with Cast receiver app. Once you do this, you can subscribe to `CHANNEL_*` events.

--- a/android/.project
+++ b/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android_</name>
+	<comment>Project android_ created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(6.0))
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -348,6 +348,23 @@ public class GoogleCastModule
     }
 
     @ReactMethod
+    public void setPlaybackRate(final double rate) {
+        if (mCastSession != null) {
+            getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+                @Override
+                public void run() {
+                    RemoteMediaClient client = mCastSession.getRemoteMediaClient();
+                    if (client == null) {
+                        return;
+                    }
+
+                    client.setPlaybackRate(rate);
+                }
+            });
+        }
+    }
+
+    @ReactMethod
     public void endSession(final boolean stopCasting, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override

--- a/example/android/.project
+++ b/example/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android</name>
+	<comment>Project android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/example/android/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(6.0))
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,13 +63,14 @@ declare module 'react-native-google-cast' {
     launchExpandedControls(): void
     showIntroductoryOverlay(): void
     setVolume(volume: number): void
+    setPlaybackRate(rate: number): void
     initChannel(channel: string): Promise<boolean>
     sendMessage(message: string, namespace: string): Promise<boolean>
     showCastPicker(): void
     toggleSubtitles(enabled: boolean, languageCode?: string): Promise<void>
 
     EventEmitter: EventEmitter
-    
+
     SESSION_STARTING: string
     SESSION_STARTED: string
     SESSION_START_FAILED: string
@@ -78,12 +79,12 @@ declare module 'react-native-google-cast' {
     SESSION_RESUMED: string
     SESSION_ENDING: string
     SESSION_ENDED: string
-    
+
     MEDIA_STATUS_UPDATED: string
     MEDIA_PLAYBACK_STARTED: string
     MEDIA_PLAYBACK_ENDED: string
     MEDIA_PROGRESS_UPDATED: string
-    
+
     CHANNEL_CONNECTED: string
     CHANNEL_DISCONNECTED: string
     CHANNEL_MESSAGE_RECEIVED: string

--- a/index.js
+++ b/index.js
@@ -112,13 +112,16 @@ export default {
   setVolume(volume: number) {
     return GoogleCast.setVolume(volume)
   },
+  setPlaybackRate(rate: number) {
+    return GoogleCast.setPlaybackRate(rate)
+  },
   initChannel(namespace: string) {
     return GoogleCast.initChannel(namespace)
   },
   sendMessage(namespace: string, message: string) {
     return GoogleCast.sendMessage(message, namespace)
   },
-  showCastPicker(){
+  showCastPicker() {
     GoogleCast.showCastPicker()
   },
 

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -288,9 +288,16 @@ RCT_EXPORT_METHOD(seek : (int)playPosition) {
     [castSession.remoteMediaClient seekToTimeInterval:playPosition];
   }
 }
+
 RCT_EXPORT_METHOD(setVolume : (float)volume) {
     if (castSession) {
         [castSession.remoteMediaClient setStreamVolume:volume];
+    }
+}
+
+RCT_EXPORT_METHOD(setPlaybackRate : (float)rate) {
+    if (castSession) {
+        [castSession.remoteMediaClient setPlaybackRate:rate];
     }
 }
 


### PR DESCRIPTION
I added the method setPlaybackRate(), modeled after how setVolume is setup. Tested and working on both iOS and Android

References/docs:

- [Android](https://developers.google.com/android/reference/com/google/android/gms/cast/framework/media/RemoteMediaClient#public-pendingresultremotemediaclient.mediachannelresult-setplaybackrate-double-playbackrate)
- [iOS](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_remote_media_client#ab64e42df31cef080b147a4663a4c2a6d)

