### PR TITLE
Added device capability array to Device

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/types/RNGCDevice.java
+++ b/android/src/main/java/com/reactnative/googlecast/types/RNGCDevice.java
@@ -44,6 +44,26 @@ public class RNGCDevice {
 
     json.putString("modelName", device.getModelName());
 
+
+    // Capabilities
+    final WritableArray capabilities = new WritableNativeArray();
+    if (device.hasCapability(CastDevice.CAPABILITY_AUDIO_IN)) {
+      capabilities.pushString("AudioIn");
+    }
+    if (device.hasCapability(CastDevice.CAPABILITY_AUDIO_OUT)) {
+      capabilities.pushString("AudioOut");
+    }
+    if (device.hasCapability(CastDevice.CAPABILITY_VIDEO_IN)) {
+      capabilities.pushString("VideoIn");
+    }
+    if (device.hasCapability(CastDevice.CAPABILITY_VIDEO_OUT)) {
+      capabilities.pushString("VideoOut");
+    }
+    if (device.hasCapability(CastDevice.CAPABILITY_MULTIZONE_GROUP)) {
+      capabilities.pushString("MultizoneGroup");
+    }
+
+    json.putArray("capabilities", capabilities);
     return json;
   }
 }

--- a/ios/RNGoogleCast/types/RCTConvert+GCKDevice.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKDevice.m
@@ -27,6 +27,31 @@
 
   json[@"modelName"] = device.modelName;
 
+  //Capabilities
+  NSMutableArray<NSString *> *capabilities = [NSMutableArray array];
+  if ([device hasCapabilities:GCKDeviceCapabilityVideoOut]) {
+    [capabilities addObject:@"VideoOut"];
+  }
+  if ([device hasCapabilities:GCKDeviceCapabilityAudioOut]) {
+    [capabilities addObject:@"AudioOut"];
+  }
+  if ([device hasCapabilities:GCKDeviceCapabilityVideoIn]) {
+    [capabilities addObject:@"VideoIn"];
+  }
+  if ([device hasCapabilities:GCKDeviceCapabilityAudioIn]) {
+    [capabilities addObject:@"AudioIn"];
+  }
+  if ([device hasCapabilities:GCKDeviceCapabilityDynamicGroup]) {
+    [capabilities addObject:@"DynamicGroup"];
+  }
+  if ([device hasCapabilities:GCKDeviceCapabilityMultizoneGroup]) {
+    [capabilities addObject:@"MultizoneGroup"];
+  }
+  if ([device hasCapabilities:GCKDeviceCapabilityMultiChannelGroup]) {
+    [capabilities addObject:@"MultiChannelGroup"];
+  }
+  json[@"capabilities"] = capabilities;
+
   return json;
 }
 

--- a/src/types/Device.ts
+++ b/src/types/Device.ts
@@ -1,5 +1,15 @@
 import WebImage from './WebImage'
 
+
+
+/**
+ * String representing a Cast receiver device's capabilties
+ * "DynamicGroup" and "MultiChannelGroup" only available on iOS
+ *
+ * @see [Android](https://developers.google.cn/android/reference/com/google/android/gms/cast/CastDevice?hl=it-IT#hasCapabilities(int%5B%5D)) | [iOS](https://developers.google.cn/cast/docs/reference/ios/interface_g_c_k_device?hl=it-IT#ad2d54d60517308097ae26ff555062803) | [Chrome](https://developers.google.cn/cast/docs/reference/web_sender/chrome.cast?hl=it-IT#.Capability)
+ */
+export type DeviceCapability = "VideoOut" | "VideoIn" | "AudioOut" | "AudioIn" | "DynamicGroup" | "MultizoneGroup" | "MultiChannelGroup"
+
 /**
  * An object representing a Cast receiver device.
  *
@@ -26,4 +36,7 @@ export default interface Device {
 
   /** Gets the model name for the device. */
   modelName: string
+
+  /** List of capabilities available on this device */
+  capabilities: DeviceCapability[]
 }


### PR DESCRIPTION
Allows for clients to filter out devices that are incompatible for the medium they're trying to cast.
For example, filtering out devices that don't have "VideoOut" capability, when client knows they're casting video.
Example:
```typescript
const subscription = GoogleCast.getDiscoverManager().onDevicesUpdated(devices => {
  const videoCompatibleDevices = devices.filter((device) => device.capabilities.includes("VideoOut"))
  // ... display a list of video compatible devices
})
```

[Capability - Cast Docs](https://developers.google.cn/android/reference/com/google/android/gms/cast/CastDevice?hl=it-IT#hasCapability(int))