### PR TITLE
Fix RCTConvert+GCKImage crash

### DIFF
--- a/ios/RNGoogleCast/types/RCTConvert+GCKImage.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKImage.m
@@ -9,11 +9,14 @@
 }
 
 + (nonnull id)fromGCKImage:(nullable GCKImage *)image {
-  if (image == nil) return [NSNull null];
+  if (image == nil || image.URL == nil) return [NSNull null];
+
+  NSString *url = [image.URL absoluteString];
+  if (url == nil) return [NSNull null];
 
   return @{
     @"height" : @(image.height),
-    @"url" : [image.URL absoluteString],
+    @"url" : url,
     @"width" : @(image.width),
   };
 }


### PR DESCRIPTION
Hello,

This fixes the following crash:

```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0xec69c __exceptionPreprocess
1  libobjc.A.dylib                0x2bc80 objc_exception_throw
2  CoreFoundation                 0x5623c -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
3  CoreFoundation                 0x55b60 +[NSDictionary dictionaryWithObjects:forKeys:count:]
4  app                  0xb4cd68 +[RCTConvert(GCKImage) fromGCKImage:] + 14 (RCTConvert+GCKImage.m:14)
5  app                  0xb4c4e0 +[RCTConvert(GCKDevice) fromGCKDevice:] + 44 (RCTConvert+GCKDevice.m:44)
6  app                  0xb55dec __42-[RNGCCastSession getCastDevice:rejecter:]_block_invoke + 110 (RNGCCastSession.m:110)
```

Not sure whether this is `image.URL` which might be nil or `[image.URL absoluteString]` but let's check both.