### PR TITLE
fix: run startDiscovery and stopDiscovery on the iOS main thread

### DIFF
--- a/ios/RNGoogleCast/api/RNGCDiscoveryManager.m
+++ b/ios/RNGoogleCast/api/RNGCDiscoveryManager.m
@@ -76,14 +76,18 @@ RCT_EXPORT_METHOD(setPassiveScan: (BOOL) on
 
 RCT_EXPORT_METHOD(startDiscovery: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject) {
-  [GCKCastContext.sharedInstance.discoveryManager startDiscovery];
-  resolve(nil);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [GCKCastContext.sharedInstance.discoveryManager startDiscovery];
+    resolve(nil);
+  });
 }
 
 RCT_EXPORT_METHOD(stopDiscovery: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject) {
-  [GCKCastContext.sharedInstance.discoveryManager stopDiscovery];
-  resolve(nil);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [GCKCastContext.sharedInstance.discoveryManager stopDiscovery];
+    resolve(nil);
+  });
 }
 
 -(NSMutableArray<id> *)getDevices {


### PR DESCRIPTION
Running the following code will throw an error on iOS:
```
import GoogleCast from 'react-native-google-cast';
GoogleCast.getDiscoveryManager().startDiscovery();
```

Error: 
```
-[GCKCastDeviceProvider startDiscovery] must be called on main thread
```

This PR will fix the crash for both start- and stopDiscovery