### PR TITLE
fix(v5): migrate jest preset to @react-native/jest-preset (RN 0.86)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,1 +1,3 @@
-module.exports = {}
+module.exports = {
+  presets: ['@react-native/babel-preset'],
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",
     "@expo/config-plugins": "^10.1.2",
+    "@react-native/babel-preset": "^0.86.0",
     "@react-native/eslint-config": "^0.86.0",
     "@react-native/jest-preset": "^0.86.0",
     "@release-it/conventional-changelog": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@expo/config-plugins": "^10.1.2",
     "@react-native/eslint-config": "^0.86.0",
+    "@react-native/jest-preset": "^0.86.0",
     "@release-it/conventional-changelog": "^3.0.1",
     "@types/jest": "^29.5.12",
     "@types/react": "^19.2.0",
@@ -93,10 +94,14 @@
     "nitro"
   ],
   "jest": {
-    "preset": "react-native",
+    "preset": "@react-native/jest-preset",
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/example/"
     ]
   },
   "husky": {

--- a/src/plugin/__tests__/__snapshots__/withIosGoogleCast-test.ts.snap
+++ b/src/plugin/__tests__/__snapshots__/withIosGoogleCast-test.ts.snap
@@ -10,7 +10,7 @@ exports[`addGoogleCastAppDelegateDidFinishLaunchingWithOptions adds maps import 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-// @generated begin react-native-google-cast-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-7a14b082a9257b8360d6e8a28eeaabb1245c3e8b
+// @generated begin react-native-google-cast-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-91e3d019d9a840ec68eeacd949d17022bbc097ae
 #if __has_include(<GoogleCast/GoogleCast.h>)
   NSString *receiverAppID = @"foobar-bacon";
   GCKDiscoveryCriteria *criteria = [[GCKDiscoveryCriteria alloc] initWithApplicationID:receiverAppID];
@@ -19,6 +19,7 @@ exports[`addGoogleCastAppDelegateDidFinishLaunchingWithOptions adds maps import 
   options.startDiscoveryAfterFirstTapOnCastButton = true;
   options.suspendSessionsWhenBackgrounded = false;
   [GCKCastContext setSharedInstanceWithOptions:options];
+  [GCKCastContext sharedInstance].useDefaultExpandedMediaControls = false;
 #endif
 // @generated end react-native-google-cast-didFinishLaunchingWithOptions
   self.moduleName = @"main";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,6 +2473,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/create-cache-key-function@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/create-cache-key-function@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+  checksum: 10c0/5c47ef62205264adf77b1ff26b969ce9fe84920b8275c3c5e83f4236859d6ae5e4e7027af99eef04a8e334c4e424d44af3e167972083406070aca733ac2a2795
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/environment@npm:29.7.0"
@@ -3268,6 +3277,21 @@ __metadata:
   version: 0.86.0
   resolution: "@react-native/gradle-plugin@npm:0.86.0"
   checksum: 10c0/02d8f7ae14c3163a6acf7098b1227a7ffd66cbfde96b6b151a02739bfbc27f123e023bd3411383e9a7a33f18e4d4d82100448615b8955a0ff95e8dee5d1ef4e8
+  languageName: node
+  linkType: hard
+
+"@react-native/jest-preset@npm:^0.86.0":
+  version: 0.86.0
+  resolution: "@react-native/jest-preset@npm:0.86.0"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^29.7.0"
+    "@react-native/js-polyfills": "npm:0.86.0"
+    babel-jest: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    regenerator-runtime: "npm:^0.13.2"
+  peerDependencies:
+    react: ^19.2.3
+  checksum: 10c0/34f6ffe9c6cedbb23eaeffa801a3dfea75034740dca2c7685aa1bbef42a5f12aa735c17e041142a4551176410b641c35656861c94827e73341a39d40b20b5fbb
   languageName: node
   linkType: hard
 
@@ -11612,6 +11636,7 @@ __metadata:
     "@commitlint/config-conventional": "npm:^11.0.0"
     "@expo/config-plugins": "npm:^10.1.2"
     "@react-native/eslint-config": "npm:^0.86.0"
+    "@react-native/jest-preset": "npm:^0.86.0"
     "@release-it/conventional-changelog": "npm:^3.0.1"
     "@types/jest": "npm:^29.5.12"
     "@types/react": "npm:^19.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,7 +3122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/babel-preset@npm:0.86.0":
+"@react-native/babel-preset@npm:0.86.0, @react-native/babel-preset@npm:^0.86.0":
   version: 0.86.0
   resolution: "@react-native/babel-preset@npm:0.86.0"
   dependencies:
@@ -11635,6 +11635,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": "npm:^11.0.0"
     "@expo/config-plugins": "npm:^10.1.2"
+    "@react-native/babel-preset": "npm:^0.86.0"
     "@react-native/eslint-config": "npm:^0.86.0"
     "@react-native/jest-preset": "npm:^0.86.0"
     "@release-it/conventional-changelog": "npm:^3.0.1"


### PR DESCRIPTION
## Summary

- Install `@react-native/jest-preset ^0.86.0` — the jest preset was extracted from `react-native` in 0.86
- Update `jest.preset` in `package.json` from `"react-native"` to `"@react-native/jest-preset"`
- Configure `babel.config.js` with `@react-native/babel-preset` (was empty; the new preset's `setup.js` contains TypeScript and needs the transform)
- Add `testPathIgnorePatterns` to exclude `example/` from the root jest run (the example app test needs the built lib and belongs in its own jest context)
- Update stale Expo plugin snapshot (v5 plugin generates a slightly different AppDelegate)

## Test plan

- [ ] `yarn jest` passes — 2 Expo plugin tests green, no preset-load error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQNKBsvfTHP8rxAyPki4Ku

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Babel configuration to align with the React Native toolchain for improved build/transpilation compatibility.
  * Refined Jest testing setup by switching to the React Native Jest preset and improving test discovery exclusions (e.g., ignoring example and dependency directories).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->