### PR TITLE
fix: removes unused libs, to add support to disable jetifier

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,5 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '+')}"
-    implementation "com.android.support:mediarouter-v7:${safeExtGet('supportLibVersion', '+')}"
     implementation "com.google.android.gms:play-services-cast-framework:${safeExtGet('castFrameworkVersion', '+')}"
 }


### PR DESCRIPTION
For some reason still added support libs. Which is not used. So deleting. 