### PR TITLE
fix: Crash on iOS when using SessionManager events and reloading

### DIFF
--- a/ios/RNGoogleCast/api/RNGCCastContext.m
+++ b/ios/RNGoogleCast/api/RNGCCastContext.m
@@ -44,6 +44,7 @@ RCT_EXPORT_MODULE();
 
 // Called when this module's last listener is removed, or on dealloc.
 - (void)stopObserving {
+  if (!hasListeners) { return; }
   hasListeners = NO;
   // Remove upstream listeners, stop unnecessary background tasks
   [[NSNotificationCenter defaultCenter]

--- a/ios/RNGoogleCast/api/RNGCCastSession.m
+++ b/ios/RNGoogleCast/api/RNGCCastSession.m
@@ -59,6 +59,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)stopObserving {
+  if (!hasListeners) { return; }
   hasListeners = NO;
   dispatch_async(dispatch_get_main_queue(), ^{
     GCKCastSession *session = [GCKCastContext.sharedInstance.sessionManager currentCastSession];

--- a/ios/RNGoogleCast/api/RNGCDiscoveryManager.m
+++ b/ios/RNGoogleCast/api/RNGCDiscoveryManager.m
@@ -33,6 +33,7 @@ RCT_EXPORT_MODULE()
 
 // Will be called when this module's last listener is removed, or on dealloc.
 - (void)stopObserving {
+  if (!hasListeners) { return; }
   hasListeners = NO;
   dispatch_async(dispatch_get_main_queue(), ^{
     [GCKCastContext.sharedInstance.discoveryManager removeListener:self];

--- a/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
+++ b/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
@@ -54,6 +54,7 @@ RCT_EXPORT_MODULE()
 
 // Will be called when this module's last listener is removed, or on dealloc.
 - (void)stopObserving {
+  if (!hasListeners) { return; }
   hasListeners = NO;
   [progressTimer invalidate];
   progressTimer = nil;

--- a/ios/RNGoogleCast/api/RNGCSessionManager.m
+++ b/ios/RNGoogleCast/api/RNGCSessionManager.m
@@ -49,6 +49,7 @@ RCT_EXPORT_MODULE()
 
 // Will be called when this module's last listener is removed, or on dealloc.
 - (void)stopObserving {
+  if (!hasListeners) { return; }
   hasListeners = NO;
   dispatch_async(dispatch_get_main_queue(), ^{
     [GCKCastContext.sharedInstance.sessionManager removeListener:self];


### PR DESCRIPTION
On iOS when using the `SessionManager` and listening to events in redux sagas the iOS app crashes when reloading.

This is happening because `stopObserving` is called twice, where on the second call it crashes the app. To prevent this crash we check for `hasListeners` and if no listeners are present we don't attempt to remove them.