### PR TITLE
feat: add liveSeekableRange object to MediaStatus

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/types/RNGCMediaLiveSeekableRange.java
+++ b/android/src/main/java/com/reactnative/googlecast/types/RNGCMediaLiveSeekableRange.java
@@ -1,0 +1,26 @@
+package com.reactnative.googlecast.types;
+
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.google.android.gms.cast.MediaLiveSeekableRange;
+
+public class RNGCMediaLiveSeekableRange {
+  public static @Nullable
+  WritableMap toJson(final @Nullable MediaLiveSeekableRange liveSeekableRange) {
+    if (liveSeekableRange == null) return null;
+
+    final WritableMap json = Arguments.createMap();
+
+    json.putDouble("endTime", liveSeekableRange.getEndTime() / 1000.0);
+
+    json.putDouble("startTime", liveSeekableRange.getStartTime() / 1000.0);
+
+    json.putBoolean("isLiveDone", liveSeekableRange.isLiveDone());
+
+    json.putBoolean("isMovingWindow", liveSeekableRange.isMovingWindow());
+
+    return json;
+  }
+}

--- a/android/src/main/java/com/reactnative/googlecast/types/RNGCMediaStatus.java
+++ b/android/src/main/java/com/reactnative/googlecast/types/RNGCMediaStatus.java
@@ -40,6 +40,10 @@ public class RNGCMediaStatus {
 
     json.putBoolean("isMuted", status.isMute());
 
+    if (status.getLiveSeekableRange() != null) {
+      json.putMap("liveSeekableRange", RNGCMediaLiveSeekableRange.toJson(status.getLiveSeekableRange()));
+    }
+
     if (status.getLoadingItemId() != MediaQueueItem.INVALID_ITEM_ID) {
       json.putInt("loadingItemId", status.getLoadingItemId());
     }

--- a/ios/RNGoogleCast.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleCast.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0AA36BA329CB398E009A7241 /* RCTConvert+GCKMediaLiveSeekableRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaLiveSeekableRange.h"; sourceTree = "<group>"; };
+		0AA36BA429CB39A8009A7241 /* RCTConvert+GCKMediaLiveSeekableRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+GCKMediaLiveSeekableRange.m"; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libRNGoogleCast.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNGoogleCast.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		911BE483201C8E7C00474413 /* RNGCCastContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGCCastContext.h; sourceTree = "<group>"; };
 		911BE484201C8E8200474413 /* RNGCCastContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGCCastContext.m; sourceTree = "<group>"; };
@@ -237,20 +239,6 @@
 		91D99D8A231A73270081468C /* types */ = {
 			isa = PBXGroup;
 			children = (
-				F5A8B31225CDE17B001CD915 /* RCTConvert+GCKCastSession.h */,
-				914BA2BD25BF7545001FFA5E /* RCTConvert+GCKCastSession.m */,
-				F5A8B37F25CDE68B001CD915 /* RCTConvert+GCKMediaLoadRequest.h */,
-				914BA2BF25BF7545001FFA5E /* RCTConvert+GCKMediaLoadRequest.m */,
-				F5A8B38125CDE6EF001CD915 /* RCTConvert+GCKMediaQueueContainerMetadata.h */,
-				914BA2C125BF7545001FFA5E /* RCTConvert+GCKMediaQueueContainerMetadata.m */,
-				F5A8B38225CDE72E001CD915 /* RCTConvert+GCKMediaQueueContainerType.h */,
-				914BA2BE25BF7545001FFA5E /* RCTConvert+GCKMediaQueueContainerType.m */,
-				F5A8B38425CDE90A001CD915 /* RCTConvert+GCKMediaQueueData.h */,
-				914BA2BC25BF7545001FFA5E /* RCTConvert+GCKMediaQueueData.m */,
-				F5A8B38525CDE916001CD915 /* RCTConvert+GCKMediaQueueType.h */,
-				914BA2C025BF7545001FFA5E /* RCTConvert+GCKMediaQueueType.m */,
-				F5A8B38625CDE929001CD915 /* RCTConvert+GCKRemoteMediaClient.h */,
-				914BA2C225BF7545001FFA5E /* RCTConvert+GCKRemoteMediaClient.m */,
 				F5A8B38725CDE932001CD915 /* RCTConvert+GCKActiveInputStatus.h */,
 				914932D0231C6EA8001AE93B /* RCTConvert+GCKActiveInputStatus.m */,
 				F5A8B38825CDE93B001CD915 /* RCTConvert+GCKAdBreakClipInfo.h */,
@@ -261,6 +249,8 @@
 				91829AA9227E1D5E00906C0C /* RCTConvert+GCKAdBreakStatus.m */,
 				F5A8B38B25CDE956001CD915 /* RCTConvert+GCKApplicationMetadata.h */,
 				914932D2231D7554001AE93B /* RCTConvert+GCKApplicationMetadata.m */,
+				F5A8B31225CDE17B001CD915 /* RCTConvert+GCKCastSession.h */,
+				914BA2BD25BF7545001FFA5E /* RCTConvert+GCKCastSession.m */,
 				F5A8B38C25CDE962001CD915 /* RCTConvert+GCKCastState.h */,
 				9143E4D4231B1659008A23D9 /* RCTConvert+GCKCastState.m */,
 				F5A8B38D25CDE96D001CD915 /* RCTConvert+GCKColor.h */,
@@ -273,6 +263,10 @@
 				91829AA2227E1D5E00906C0C /* RCTConvert+GCKImage.m */,
 				F5A8B39125CDE9E0001CD915 /* RCTConvert+GCKMediaInformation.h */,
 				91829ABA227E1D5F00906C0C /* RCTConvert+GCKMediaInformation.m */,
+				0AA36BA329CB398E009A7241 /* RCTConvert+GCKMediaLiveSeekableRange.h */,
+				0AA36BA429CB39A8009A7241 /* RCTConvert+GCKMediaLiveSeekableRange.m */,
+				F5A8B37F25CDE68B001CD915 /* RCTConvert+GCKMediaLoadRequest.h */,
+				914BA2BF25BF7545001FFA5E /* RCTConvert+GCKMediaLoadRequest.m */,
 				F5A8B39225CDE9E8001CD915 /* RCTConvert+GCKMediaMetadata.h */,
 				91829AA3227E1D5E00906C0C /* RCTConvert+GCKMediaMetadata.m */,
 				F5A8B39325CDE9F1001CD915 /* RCTConvert+GCKMediaMetadataType.h */,
@@ -281,8 +275,16 @@
 				91829AB0227E1D5F00906C0C /* RCTConvert+GCKMediaPlayerIdleReason.m */,
 				F5A8B39525CDE9FF001CD915 /* RCTConvert+GCKMediaPlayerState.h */,
 				91829AAD227E1D5E00906C0C /* RCTConvert+GCKMediaPlayerState.m */,
+				F5A8B38125CDE6EF001CD915 /* RCTConvert+GCKMediaQueueContainerMetadata.h */,
+				914BA2C125BF7545001FFA5E /* RCTConvert+GCKMediaQueueContainerMetadata.m */,
+				F5A8B38225CDE72E001CD915 /* RCTConvert+GCKMediaQueueContainerType.h */,
+				914BA2BE25BF7545001FFA5E /* RCTConvert+GCKMediaQueueContainerType.m */,
+				F5A8B38425CDE90A001CD915 /* RCTConvert+GCKMediaQueueData.h */,
+				914BA2BC25BF7545001FFA5E /* RCTConvert+GCKMediaQueueData.m */,
 				F5A8B39625CDEA05001CD915 /* RCTConvert+GCKMediaQueueItem.h */,
 				91829ABB227E1D5F00906C0C /* RCTConvert+GCKMediaQueueItem.m */,
+				F5A8B38525CDE916001CD915 /* RCTConvert+GCKMediaQueueType.h */,
+				914BA2C025BF7545001FFA5E /* RCTConvert+GCKMediaQueueType.m */,
 				F5A8B39725CDEA10001CD915 /* RCTConvert+GCKMediaRepeatMode.h */,
 				91829AAB227E1D5E00906C0C /* RCTConvert+GCKMediaRepeatMode.m */,
 				F5A8B39825CDEA19001CD915 /* RCTConvert+GCKMediaResumeState.h */,
@@ -299,16 +301,18 @@
 				914932D8231E9A07001AE93B /* RCTConvert+GCKMediaTextTrackStyleEdgeType.m */,
 				F5A8B39E25CDEA64001CD915 /* RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h */,
 				914932DC231E9BBD001AE93B /* RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.m */,
-				F5A8B39F25CDEA6D001CD915 /* RCTConvert+GCKMediaTextTrackStyleWindowType.h */,
-				914932DA231E9B4E001AE93B /* RCTConvert+GCKMediaTextTrackStyleWindowType.m */,
 				F5A8B3A025CDEA76001CD915 /* RCTConvert+GCKMediaTextTrackStyleFontStyle.h */,
 				914932DE231E9CC0001AE93B /* RCTConvert+GCKMediaTextTrackStyleFontStyle.m */,
+				F5A8B39F25CDEA6D001CD915 /* RCTConvert+GCKMediaTextTrackStyleWindowType.h */,
+				914932DA231E9B4E001AE93B /* RCTConvert+GCKMediaTextTrackStyleWindowType.m */,
 				F5A8B3A125CDEA7F001CD915 /* RCTConvert+GCKMediaTextTrackSubtype.h */,
 				91829AB9227E1D5F00906C0C /* RCTConvert+GCKMediaTextTrackSubtype.m */,
 				F5A8B3A225CDEA87001CD915 /* RCTConvert+GCKMediaTrack.h */,
 				91829AA8227E1D5E00906C0C /* RCTConvert+GCKMediaTrack.m */,
 				F5A8B3A325CDEA8E001CD915 /* RCTConvert+GCKMediaTrackType.h */,
 				91829AA4227E1D5E00906C0C /* RCTConvert+GCKMediaTrackType.m */,
+				F5A8B38625CDE929001CD915 /* RCTConvert+GCKRemoteMediaClient.h */,
+				914BA2C225BF7545001FFA5E /* RCTConvert+GCKRemoteMediaClient.m */,
 				F5A8B3A425CDEA9D001CD915 /* RCTConvert+GCKStandbyStatus.h */,
 				91829AB2227E1D5F00906C0C /* RCTConvert+GCKStandbyStatus.m */,
 				F5A8B3A525CDEAA4001CD915 /* RCTConvert+GCKVideoInfo.h */,

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaLiveSeekableRange.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaLiveSeekableRange.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKMediaLiveSeekableRange_h
+#define RCTConvert_GCKMediaLiveSeekableRange_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaLiveSeekableRange)
+
++ (nonnull id)fromGCKMediaLiveSeekableRange:(nullable GCKMediaLiveSeekableRange *)range;
+
+@end
+
+#endif /* RCTConvert_GCKMediaInformation_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaLiveSeekableRange.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaLiveSeekableRange.m
@@ -1,0 +1,19 @@
+#import "RCTConvert+GCKMediaLiveSeekableRange.h"
+
+
+@implementation RCTConvert (GCKMediaLiveSeekableRange)
+
++ (nonnull id)fromGCKMediaLiveSeekableRange:(nullable GCKMediaLiveSeekableRange *)info {
+  if (info == nil) return [NSNull null];
+
+  NSMutableDictionary *json = [[NSMutableDictionary alloc] init];
+
+  json[@"startTime"] = @(info.startTime);
+  json[@"endTime"] = @(info.endTime);
+  json[@"isMovingWindow"] = @(info.isMovingWindow);
+  json[@"isLiveDone"] = @(info.isLiveDone);
+
+  return json;
+}
+
+@end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaStatus.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaStatus.m
@@ -7,6 +7,7 @@
 #import "RCTConvert+GCKMediaQueueItem.h"
 #import "RCTConvert+GCKVideoInfo.h"
 #import "RCTConvert+GCKAdBreakStatus.h"
+#import "RCTConvert+GCKMediaLiveSeekableRange.h"
 
 @implementation RCTConvert (GCKMediaStatus)
 
@@ -29,6 +30,9 @@
   [RCTConvert fromGCKMediaPlayerIdleReason:status.idleReason];
 
   json[@"isMuted"] = @(status.isMuted);
+
+  json[@"liveSeekableRange"] =
+  [RCTConvert fromGCKMediaLiveSeekableRange:status.liveSeekableRange];
 
   json[@"loadingItemId"] = @(status.loadingItemID);
 

--- a/src/types/MediaLiveSeekableRange.ts
+++ b/src/types/MediaLiveSeekableRange.ts
@@ -1,0 +1,22 @@
+/**
+ * A class that aggregates information about the seekable range of a media stream.
+ *
+ * Each media session is associated with a media queue on the receiver application. The list of media items in the current queue can be obtained from `queueItems`. Media items are assigned a unique item ID. Accessors for individual item and values of properties of the queue are also provided here.
+ *
+ * `currentItemId`, `loadingItemId` and `preloadedItemId` tells which item is playing, which item is loading and which item has been preloaded on the receiver.
+ *
+ * @see [Android](https://developers.google.com/android/reference/com/google/android/gms/cast/MediaLiveSeekableRange) | [iOS](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_media_live_seekable_range) | [Chrome](https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.LiveSeekableRange)
+ */
+export default interface MediaLiveSeekableRange {
+  /** End of the seekable range in seconds. */
+  end: number
+
+  /** A boolean value indicates whether the live seekable range is a moving window. */
+  isMovingWindow: boolean
+
+  /** A boolean value indicates whether a live stream is ended. */
+  isLiveDone: boolean
+
+  /** Start of the seekable range in seconds. */
+  start: number
+}

--- a/src/types/MediaLiveSeekableRange.ts
+++ b/src/types/MediaLiveSeekableRange.ts
@@ -9,7 +9,7 @@
  */
 export default interface MediaLiveSeekableRange {
   /** End of the seekable range in seconds. */
-  end: number
+  endTime: number
 
   /** A boolean value indicates whether the live seekable range is a moving window. */
   isMovingWindow: boolean
@@ -18,5 +18,5 @@ export default interface MediaLiveSeekableRange {
   isLiveDone: boolean
 
   /** Start of the seekable range in seconds. */
-  start: number
+  startTime: number
 }

--- a/src/types/MediaStatus.ts
+++ b/src/types/MediaStatus.ts
@@ -1,4 +1,5 @@
 import MediaInfo from './MediaInfo'
+import MediaLiveSeekableRange from './MediaLiveSeekableRange'
 import MediaPlayerIdleReason from './MediaPlayerIdleReason'
 import MediaPlayerState from './MediaPlayerState'
 import MediaQueueItem from './MediaQueueItem'
@@ -29,6 +30,9 @@ export default interface MediaStatus {
 
   /** The stream's mute state. */
   isMuted: boolean
+
+  /** The seekable range of a live media stream */
+  liveSeekableRange?: MediaLiveSeekableRange | null
 
   /** The itemId of the {@link MediaQueueItem} that is currently loading (but isn't active in the queue) on the receiver. */
   loadingItemId?: number


### PR DESCRIPTION
This PR adds the liveSeekableRange property that is already available on the native SDKs to MediaStatus.

We use this range for the seek bar on the sender when playing a live stream.