### PR TITLE
Set contentId in newer SDK versions

### DIFF
--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaInformation.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaInformation.m
@@ -33,6 +33,12 @@
     builder.adBreaks = adBreaks;
   }
 
+  #if GCK_VERSION_IS_AT_LEAST(4, 3, 4)
+    if (json[@"contentId"]) {
+      builder.contentID = [RCTConvert NSString:json[@"contentId"]];
+    }
+  #endif
+
   if (json[@"contentType"]) {
     builder.contentType = [RCTConvert NSString:json[@"contentType"]];
   }


### PR DESCRIPTION
Fixes #267.

https://github.com/react-native-google-cast/react-native-google-cast/commit/77024e8b709c2aff1c917e20275553bcde2301e7#diff-6d677f963fe5c5b5862774cbf28f93836da12833c17d41397a56827cf7788056R12 changed the conversion of `GCKMediaInformation` to use the new `[GCKMediaInformationBuilder initWithContentURL:contentURL]` initialiser, but in the process lost the the ability to set the *new* contentId field.

I've gated this behind the same version check as the initialiser just in case it would otherwise introduce compatibility issues.