### PR TITLE
Add documentation regarding iOS initialization ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,13 @@ Finally, run `pod install`.
 
 - In `AppDelegate.m` add
 
+  To the top of the file with the other imports:
+
   ```obj-c
   #import <GoogleCast/GoogleCast.h>
   ```
+
+  Before attaching the React Native root view to the window:
 
   ```obj-c
   GCKDiscoveryCriteria *criteria = [[GCKDiscoveryCriteria alloc] initWithApplicationID:kGCKDefaultMediaReceiverApplicationID];


### PR DESCRIPTION
This change adds documentation notes to clarify that the order in which
modules are initialized is important.

After experiencing #151 and #185 within my own app and spending time
debugging, I observed that the `init` and `startObserving` methods
within `RNGoogleCast.m` appeared to execute prior to the `AppDelegate.m`
`didFinishLaunchingWithOptions`. This appeared to result in the Cast
context being unavailable to *all* RNGC methods and event listeners.

The issue appears to be a race condition, because it did not necessarily
always occur. It also seemed to occur more frequently in a "release"
build, rather than a "debug" build. Because of this, I am not certain
that the order in which `AppDelegate.m` and `RNGoogleCast.m`
initializing may always be the same.

Regardless, moving the initialization of the Google Cast context to
occur *prior* to attaching the React Native root view appears to have
resolved various RNGC methods and event listeners failing due to the
Cast context missing.
