### PR TITLE
Unused GCKCastDeviceStatusListener protocol

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.h
+++ b/ios/RNGoogleCast/RNGoogleCast.h
@@ -23,7 +23,7 @@ static NSString *const CHANNEL_DISCONNECTED = @"GoogleCast:ChannelDisconnected";
 static NSString *const DEFAULT_SUBTITLES_LANGUAGE = @"en";
 
 @interface RNGoogleCast
-    : RCTEventEmitter <RCTBridgeModule, GCKCastDeviceStatusListener,
+    : RCTEventEmitter <RCTBridgeModule,
                        GCKSessionManagerListener, GCKRemoteMediaClientListener,
                        GCKGenericChannelDelegate>
 @end


### PR DESCRIPTION
I got confused by the `GCKCastDeviceStatusListener` protocol that is not actually used.