### PR TITLE
add blank author as missing required attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "!**/__mocks__",
     "lib/**/*"
   ],
+  "author": [""],
   "contributors": [
     "Charlie L <charliesbot@gmail.com>",
     "Petr Bela <github@petrbela.com>"


### PR DESCRIPTION
missing required attribute for `pod install` when running `/example`

[!] The `react-native-google-cast` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `authors`.