### PR TITLE
fix: update missing path, following podspec move

### DIFF
--- a/react-native-google-cast.podspec
+++ b/react-native-google-cast.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'RNGoogleCast' do |ss|
-    ss.source_files = 'RNGoogleCast/**/*.{h,m}'
+    ss.source_files = 'ios/RNGoogleCast/**/*.{h,m}'
     ss.dependency 'PromisesObjC'
   end
 end


### PR DESCRIPTION
Hello!

Recently used latest version (v4.2.6), and got these kind of runtime error on iOS:
- ``Invariant Violation: `new NativeEventEmitter()` requires a non-null argument.``

This follows discussion/fixes #438

Thanks for the lib ;)