### PR TITLE
feat: add requestStatus method

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/api/RNGCRemoteMediaClient.java
+++ b/android/src/main/java/com/reactnative/googlecast/api/RNGCRemoteMediaClient.java
@@ -105,6 +105,16 @@ public class RNGCRemoteMediaClient extends ReactContextBaseJavaModule implements
   }
 
   @ReactMethod
+  public void requestStatus(final Promise promise) {
+    with.withX(new With.WithXPromisify<RemoteMediaClient>() {
+      @Override
+      public PendingResult execute(RemoteMediaClient client) {
+        return client.requestStatus();
+      }
+    }, promise);
+  }
+
+  @ReactMethod
   public void loadMedia(final ReadableMap request, final Promise promise) {
     with.withX(new With.WithXPromisify<RemoteMediaClient>() {
       @Override

--- a/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
+++ b/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
@@ -99,6 +99,14 @@ RCT_REMAP_METHOD(getStreamPosition,
   }];
 }
 
+RCT_EXPORT_METHOD(requestStatus: (RCTPromiseResolveBlock) resolve
+                  rejecter: (RCTPromiseRejectBlock) reject) {
+
+  [self withClientPromisifyResolve:resolve reject:reject perform:^GCKRequest *(GCKRemoteMediaClient *client) {
+    return [client requestStatus];
+  }];
+}
+
 RCT_EXPORT_METHOD(loadMedia: (GCKMediaLoadRequestData *) request
                   resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject) {

--- a/src/api/RemoteMediaClient.ts
+++ b/src/api/RemoteMediaClient.ts
@@ -50,6 +50,13 @@ export default class RemoteMediaClient {
   }
 
   /**
+   * Requests updated media status information from the receiver.
+   */
+  requestStatus(): Promise<void> {
+    return Native.requestStatus()
+  }
+
+  /**
    * Loads and starts playback of a media item or a queue of media items with a request data.
    *
    * @example


### PR DESCRIPTION
@petrbela 

This PR adds the requestStatus method that is already available on the native SDKs.

We use this method to explicitly request the status when the app comes back to the foreground, as the MediaStatus is not available immediately when the session is resumed.