### PR TITLE
Properly point to podspec

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,9 +1,11 @@
+const path = require('path');
+
 module.exports = {
   dependency: {
     platforms: {
       ios: {
         podspecPath:
-          'node_modules/react-native-google-cast/ios/react-native-google-cast.podspec',
+          path.join(__dirname, 'ios', 'react-native-google-cast.podspec'),
       },
     },
   },


### PR DESCRIPTION
I can create an issue if you like - but I had an issue when running `pod install`.  It complained that it couldn't find the podspec at the path.  This fixed that.