### PR TITLE
[android] Don't send an error in onSessionEnded when user stops casting

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/api/RNGCSessionManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/api/RNGCSessionManager.java
@@ -17,6 +17,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.CastStatusCodes;
 import com.google.android.gms.cast.framework.CastContext;
+import com.google.android.gms.cast.framework.CastReasonCodes;
 import com.google.android.gms.cast.framework.CastSession;
 import com.google.android.gms.cast.framework.SessionManager;
 import com.google.android.gms.cast.framework.SessionManagerListener;
@@ -26,6 +27,7 @@ import com.reactnative.googlecast.types.RNGCDevice;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class RNGCSessionManager
   extends ReactContextBaseJavaModule implements LifecycleEventListener, SessionManagerListener<CastSession> {
@@ -135,6 +137,15 @@ public class RNGCSessionManager
     WritableMap params = Arguments.createMap();
 
     params.putMap("session", RNGCCastSession.toJson((session)));
+
+    try {
+      Integer reasonCode = Objects.requireNonNull(CastContext.getSharedInstance()).getCastReasonCodeForCastStatusCode(error);
+      if (reasonCode.equals(CastReasonCodes.CASTING_STOPPED)) {
+        sendEvent(SESSION_ENDED, params);
+        return;
+      }
+    } catch (Exception ignored) {}
+
     params.putString("error", CastStatusCodes.getStatusCodeString(error));
 
     sendEvent(SESSION_ENDED, params);


### PR DESCRIPTION
Currently, on Android, when user clicks on "Stop casting" in the controls activity on their phone, the onSessionEnded listeners is called (OK) but with an error (KO). Google provides a reason for this obscure error code (2154 currently but this is internal so it might change) and a way to get a stable error code from this : CastReasonCodes.
The reason code for this particular reason is "Reason code indicating that the Cast session is explicitly stopped by users". So it is safe to ignore this false error and not send it back to the JS.
Also, on iOS, no error is sent back to the JS when user clicks on "Stop casting".