### PR TITLE
Fix: MediaQueueItem empty properties default to Infinite/NaN causing a crash

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/types/RNGCMediaQueueItem.java
+++ b/android/src/main/java/com/reactnative/googlecast/types/RNGCMediaQueueItem.java
@@ -89,11 +89,15 @@ public class RNGCMediaQueueItem {
 
     json.putMap("mediaInfo", RNGCMediaInfo.toJson(item.getMedia()));
 
-    json.putDouble("playbackDuration", item.getPlaybackDuration());
+    if(!Double.isInfinite(item.getPlaybackDuration())) {
+      json.putDouble("playbackDuration", item.getPlaybackDuration());
+    }
 
     json.putDouble("preloadTime", item.getPreloadTime());
 
-    json.putDouble("startTime", item.getStartTime());
+    if(!Double.isNaN(item.getStartTime())) {
+      json.putDouble("startTime", item.getStartTime());
+    }
 
     return json;
   }


### PR DESCRIPTION
In some instances while converting `MediaQueueItem` to JSON it would cause a crash with the following error:
> java.lang.RuntimeException: folly::toJson: JSON object value was a NaN or INF

This is can be caused by two properties in the `MediaQueueItem`:
 * `playbackDuration` which if not provided [defaults to Infinite ](https://developers.google.com/android/reference/com/google/android/gms/cast/MediaQueueItem#DEFAULT_PLAYBACK_DURATION)
 * `startTime` which if not provided [defaults to NaN](https://developers.google.com/android/reference/com/google/android/gms/cast/MediaQueueItem#public-double-getstarttime)

Both `Infinite` and `NaN` within a `WritableMap` will cause a crash. Since both values are defaults we can just skip sending the values and prevent the crash.
