### PR TITLE
fix: update googleCastVersionImport to support versions of expo that doen't have ext block

### DIFF
--- a/src/plugin/withAndroidGoogleCast.ts
+++ b/src/plugin/withAndroidGoogleCast.ts
@@ -262,14 +262,20 @@ function addGoogleCastVersionImport(
   src: string,
   { version }: { version?: string } = {}
 ) {
-  const newSrc = []
-  newSrc.push(`        castFrameworkVersion = "${version}"`)
+  const newSrc = [`        castFrameworkVersion = "${version}"`]
+  const hasExtBlock = src.match(/ext(?:\s+)?\{/)
+  const anchor = hasExtBlock ? /ext(?:\s+)?\{/ : /buildscript(?:\s+)?\{/
+
+  if (!hasExtBlock) {
+    newSrc.unshift('  ext {')
+    newSrc.push('  }')
+  }
 
   return mergeContents({
-    tag: 'react-native-google-cast-version',
+    tag: 'react-native-google-cast-version-import',
     src,
     newSrc: newSrc.join('\n'),
-    anchor: /ext(?:\s+)?\{/,
+    anchor,
     offset: 1,
     comment: '//',
   })


### PR DESCRIPTION
In this [PR](https://github.com/expo/expo/pull/34665) expo team removed the ext block.
This breaks the config plugin for all new expo versions.

Added logic to detect whether an `ext` block exists in the source (`src`) and dynamically set the anchor point to either `ext` or `buildscript` blocks, and included logic to wrap the version import with an `ext` block if one does not already exist.
