### PR TITLE
feat(v5): CastError type + per-platform GCKError mapper (T5/C1)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/converters/GckStatusCode+toCastErrorCode.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/converters/GckStatusCode+toCastErrorCode.kt
@@ -1,0 +1,29 @@
+package com.margelo.nitro.googlecast.converters
+
+import com.google.android.gms.cast.CastStatusCodes
+
+/**
+ * Maps a [CastStatusCodes] integer to a `CastErrorCode` string literal (the TS string-literal union).
+ *
+ * Phase 3/4 reject sites will assemble the full `CastError` struct using this code plus the
+ * exception/status message and the raw status code as `nativeCode`.
+ *
+ * Default for any unrecognised code → `"failed"`.
+ */
+internal fun castErrorCodeFromGckStatusCode(statusCode: Int): String = when (statusCode) {
+  CastStatusCodes.NETWORK_ERROR -> "network"
+  CastStatusCodes.TIMEOUT -> "timeout"
+  CastStatusCodes.INTERRUPTED -> "interrupted"
+  CastStatusCodes.REPLACED -> "interrupted"
+  CastStatusCodes.CANCELED -> "cancelled"
+  CastStatusCodes.AUTHENTICATION_FAILED -> "authentication"
+  CastStatusCodes.INVALID_REQUEST -> "invalidRequest"
+  CastStatusCodes.NOT_ALLOWED,
+  CastStatusCodes.ERROR_HOST_NOT_ALLOWED -> "notAllowed"
+  CastStatusCodes.APPLICATION_NOT_FOUND,
+  CastStatusCodes.APPLICATION_NOT_RUNNING -> "appNotFound"
+  CastStatusCodes.DEVICE_CONNECTION_SUSPENDED,
+  CastStatusCodes.ERROR_CAST_PLATFORM_NOT_CONNECTED,
+  CastStatusCodes.ERROR_SERVICE_DISCONNECTED -> "noSession"
+  else -> "failed"
+}

--- a/ios/NitroGoogleCast/Converters/GckError+toCastError.swift
+++ b/ios/NitroGoogleCast/Converters/GckError+toCastError.swift
@@ -1,0 +1,67 @@
+import Foundation
+import GoogleCast
+
+/// Maps a `GCKError` to a `CastErrorCode` string literal (our TS string-literal union).
+///
+/// Guard on `error.domain == kGCKErrorDomain` at call sites that may receive errors from
+/// other NS error domains before calling this method.
+///
+/// Phase 3/4 reject sites will assemble the full `CastError` struct (`{ code, message, nativeCode }`)
+/// using this code plus `error.localizedDescription` and `error.code`.
+extension GCKError {
+  func toCastErrorCode() -> String {
+    switch GCKErrorCode(rawValue: code) {
+    case .networkError, .networkNotReachable:
+      return "network"
+    case .timeout:
+      return "timeout"
+    case .cancelled, .launchRequestCancelled:
+      return "cancelled"
+    case .replaced, .appDidEnterBackground:
+      return "interrupted"
+    case .notAllowed, .maxUsersConnected:
+      return "notAllowed"
+    case .invalidRequest, .invalidApplicationSessionID, .invalidMediaPlayerState:
+      return "invalidRequest"
+    case .socketInvalidParameter:
+      return "invalidParameter"
+    case .deviceAuthenticationFailure,
+         .deviceAuthorizationFailure,
+         .secureTransportError,
+         .authenticationErrorReceived,
+         .malformedClientCertificate,
+         .notX509Certificate,
+         .deviceCertificateNotTrusted,
+         .sslCertificateNotTrusted,
+         .malformedAuthenticationResponse,
+         .crlInvalid,
+         .crlCheckFailed,
+         .deviceAuthenticationMessageParseFailure,
+         .deviceAuthenticationMessageChallengeReceivedFailure,
+         .deviceAuthenticationTimeoutFailure:
+      return "authentication"
+    case .channelNotConnected,
+         .deviceNotConnected,
+         .sessionIsNotActive,
+         .noMediaSession,
+         .notCastSession,
+         .disconnected:
+      return "noSession"
+    case .applicationNotFound,
+         .applicationNotRunning,
+         .applicationNotRunningWithNamespaceMismatched,
+         .applicationNotRunningWhenResumed,
+         .applicationNotRunningForJoin,
+         .applicationNotRunningForJoinWhenReconnecting,
+         .applicationNotRunningWithApplicationIDMismatch:
+      return "appNotFound"
+    case .deviceCapabilityNotSupported,
+         .unsupportedFeature,
+         .remoteDisplayDeviceNotSupported,
+         .remoteDisplayFeatureNotSupported:
+      return "notSupported"
+    default:
+      return "failed"
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export type {
   CastState,
   ListenerSubscription,
 } from './transport/types'
+export type { CastError, CastErrorCode } from './types/CastError'

--- a/src/types/CastError.ts
+++ b/src/types/CastError.ts
@@ -1,0 +1,51 @@
+/**
+ * Typed error codes surfaced by every async Cast operation.
+ *
+ * These codes are produced either by the native GCKError mapper (Phase 3/4
+ * reject sites) or by the TS façade/state machine for logical errors
+ * such as {@link noSession} and {@link notSupported}.
+ *
+ * @see [Android CastStatusCodes](https://developers.google.com/android/reference/com/google/android/gms/cast/CastStatusCodes)
+ * @see [iOS GCKErrorCode](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_error)
+ */
+export type CastErrorCode =
+  /** No active Cast session; operation requires one. Produced by the TS state machine. */
+  | 'noSession'
+  /** Feature is not supported on this device or platform. */
+  | 'notSupported'
+  /** Network I/O error or device not reachable. */
+  | 'network'
+  /** Operation exceeded the allowed time limit. */
+  | 'timeout'
+  /** Operation was cancelled (typically by the sender). */
+  | 'cancelled'
+  /** Operation was interrupted, e.g. replaced by a newer request or app backgrounded. */
+  | 'interrupted'
+  /** Generic failure not covered by a more specific code. */
+  | 'failed'
+  /** A parameter passed to a native API was invalid. */
+  | 'invalidParameter'
+  /** The request was structurally invalid or made in the wrong state. */
+  | 'invalidRequest'
+  /** Device authentication or TLS/cert error. */
+  | 'authentication'
+  /** The sender is not authorised to perform the operation. */
+  | 'notAllowed'
+  /** The requested Cast application could not be found or is not running. */
+  | 'appNotFound'
+
+/**
+ * Structured error returned by async Cast operations.
+ *
+ * `code` is always present and is the primary discrimination key.
+ * `message` is the human-readable GCK description (locale-dependent).
+ * `nativeCode` is the raw platform error integer for diagnostics; assembled at reject sites in Phase 3/4.
+ */
+export interface CastError {
+  /** Typed error-code string literal. */
+  code: CastErrorCode
+  /** Optional human-readable description from the native SDK. */
+  message?: string
+  /** Raw platform error integer (`GCKErrorCode` on iOS, `CastStatusCodes` on Android). */
+  nativeCode?: number
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@
 // and the hand-written per-platform struct↔GCK converters.
 
 export type { ActiveInputState } from './ActiveInputState'
+export type { CastError, CastErrorCode } from './CastError'
 export type { ApplicationMetadata } from './ApplicationMetadata'
 export type { CastState } from './CastState'
 export type { Device, DeviceCapability } from './Device'


### PR DESCRIPTION
## Summary

- Adds `CastErrorCode` string-literal union (12 codes) and `CastError` interface to `src/types/CastError.ts`; re-exported from both barrel files.
- iOS: `GckError+toCastError.swift` — `GCKError` extension mapping ~30 `GCKErrorCode` cases to the union literals.
- Android: `GckStatusCode+toCastErrorCode.kt` — free `internal fun castErrorCodeFromGckStatusCode(Int): String` mapping `CastStatusCodes` named constants (not an `Int`-receiver extension per the Kotlin skill rule).

Mappers return `String` rather than a generated struct because `CastError` is not yet anchored to a `.nitro.ts` spec — wiring into async reject sites is Phase 3/4 scope. The comment in each mapper file calls this out explicitly.

## Quality gates

- `yarn typescript` — green (no output)
- `./gradlew :react-native-google-cast:compileDebugKotlin` — `BUILD SUCCESSFUL`
- iOS compile — deferred to integration (full `pod-install` + `xcodebuild` is heavy; the Swift file is straightforward and has no new dependencies)

## Test plan

- [ ] `yarn typescript` passes
- [ ] `./gradlew :react-native-google-cast:compileDebugKotlin` passes
- [ ] Phase 3/4: confirm mappers wire correctly into async reject sites when `CastError` is added to a `.nitro.ts` spec and codegen runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em11sCp1RWi8ryy85poovZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured cast error types for clearer handling of async failures.
  * Expanded the public API to expose these new error types for app code.
  * Improved native error translation so more platform errors map to consistent, user-facing error codes.

* **Bug Fixes**
  * Unrecognized native errors now fall back to a generic failure code instead of breaking error reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->