### PR TITLE
Fix crash in RCTConvert+GCKMediaTextTrackStyle

### DIFF
--- a/ios/RNGoogleCast/types/RCTConvert+GCKColor.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKColor.h
@@ -7,7 +7,7 @@
 @interface RCTConvert (GCKColor)
 
 + (nullable GCKColor *)GCKColor:(nullable id)json;
-+ (nullable id)fromGCKColor:(nullable GCKColor *)color;
++ (nonnull id)fromGCKColor:(nullable GCKColor *)color;
 
 @end
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKColor.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKColor.m
@@ -8,8 +8,8 @@
   return [[GCKColor alloc] initWithCSSString:json];
 }
 
-+ (nullable id)fromGCKColor:(nullable GCKColor *)color {
-  if (color == nil) return nil;
++ (nonnull id)fromGCKColor:(nullable GCKColor *)color {
+  if (color == nil) return [NSNull null];
 
   return color.CSSString;
 }


### PR DESCRIPTION
Hello,

This fixes the following crash:

```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0xec69c __exceptionPreprocess
1  libobjc.A.dylib                0x2bc80 objc_exception_throw
2  CoreFoundation                 0x5623c -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
3  CoreFoundation                 0x55b60 +[NSDictionary dictionaryWithObjects:forKeys:count:]
4  app                  0xadafa4 +[RCTConvert(GCKMediaTextTrackStyle) fromGCKMediaTextTrackStyle:] + 64 (RCTConvert+GCKMediaTextTrackStyle.m:64)
5  app                  0xad5c40 +[RCTConvert(GCKMediaInformation) fromGCKMediaInformation:] + 148 (RCTConvert+GCKMediaInformation.m:148)
6  app                  0xada2a4 +[RCTConvert(GCKMediaStatus) fromGCKMediaStatus:] + 36 (RCTConvert+GCKMediaStatus.m:36)
7  app                  0xadfc3c __57-[RNGCRemoteMediaClient getMediaStatusResolver:rejecter:]_block_invoke + 84 (RNGCRemoteMediaClient.m:84)
8  app                  0xae0f18 __58-[RNGCRemoteMediaClient withClientResolve:reject:perform:]_block_invoke + 329 (RNGCRemoteMediaClient.m:329)
```
