### PR TITLE
fix(ios): added null fallback to adBreakClipInfo dictionary

### DIFF
--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakClipInfo.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakClipInfo.m
@@ -18,17 +18,17 @@
   if (info == nil) return [NSNull null];
 
   return @{
-    @"adBreakClipId" : info.adBreakClipID,
-    @"duration" : @(info.duration),
-    @"title" : info.title,
+    @"adBreakClipId" : info.adBreakClipID  ?: [NSNull null],
+    @"duration" : @(info.duration)  ?: [NSNull null],
+    @"title" : info.title  ?: [NSNull null],
     @"clickThroughUrl" : info.clickThroughURL ?: [NSNull null],
     @"contentUrl" : info.contentURL ?: [NSNull null],
     @"mimeType" : info.mimeType ?: [NSNull null],
     @"contentId" : info.contentID ?: [NSNull null],
     @"posterUrl" : info.posterURL ?: [NSNull null],
-    @"whenSkippable" : @(info.whenSkippable),
+    @"whenSkippable" : @(info.whenSkippable)  ?: [NSNull null],
     @"hlsSegmentFormat" :
-        [RCTConvert fromGCKHLSSegmentFormat:info.hlsSegmentFormat],
+        [RCTConvert fromGCKHLSSegmentFormat:info.hlsSegmentFormat] ?: [NSNull null],
     //    @"vastAdsRequest" : ,
     @"customData" : info.customData ?: [NSNull null],
   };


### PR DESCRIPTION
Hi!

I stumbled upon an issue where my app would fatally crash when showing ads on the Chromecast because these values weren't converted from nil to null in the dictionary
I have very little experience in Objective C, but this did fix my problem of having a fatal crash and everything seems to work fine, but it is worth a check from someone who understands this logic a bit better then me ;p 

This was my exact error:
```
NSInvalidArgumentException: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[2]
```
on this location: 
```+[RCTConvert(GCKAdBreakClipInfo) fromGCKAdBreakClipInfo:]
(RCTConvert+GCKAdBreakClipInfo.m:20)
```