### PR TITLE
Add initial pass at queue details support

### DIFF
--- a/ios/RNGoogleCast/api/RNGCMediaQueue.h
+++ b/ios/RNGoogleCast/api/RNGCMediaQueue.h
@@ -1,0 +1,10 @@
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+static NSString *const QUEUE_CHANGED = @"GoogleCast:QueueChanged";
+static NSString *const QUEUE_RECEIVED_ITEM = @"GoogleCast:QueueReceivedItem";
+
+@interface RNGCMediaQueue : RCTEventEmitter <RCTBridgeModule, GCKMediaQueueDelegate, GCKSessionManagerListener>
+  
+@end

--- a/ios/RNGoogleCast/api/RNGCMediaQueue.m
+++ b/ios/RNGoogleCast/api/RNGCMediaQueue.m
@@ -1,0 +1,126 @@
+#import "RNGCMediaQueue.h"
+#import <Foundation/Foundation.h>
+#import <React/RCTConvert.h>
+#import "../types/RCTConvert+GCKMediaQueue.m"
+
+@implementation RNGCMediaQueue {
+	GCKMediaQueue *queue;
+  bool hasListeners;
+}
+
+RCT_EXPORT_MODULE()
+
+- (NSDictionary *)constantsToExport {
+  return @{
+    @"QUEUE_CHANGED" : QUEUE_CHANGED,
+    @"QUEUE_RECEIVED_ITEM" : QUEUE_RECEIVED_ITEM,
+  };
+}
+
+-(void)startObserving {
+  hasListeners = YES;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [GCKCastContext.sharedInstance.sessionManager addListener:self];
+
+    self->queue = [self getQueue];
+    if (self->queue != nil) {
+      [self->queue addDelegate:self];
+    }
+  });
+}
+
+-(void)stopObserving {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [GCKCastContext.sharedInstance.sessionManager removeListener:self];
+    
+    self->queue = [self getQueue];
+    if (self->queue != nil) {
+      [self->queue removeDelegate:self];
+    }
+  });
+  hasListeners = NO;
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[
+    QUEUE_CHANGED,
+    QUEUE_RECEIVED_ITEM,
+  ];
+}
+
+RCT_REMAP_METHOD(getState,
+                 getStateWithResolver: (RCTPromiseResolveBlock) resolve
+                 rejecter: (RCTPromiseRejectBlock) reject) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    resolve([RCTConvert fromGCKMediaQueue:self->queue]);
+  });
+}
+
+RCT_EXPORT_METHOD(getItemWithId: (NSUInteger) itemId
+                  fetchIfNeeded: (BOOL) fetchIfNeeded) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    GCKMediaQueue *queue = self->queue;
+    if (queue == nil) {
+  //    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:nil];
+  //    reject(@"no_queue", @"No queue available", error);
+      return;
+    }
+    
+    NSInteger index = [queue indexOfItemWithID:itemId];
+    if (index == NSNotFound) {
+      return;
+    }
+
+    GCKMediaQueueItem *item = [queue itemAtIndex:index fetchIfNeeded:fetchIfNeeded];
+    if (item && self->hasListeners) { // Only send events if anyone is listening
+      [self sendEventWithName:QUEUE_RECEIVED_ITEM body:[RCTConvert fromGCKMediaQueueItem:item]];
+    }
+  });
+}
+
+# pragma mark - GCKSessionManager events
+
+- (void)sessionManager:(GCKSessionManager *)sessionManager didStartCastSession:(GCKCastSession *)session {
+  queue = [session.remoteMediaClient mediaQueue];
+  [queue addDelegate:self];
+}
+
+- (void)sessionManager:(GCKSessionManager *)sessionManager didResumeCastSession:(GCKCastSession *)session {
+  queue = [session.remoteMediaClient mediaQueue];
+  [queue addDelegate:self];
+}
+
+- (void)sessionManager:(GCKSessionManager *)sessionManager willEndCastSession:(GCKCastSession *)session {
+  [queue removeDelegate:self];
+}
+
+# pragma mark - GCKMediaQueue events
+
+- (void) mediaQueue:(GCKMediaQueue *)queue didUpdateItemsAtIndexes:(NSArray<NSNumber *> *)indexes {
+  if (hasListeners) { // Only send events if anyone is listening
+    for (NSNumber *index in indexes) {
+      GCKMediaQueueItem *item = [queue itemAtIndex:[index unsignedIntegerValue] fetchIfNeeded:NO];
+      if (item) {
+        [self sendEventWithName:QUEUE_RECEIVED_ITEM body:[RCTConvert fromGCKMediaQueueItem:item]];
+      }
+    }
+  }
+}
+- (void)mediaQueueDidChange:(GCKMediaQueue *)queue {
+  if (hasListeners) {
+    [self sendEventWithName:QUEUE_CHANGED body:[RCTConvert fromGCKMediaQueue:queue]];
+  }
+}
+
+# pragma mark - Helpers
+
+- (nullable GCKMediaQueue *)getQueue {
+  GCKSession *session =
+      GCKCastContext.sharedInstance.sessionManager.currentSession;
+
+  if (session == nil || session.remoteMediaClient == nil) { return nil; }
+
+  return [session.remoteMediaClient mediaQueue];
+}
+
+@end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueue.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueue.m
@@ -1,0 +1,23 @@
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+#import "./RCTConvert+GCKMediaQueueItem.m"
+
+@implementation RCTConvert (GCKMediaQueue)
+
++ (nonnull id)fromGCKMediaQueue:(nullable GCKMediaQueue *)queue {
+  if (queue == nil) return [NSNull null];
+
+  NSMutableDictionary *json = [[NSMutableDictionary alloc] init];
+
+  json[@"count"] = @(queue.itemCount);
+  
+  json[@"queuedIds"] = [[NSMutableArray alloc] init];
+  for (NSInteger i = 0; i < queue.itemCount; i++) {
+    [json[@"queuedIds"] addObject:@([queue itemIDAtIndex:i])];
+  }
+  
+  return json;
+}
+
+@end
+

--- a/src/api/MediaQueue.ts
+++ b/src/api/MediaQueue.ts
@@ -1,0 +1,64 @@
+import { NativeEventEmitter, NativeModules } from 'react-native';
+import MediaQueueItem from '../types/MediaQueueItem';
+
+const { RNGCMediaQueue: Native } = NativeModules;
+const EventEmitter = new NativeEventEmitter(Native)
+
+type Resolvable<T> = {
+	resolve( value: T ): void,
+	reject( reason: any ): void,
+}
+
+interface MediaQueueState {
+	count: number;
+	queuedIds: number[];
+}
+
+export default class MediaQueue implements MediaQueueState {
+	count: number;
+	queuedIds: number[];
+
+	private itemPromises: Promise<MediaQueueItem>[] = [];
+	private itemResolvers: Resolvable<MediaQueueItem>[] = [];
+
+	private constructor(state: MediaQueueState) {
+		this.count = state.count;
+		this.queuedIds = state.queuedIds;
+
+		EventEmitter.addListener(Native.QUEUE_RECEIVED_ITEM, (item: MediaQueueItem) => {
+			if (item.itemId && this.itemResolvers[item.itemId]) {
+				this.itemResolvers[item.itemId].resolve(item);
+			}
+		});
+	}
+
+	static async getState(): Promise<MediaQueueState | null> {
+		const state = await Native.getState();
+		if (!state) return null;
+
+		return new MediaQueue(state);
+	}
+
+	static onChanged(listener: (queue: MediaQueue) => void) {
+		return EventEmitter.addListener(Native.QUEUE_CHANGED, (state: MediaQueueState) => {
+			listener(new MediaQueue(state));
+		});
+	}
+
+	getItemById(id: number): Promise<MediaQueueItem> {
+		if (this.itemPromises[id]) {
+			return this.itemPromises[id];
+		}
+
+		// Prepare promise.
+		this.itemPromises[id] = new Promise((resolve, reject) => {
+			this.itemResolvers[id] = { resolve, reject };
+		});
+
+		// Actually fetch it too.
+		// Responses are handled by the listener.
+		Native.getItemWithId(id, true);
+
+		return this.itemPromises[id];
+	}
+}

--- a/src/api/RemoteMediaClient.ts
+++ b/src/api/RemoteMediaClient.ts
@@ -35,9 +35,6 @@ const EventEmitter = new NativeEventEmitter(Native)
  * ```
  */
 export default class RemoteMediaClient {
-  // getMediaQueue(): Promise<MediaQueue> {
-  // }
-
   /**
    * The current media status, or `null` if there isn't a media session.
    */

--- a/src/api/useQueue.ts
+++ b/src/api/useQueue.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import MediaQueue from './MediaQueue';
+
+/**
+ * Hook that provides the current {@link MediaQueue}.
+ *
+ * @returns current media queue, or `null` if there's no session connected
+ * @example
+ * ```js
+ * import { useQueue } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const queue = useQueue()
+ *
+ *   if (queue) {
+ *     queue.getItemById(...)
+ *   }
+ * }
+ * ```
+ */
+export default function useQueue() {
+  const [queue, setQueue] = useState<any>(null);
+  useEffect(() => {
+    MediaQueue.getState().then(state => setQueue(state));
+
+    const changed = MediaQueue.onChanged(queue => setQueue(queue));
+    return () => {
+      changed.remove();
+    };
+  }, []);
+  return queue;
+}


### PR DESCRIPTION
See #273.

Adds a new `useQueue` hook which provides the ability to fetch both the full queue's length and details for each item within it. This builds on the [GCKMediaQueue](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_media_queue) functionality under the hood.

For example, this can be used to show the queued items to the user with something like:

```tsx
import React, { useEffect, useState } from 'react';
import { FlatList, Text, View } from 'react-native';
import { MediaQueueItem } from '../react-native-google-cast/src';
import MediaQueue from '../react-native-google-cast/src/api/MediaQueue';
import useQueue from '../react-native-google-cast/src/api/useQueue';

interface ItemProps {
	id: number,
	queue: MediaQueue,
}
const QueueItem = ( props: ItemProps ) => {
	const [ item, setItem ] = useState<MediaQueueItem | null>( null );
	useEffect( () => {
		props.queue.getItemById( props.id ).then( item => setItem( item ) );
	}, [ props.id ] );

	return (
		<View>
			<Text>{ item?.mediaInfo.metadata?.title || 'Loading…' }</Text>
		</View>
	)
}

export default function Queue() {
	const queue = useQueue();

	if ( queue === null ) {
		return null;
	}

	return (
		<FlatList
			data={ queue.queuedIds }
			keyExtractor={ id => `${ id }` }
			renderItem={ ( { item } ) => (
				<QueueItem
					id={ item }
					queue={ queue }
				/>
			) }
		/>
	);
}
```

I have not yet implemented error handling (so the promises can hang forever), nor added full inline documentation, so leaving as draft for now. The JS side of things is also a little janky right now.