### PR TITLE
Link ios as static_framework

### DIFF
--- a/ios/react-native-google-cast.podspec
+++ b/ios/react-native-google-cast.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.authors  = package['author']
   s.homepage = package['homepage']
   s.platform = :ios, '10.0'
+  s.static_framework = true
 
   s.source = {
     :git => 'https://github.com/react-native-google-cast/react-native-google-cast.git',


### PR DESCRIPTION
Hi @petrbela,
We are using use_frameworks in our pod file. So we need  "s.static_framework = true" to get it to work.
Please review the changes and merge.

It is linked to the below issue:
https://github.com/react-native-google-cast/react-native-google-cast/issues/309
