### PR TITLE
ci(v5): iOS XCTest converter-parity workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # No later step needs git auth; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,115 @@
+name: iOS CI
+
+# Converter parity suite for the v5 (Nitro) rewrite — the iOS counterpart to android.yml.
+#
+# This is a SINGLE job (no paths-filter / emulator split like Android). iOS XCTest links the
+# real compiled NitroGoogleCast + GoogleCast static framework, so it can exercise the
+# AnyMap-carrying converters (MediaInfo, MediaMetadata, MediaStatus, …) that the Android
+# Robolectric tier cannot. That makes this one job the authority for the whole shared golden
+# corpus (fixtures/converters/*.json) — the cross-platform contract both platforms verify.
+#
+# nitrogen/generated/ is committed, so codegen is NOT run here; a clean `pod install` + build
+# must reproduce the 16/16 green suite from the committed pbxproj build settings.
+
+on:
+  push:
+    branches: [v5]
+  pull_request:
+    branches: [v5]
+  workflow_dispatch:
+
+# Newer pushes to the same ref cancel in-flight runs.
+concurrency:
+  group: ios-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  xctest:
+    name: XCTest converter parity
+    # Pin the image (not macos-latest) so `latest-stable` Xcode + the bundled simulator
+    # runtime stay deterministic across runner-image rollouts.
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # --- JS deps (Yarn Berry 4 via corepack; example is a workspace of the repo root) ---
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Locate Yarn cache
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+
+      - name: Install JS dependencies
+        run: yarn install --immutable
+
+      # --- Ruby / CocoaPods (Gemfile lives in example/, pinned via bundler) ---
+      - name: Setup Ruby + Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: example
+
+      - name: Cache Pods
+        uses: actions/cache@v4
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: ${{ runner.os }}-pods-
+
+      - name: Pod install
+        working-directory: example/ios
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/example/Gemfile
+        run: bundle exec pod install
+
+      # Device names differ by Xcode/runner image, so resolve a concrete simulator at runtime
+      # instead of hardcoding one. The converter tests are device-agnostic — any booted iPhone
+      # simulator works — so pick the newest available iPhone and fail loudly if none exist.
+      - name: Select iOS Simulator
+        run: |
+          UDID=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices | to_entries[]
+                      | select(.key | test("iOS"))
+                      | .value[] | select(.name | test("^iPhone"))]
+                     | last | .udid')
+          if [ -z "$UDID" ] || [ "$UDID" = "null" ]; then
+            echo "::error::No available iPhone simulator found on this runner."
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Selected simulator UDID: $UDID"
+          xcrun simctl list devices available | grep -i "$UDID" || true
+          echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
+
+      - name: Run XCTest converter parity suite
+        working-directory: example/ios
+        run: |
+          xcodebuild test \
+            -workspace CastExample.xcworkspace \
+            -scheme NitroGoogleCastTests \
+            -destination "id=$SIMULATOR_UDID" \
+            -resultBundlePath "$GITHUB_WORKSPACE/NitroGoogleCastTests.xcresult"
+
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-xcresult
+          path: NitroGoogleCastTests.xcresult
+          if-no-files-found: ignore


### PR DESCRIPTION
## What

Adds `.github/workflows/ios.yml` — the iOS counterpart to the Android CI from #588.

A single macOS job runs the `NitroGoogleCastTests` converter-parity XCTest suite (16 tests) on push/PR to `v5` (+ `workflow_dispatch`):

1. `maxim-lobanov/setup-xcode` → latest-stable Xcode
2. corepack enable + `yarn install --immutable` (Yarn Berry 4; example is a workspace of the repo root)
3. `ruby/setup-ruby` (bundler-cache) + `bundle exec pod install` in `example/ios`
4. resolve a concrete simulator at runtime (device names drift across runner images; the converter tests are device-agnostic) and `xcodebuild test`

## Why one job (no Android-style tier split)

iOS XCTest links the **real compiled** `NitroGoogleCast` + `GoogleCast` static framework, so it exercises the AnyMap-carrying converters (MediaInfo, MediaMetadata, MediaStatus, …) that the Android Robolectric tier can't reach. That makes this single job the authority for the whole shared golden corpus (`fixtures/converters/*.json`) — the cross-platform contract.

## Notes

- `nitrogen/generated/` is committed, so codegen is **not** run; a clean `pod install` + build reproduces green from the committed pbxproj build settings (`SWIFT_OBJC_INTEROP_MODE=objcxx`, c++20, `HEADER_SEARCH_PATHS += $(PODS_ROOT)/Headers/Private/NitroModules`).
- Caches Yarn, gems, and Pods (keyed on `Podfile.lock`). DerivedData intentionally **not** cached (mirrors Android caching only deps, avoids stale-link false-greens).
- Mirrors the Android workflow shape: concurrency group, `.xcresult` artifact upload on `always()`.

## Verification

Ran the exact `xcodebuild test -workspace … -scheme NitroGoogleCastTests` invocation locally from a clean `pod install` → **16/16 green** (`TEST SUCCEEDED`) before pushing. The runner has a different Xcode/simulator set than local, so the first CI run is the real gate — watching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new macOS-based iOS CI workflow that automatically runs on pushes, pull requests, and manual triggers.
  * The workflow selects an available iPhone simulator at runtime, runs the iOS XCTest “converter parity” suite, and uploads the generated test result bundle for review. 
  * Includes run cancellation for the same ref to keep feedback up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->