### PR TITLE
Check if there's a cast session on init

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -27,6 +27,11 @@ RCT_EXPORT_MODULE();
 - (instancetype)init {
   self = [super init];
   channels = [[NSMutableDictionary alloc] init];
+
+  if([GCKCastContext.sharedInstance castState] == GCKCastStateConnected) {
+    castSession = [[GCKCastContext.sharedInstance sessionManager] currentCastSession];
+  }
+
   return self;
 }
 


### PR DESCRIPTION
If cast state is connected it should be safe to assign the current cast session of the local castSession variable.

This should fix the issues in #151 #185