### PR TITLE
Fixes clearing behavior in setProgressUpdateInterval

### DIFF
--- a/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
+++ b/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
@@ -197,7 +197,7 @@ RCT_EXPORT_METHOD(setPlaybackRate: (float) playbackRate
 RCT_EXPORT_METHOD(setProgressUpdateInterval: (nonnull NSNumber *) interval
                  resolver: (RCTPromiseResolveBlock) resolve
                  rejecter: (RCTPromiseRejectBlock) reject) {
-  if (interval == nil || interval <= 0) {
+  if (interval == nil || interval.doubleValue <= 0) {
     [progressTimer invalidate];
     progressTimer = nil;
     progressInterval = nil;


### PR DESCRIPTION
The `setProgressUpdateInterval` method was using the `interval` NSNumber object reference to check for zero, instead of the actual number representation. This was resulting in a false negative and a zero value in the interval property, causing the next `didUpdateMediaStatus` trigger to attach a zero-value `scheduledTimerWithTimeInterval`, resulting in thousands of MEDIA_PROGRESS_UPDATED events per second, effectively saturating the JS thread and preventing any other actions.

Using the NSNumber's double value allows the intervals to be cleared properly.