### PR TITLE
added namespace for AGP version 7+. This should fix compatibility iss…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,10 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace = "com.reactnative.googlecast"
+    }
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', '31.0.0')
 


### PR DESCRIPTION
…ues with gradle 8.

This fixes issue [#525](https://github.com/react-native-google-cast/react-native-google-cast/issues/525)