### PR TITLE
Add support for expo 53 - Swift AppDelegate

### DIFF
--- a/src/plugin/withIosGoogleCast.ts
+++ b/src/plugin/withIosGoogleCast.ts
@@ -4,7 +4,7 @@ import {
   withAppDelegate,
   withInfoPlist,
 } from '@expo/config-plugins'
-
+import { insertContentsInsideSwiftFunctionBlock } from '@expo/config-plugins/build/ios/codeMod'
 const LOCAL_NETWORK_USAGE =
   '${PRODUCT_NAME} uses the local network to discover Cast-enabled devices on your WiFi network'
 
@@ -61,7 +61,7 @@ const withIosAppDelegateLoaded: ConfigPlugin<IosProps> = (config, props) => {
         addSwiftGoogleCastAppDelegateDidFinishLaunchingWithOptions(
           config_.modResults.contents,
           props
-        ).contents
+        )
       config_.modResults.contents = addSwiftGoogleCastAppDelegateImport(
         config_.modResults.contents
       ).contents
@@ -226,14 +226,10 @@ export function addSwiftGoogleCastAppDelegateDidFinishLaunchingWithOptions(
 
   newSrc = newSrc.filter(Boolean)
 
-  // For better reliability, let's look for any appearance of "self.moduleName" which is common in
-  // Swift Expo AppDelegates
-  return mergeContents({
-    tag: 'react-native-google-cast-didFinishLaunchingWithOptions',
+  return insertContentsInsideSwiftFunctionBlock(
     src,
-    newSrc: newSrc.join('\n'),
-    anchor: /self\.moduleName/,
-    offset: -1, // Insert right before this line
-    comment: '//',
-  })
+    'application didFinishLaunchingWithOptions:',
+    newSrc.join('\n'),
+    { position: 'tailBeforeLastReturn' }
+  )
 }

--- a/src/plugin/withIosGoogleCast.ts
+++ b/src/plugin/withIosGoogleCast.ts
@@ -44,7 +44,16 @@ const withIosLocalNetworkPermissions: ConfigPlugin<{
 // TODO: Use AppDelegate swizzling
 const withIosAppDelegateLoaded: ConfigPlugin<IosProps> = (config, props) => {
   return withAppDelegate(config, (config_) => {
-    if (
+    if (config_.modResults.language === 'swift') {
+      config_.modResults.contents =
+        addSwiftGoogleCastAppDelegateDidFinishLaunchingWithOptions(
+          config_.modResults.contents,
+          props
+        )
+      config_.modResults.contents = addSwiftGoogleCastAppDelegateImport(
+        config_.modResults.contents
+      ).contents
+    } else if (
       config_.modResults.language === 'objc' ||
       config_.modResults.language === 'objcpp'
     ) {
@@ -56,19 +65,6 @@ const withIosAppDelegateLoaded: ConfigPlugin<IosProps> = (config, props) => {
       config_.modResults.contents = addGoogleCastAppDelegateImport(
         config_.modResults.contents
       ).contents
-    } else if (config_.modResults.language === 'swift') {
-      config_.modResults.contents =
-        addSwiftGoogleCastAppDelegateDidFinishLaunchingWithOptions(
-          config_.modResults.contents,
-          props
-        )
-      config_.modResults.contents = addSwiftGoogleCastAppDelegateImport(
-        config_.modResults.contents
-      ).contents
-    } else {
-      throw new Error(
-        'react-native-google-cast config plugin only supports Objective-C(++) or Swift AppDelegates.'
-      )
     }
 
     return config_
@@ -100,10 +96,6 @@ export const withIosGoogleCast: ConfigPlugin<{
 // From expo-cli RNMaps setup
 export const MATCH_INIT =
   /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g
-
-// Match Swift AppDelegate's didFinishLaunchingWithOptions method - updated with more flexible pattern
-export const MATCH_SWIFT_INIT =
-  /public\s+override\s+func\s+application\s*\(\s*_?\s*application\s*:\s*UIApplication\s*,\s*didFinishLaunchingWithOptions\s+launchOptions\s*:.*\)\s*->\s*Bool/g
 
 type IosProps = {
   disableDiscoveryAutostart?: boolean


### PR DESCRIPTION
In Expo 53, Expo team migrated to swift AppDelegate.

https://expo.dev/changelog/sdk-53-beta
![image](https://github.com/user-attachments/assets/826616a3-792b-47d9-b688-61a1163aa6a7)
