### PR TITLE
OP-609 Subtitle issues caused by replacing BrightCove text tracks

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -250,8 +250,9 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   NSMutableArray *tracks = [[NSMutableArray alloc] init];
   if ([textTracks[0] count] > 0) {
     GCKMediaTrack *captionsTrack;
+    int trackId = 1;
     for (NSDictionary *track in textTracks) {        
-      captionsTrack = [[GCKMediaTrack alloc] initWithIdentifier:track[@"srclang"]
+      captionsTrack = [[GCKMediaTrack alloc] initWithIdentifier:trackId
                               contentIdentifier:track[@"src"]
                                     contentType:track[@"mime_type"]
                                             type:GCKMediaTrackTypeText
@@ -260,6 +261,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                     languageCode:track[@"srclang"]
                                       customData:nil];
       [tracks addObject: captionsTrack];
+      trackId++;
     }
   }
   else {

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -212,6 +212,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   NSString *posterUrl = [RCTConvert NSString:params[@"posterUrl"]];
   NSString *contentType = [RCTConvert NSString:params[@"contentType"]];
   NSDictionary *customData = [RCTConvert NSDictionary:params[@"customData"]];
+  NSArray *textTracks = [RCTConvert NSArray:params[@"textTracks"]];
   double streamDuration = [RCTConvert double:params[@"streamDuration"]];
   double playPosition = [RCTConvert double:params[@"playPosition"]];
 
@@ -244,13 +245,34 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                  width:480
                                 height:720]];
   }
+
+  // Add text tracks from Brightcove API
+  NSMutableArray *tracks = [[NSMutableArray alloc] init];
+  if ([textTracks[0] count] > 0) {
+    GCKMediaTrack *captionsTrack;
+    for (NSDictionary *track in textTracks) {        
+      captionsTrack = [[GCKMediaTrack alloc] initWithIdentifier:track[@"srclang"]
+                              contentIdentifier:track[@"src"]
+                                    contentType:track[@"mime_type"]
+                                            type:GCKMediaTrackTypeText
+                                    textSubtype:GCKMediaTextTrackSubtypeCaptions
+                                            name:track[@"label"]
+                                    languageCode:track[@"srclang"]
+                                      customData:nil];
+      [tracks addObject: captionsTrack];
+    }
+  }
+  else {
+    tracks = nil;
+  }
+
   GCKMediaInformation *mediaInfo =
       [[GCKMediaInformation alloc] initWithContentID:mediaUrl
                                           streamType:GCKMediaStreamTypeBuffered
                                          contentType:contentType
                                             metadata:metadata
                                       streamDuration:streamDuration
-                                         mediaTracks:nil
+                                         mediaTracks:tracks
                                       textTrackStyle:nil
                                           customData:customData];
   // Cast the video.


### PR DESCRIPTION
I replaced the BrightCove text tracks name "Track #" by adding text tracks with proper names. It caused some issues with playing cast video in expanded controller because the text tracks were not replaced properly. I'm making a change to show both correct subtitle name and Track # name for now as shown in below image to resolve the issues. 
<img width="367" alt="Screen Shot 2020-03-05 at 12 55 40 PM" src="https://user-images.githubusercontent.com/54517709/76360624-99be4e80-62da-11ea-90c6-a98909d23aa7.png">
