### PR TITLE
fix: prevent crash when ending session due to missing GMS

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/api/RNGCSessionManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/api/RNGCSessionManager.java
@@ -87,6 +87,11 @@ public class RNGCSessionManager
     getReactApplicationContext().runOnUiQueueThread(new Runnable() {
       @Override
       public void run() {
+        if (!RNGCCastContext.isCastApiAvailable(getReactApplicationContext())) {
+          promise.resolve(null);
+          return;
+        }
+
         SessionManager sessionManager =
           CastContext.getSharedInstance(getReactApplicationContext())
             .getSessionManager();


### PR DESCRIPTION
In my app, when closing the screen I end the casting session with this command:

```
await GoogleCast.sessionManager.endCurrentSession(true);
```

This works fine generally but if the device doesn't have Google Mobile Services installed, it causes a crash with this message:
> com.google.android.gms.cast.framework.zzat: com.google.android.gms.dynamite.DynamiteModule$LoadingException: No acceptable module com.google.android.gms.cast.framework.dynamite found. Local version is 0 and remote version is 0.

This PR resolves this crash.