### PR TITLE
fixed 'crash on null mCastSession' bug (Android)

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -142,6 +142,10 @@ public class GoogleCastModule
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
+                if(mCastSession == null){
+                    return;
+                }
+                
                 RemoteMediaClient remoteMediaClient = mCastSession.getRemoteMediaClient();
                 if (remoteMediaClient == null) {
                     return;


### PR DESCRIPTION
This pr fixes app crashes on android due to the null CastSession object.