### PR TITLE
fix: provide an error message onSessionStartFailed

### DIFF
--- a/src/api/SessionManager.ts
+++ b/src/api/SessionManager.ts
@@ -71,10 +71,10 @@ export default class SessionManager {
   }
 
   /** Called when a session has failed to start. */
-  onSessionStartFailed(handler: (session: CastSession) => void) {
+  onSessionStartFailed(handler: (session: CastSession, error: string) => void) {
     return this.eventEmitter.addListener(
       Native.SESSION_START_FAILED,
-      ({ session }) => handler(new CastSession(session))
+      ({ session, error }) => handler(new CastSession(session), error)
     )
   }
 


### PR DESCRIPTION
Hello and thank you for the lib!

I just noticed that the error message provided by android+ios native implementation is getting ignored on the JS method.

I didn't take time to test this small fix yet, do you know how to reproduce a failed start easily?