### PR TITLE
Fix Android CastButton not responding to taps inside JS responder views

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/components/RNGoogleCastButtonManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/components/RNGoogleCastButtonManager.java
@@ -5,6 +5,7 @@ import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
+import android.view.MotionEvent;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -16,6 +17,7 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.events.NativeGestureUtil;
 import com.google.android.gms.cast.framework.CastButtonFactory;
 import com.google.android.gms.cast.framework.CastContext;
 import com.google.android.gms.cast.framework.CastState;
@@ -88,6 +90,14 @@ public class RNGoogleCastButtonManager
     public ColorableMediaRouteButton(Context context, AttributeSet attrs,
                                      int defStyleAttr) {
       super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+      if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
+        NativeGestureUtil.notifyNativeGestureStarted(this, event);
+      }
+      return super.onTouchEvent(event);
     }
 
     @Override

--- a/playground/src/screens/Home.tsx
+++ b/playground/src/screens/Home.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
-import { StackNavigationProp } from '@react-navigation/stack'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import React, { useEffect } from 'react'
 import { Button, SectionList, Text, View } from 'react-native'
 import CastContext, { PlayServicesState } from 'react-native-google-cast'
@@ -9,7 +9,7 @@ export interface HomeProps {}
 
 export default function Home() {
   const navigation =
-    useNavigation<StackNavigationProp<RootStackParamList, 'Home'>>()
+    useNavigation<NativeStackNavigationProp<RootStackParamList, 'Home'>>()
 
   useEffect(() => {
     CastContext.getPlayServicesState().then((state) => {


### PR DESCRIPTION
 **Problem**

  On Android, the MediaRouteButton (Chromecast button) does not respond to taps when placed inside a view hierarchy where a parent React Native view claims the JS touch responder via onStartShouldSetResponder.

  This happens because React Native's gesture system doesn't know that a native child view wants to handle the touch. The JS responder claims the touch event, and the native MediaRouteButton never receives performClick().

  **Fix**

  Override onTouchEvent in ColorableMediaRouteButton to call NativeGestureUtil.notifyNativeGestureStarted() on ACTION_DOWN. This tells React Native's gesture system that a native gesture has begun, causing it to cancel any competing JS responders for the current touch sequence.

  This is the same mechanism used by React Native's own ReactScrollView, ReactSwipeRefreshLayout, and other native views that need to coexist with the JS responder system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation type definitions for improved type safety and consistency
  * Enhanced Android gesture recognition by improving touch event handling mechanisms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-native-google-cast/react-native-google-cast/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->