### PR TITLE
added GuestMode with Apple Silicon (M1/M2) support 

### DIFF
--- a/react-native-google-cast.podspec
+++ b/react-native-google-cast.podspec
@@ -25,6 +25,11 @@ Pod::Spec.new do |s|
     ss.dependency 'google-cast-sdk'
   end
 
+  s.subspec 'GuestModeArm' do |ss|
+    ss.dependency "#{package['name']}/RNGoogleCast"
+    ss.dependency 'google-cast-sdk-dynamic-xcframework'
+  end
+
   s.subspec 'NoBluetooth' do |ss|
     ss.dependency "#{package['name']}/RNGoogleCast"
     ss.dependency 'google-cast-sdk-no-bluetooth'


### PR DESCRIPTION
Introducing subspec for Apple Silicon Arm/M1/M2 architecture.

Maybe we could use it as the default subspec, so people don't have to change anything on Apple Silicon Mac computers?