### PR TITLE
feat(v5): Phase 4 T4b — RemoteMediaClient TS façade + hooks

### DIFF
--- a/src/api/RemoteMediaClient.ts
+++ b/src/api/RemoteMediaClient.ts
@@ -1,0 +1,258 @@
+import type { CastError, CastTransportApi } from '../transport/types'
+import type { CastStore } from '../state/CastStore'
+import { MEDIA_SLICE_KEY, type MediaState } from '../state/media.slice'
+import type { MediaLoadRequest } from '../types/MediaLoadRequest'
+import type { MediaQueueItem } from '../types/MediaQueueItem'
+import type { MediaRepeatMode } from '../types/MediaRepeatMode'
+import type { MediaSeekOptions } from '../types/MediaSeekOptions'
+import type { MediaStatus } from '../types/MediaStatus'
+import type { TextTrackStyle } from '../types/TextTrackStyle'
+
+/** The store capability the client needs: the live generation + the media slice. */
+type MediaStoreView = Pick<CastStore, 'getCurrentGeneration' | 'getSliceState'>
+
+/**
+ * Per-store memo of the live client, keyed by the store instance so two stores
+ * (e.g. parallel jest cases) never share a handle. Keyed-by-generation inside,
+ * so {@link RemoteMediaClient.current} hands back a referentially-stable client
+ * within a session — what `useRemoteMediaClient`'s `useSyncExternalStore`
+ * `getSnapshot` needs to avoid an over-render loop.
+ */
+const cache = new WeakMap<
+  object,
+  { generation: number; client: RemoteMediaClient }
+>()
+
+/**
+ * Controls a media player running on the Cast receiver — a thin façade over the
+ * singleton transport. Mutations route to the transport's RemoteMediaClient
+ * surface; reads are served synchronously from the central store's media slice.
+ *
+ * Like {@link CastSession}, it is bound to the lifecycle **generation** at which
+ * its session became live, so a handle retained across a disconnect is *stale*:
+ * {@link assertActive} rejects mutations with `noSession` before they cross the
+ * bridge, and reads return `null` rather than leaking a later session's status
+ * (Invariant 3, media flavour). Obtain one via the {@link useRemoteMediaClient}
+ * hook; never construct or cache it directly.
+ *
+ * @see [Android](https://developers.google.com/android/reference/com/google/android/gms/cast/framework/media/RemoteMediaClient) | [iOS](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_remote_media_client) _GCKRemoteMediaClient_ | [Chrome](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayer) _RemotePlayer_
+ *
+ * @example
+ * ```ts
+ * import { useRemoteMediaClient } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const client = useRemoteMediaClient()
+ *   client?.loadMedia({
+ *     mediaInfo: { contentUrl: 'https://.../BigBuckBunny.mp4' },
+ *   })
+ * }
+ * ```
+ */
+export class RemoteMediaClient {
+  private readonly store: MediaStoreView
+  private readonly transport: CastTransportApi
+  private readonly generation: number
+
+  /**
+   * The live client for the current session, memoized per generation, or `null`
+   * when there is no session. Internal — the hook layer's `getSnapshot`.
+   */
+  static current(
+    store: CastStore,
+    transport: CastTransportApi
+  ): RemoteMediaClient | null {
+    const session = store.getSnapshot().currentSession
+    if (!session) {
+      cache.delete(store)
+      return null
+    }
+    const cached = cache.get(store)
+    if (cached && cached.generation === session.generation) {
+      return cached.client
+    }
+    const client = new RemoteMediaClient(store, transport, session.generation)
+    cache.set(store, { generation: session.generation, client })
+    return client
+  }
+
+  constructor(
+    store: MediaStoreView,
+    transport: CastTransportApi,
+    generation: number
+  ) {
+    this.store = store
+    this.transport = transport
+    this.generation = generation
+  }
+
+  /** Whether this handle still refers to the current live session. */
+  get isActive(): boolean {
+    return this.store.getCurrentGeneration() === this.generation
+  }
+
+  /**
+   * Guard every bridge-crossing mutation must call first. Throws a
+   * {@link CastError} `noSession` the instant this handle is stale; because the
+   * mutations are `async`, that surfaces to the caller as a rejected promise.
+   */
+  private assertActive(): void {
+    if (!this.isActive) {
+      const error: CastError = {
+        code: 'noSession',
+        message: 'This media session has ended.',
+      }
+      throw error
+    }
+  }
+
+  // --- reads (synchronous; served from the media slice cache) ---
+
+  /** The current media status, or `null` if there is no media (or stale handle). */
+  getMediaStatus(): MediaStatus | null {
+    if (!this.isActive) return null
+    return this.store.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
+  }
+
+  /**
+   * The current stream position in seconds, or `null` if there is no media. Note
+   * this is the position at the *last status update*, not a real-time tick.
+   */
+  getStreamPosition(): number | null {
+    const status = this.getMediaStatus()
+    return status ? status.streamPosition : null
+  }
+
+  // --- mutations (async; route to the transport, status streams back) ---
+
+  /** Load (and, per the request, autoplay) media on the active session. */
+  async loadMedia(request: MediaLoadRequest): Promise<void> {
+    this.assertActive()
+    return this.transport.loadMedia(request)
+  }
+
+  /** Begin (or resume) playback of the current item. */
+  async play(): Promise<void> {
+    this.assertActive()
+    return this.transport.play()
+  }
+
+  /** Pause playback of the current item. */
+  async pause(): Promise<void> {
+    this.assertActive()
+    return this.transport.pause()
+  }
+
+  /** Stop playback and unload the current item (a loaded queue is removed). */
+  async stop(): Promise<void> {
+    this.assertActive()
+    return this.transport.stop()
+  }
+
+  /** Seek within the current item (absolute/relative + resume state). */
+  async seek(options: MediaSeekOptions): Promise<void> {
+    this.assertActive()
+    return this.transport.seek(options)
+  }
+
+  /** Set the playback rate (1 = normal; GCK clamps the supported range). */
+  async setPlaybackRate(playbackRate: number): Promise<void> {
+    this.assertActive()
+    return this.transport.setPlaybackRate(playbackRate)
+  }
+
+  /**
+   * Set the active media track ids (audio/text). Omit or pass an empty array to
+   * clear the current set and fall back to the receiver defaults.
+   */
+  async setActiveTrackIds(trackIds: number[] = []): Promise<void> {
+    this.assertActive()
+    return this.transport.setActiveTrackIds(trackIds)
+  }
+
+  /** Set the text-track (caption) style. */
+  async setTextTrackStyle(textTrackStyle: TextTrackStyle): Promise<void> {
+    this.assertActive()
+    return this.transport.setTextTrackStyle(textTrackStyle)
+  }
+
+  /** Set the stream volume of the active session (0…1). */
+  async setStreamVolume(volume: number): Promise<void> {
+    this.assertActive()
+    return this.transport.setStreamVolume(volume)
+  }
+
+  /** Mute/unmute the active session's stream. */
+  async setStreamMuted(muted: boolean): Promise<void> {
+    this.assertActive()
+    return this.transport.setStreamMuted(muted)
+  }
+
+  /** Replace the queue with `items`, starting at `startIndex`, in `repeatMode`. */
+  async queueLoad(
+    items: MediaQueueItem[],
+    startIndex = 0,
+    repeatMode: MediaRepeatMode = 'off'
+  ): Promise<void> {
+    this.assertActive()
+    return this.transport.queueLoad(items, startIndex, repeatMode)
+  }
+
+  /**
+   * Insert `items` before `beforeItemId`. A `beforeItemId` of `0` (GCK's
+   * invalid-item sentinel, the default) appends to the end of the queue.
+   */
+  async queueInsertItems(
+    items: MediaQueueItem[],
+    beforeItemId = 0
+  ): Promise<void> {
+    this.assertActive()
+    return this.transport.queueInsertItems(items, beforeItemId)
+  }
+
+  /** Move `itemIds` to before `beforeItemId` (`0` = move-to-end, the default). */
+  async queueReorderItems(itemIds: number[], beforeItemId = 0): Promise<void> {
+    this.assertActive()
+    return this.transport.queueReorderItems(itemIds, beforeItemId)
+  }
+
+  /** Remove `itemIds` from the queue. */
+  async queueRemoveItems(itemIds: number[]): Promise<void> {
+    this.assertActive()
+    return this.transport.queueRemoveItems(itemIds)
+  }
+
+  /** Advance to the next queue item. */
+  async queueNext(): Promise<void> {
+    this.assertActive()
+    return this.transport.queueNext()
+  }
+
+  /** Go back to the previous queue item. */
+  async queuePrev(): Promise<void> {
+    this.assertActive()
+    return this.transport.queuePrev()
+  }
+
+  /** Jump to a specific queue item by id. */
+  async queueJumpToItem(itemId: number): Promise<void> {
+    this.assertActive()
+    return this.transport.queueJumpToItem(itemId)
+  }
+
+  /** Set the queue repeat mode. */
+  async queueSetRepeatMode(repeatMode: MediaRepeatMode): Promise<void> {
+    this.assertActive()
+    return this.transport.queueSetRepeatMode(repeatMode)
+  }
+
+  /**
+   * Request a fresh media status from the receiver. Resolves once the request
+   * settles; the new status arrives via the store (and so the `useMediaStatus`
+   * hook), not the return value. (v4 name: `requestStatus`.)
+   */
+  async requestStatus(): Promise<void> {
+    this.assertActive()
+    return this.transport.requestMediaStatus()
+  }
+}

--- a/src/api/__tests__/RemoteMediaClient.test.ts
+++ b/src/api/__tests__/RemoteMediaClient.test.ts
@@ -1,0 +1,301 @@
+import { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import type { CastError, Device, SessionInfo } from '../../transport/types'
+import type { MediaStatus } from '../../types/MediaStatus'
+import type { MediaInfo } from '../../types/MediaInfo'
+import type { MediaLoadRequest } from '../../types/MediaLoadRequest'
+import type { MediaSeekOptions } from '../../types/MediaSeekOptions'
+import type { MediaQueueItem } from '../../types/MediaQueueItem'
+import type { TextTrackStyle } from '../../types/TextTrackStyle'
+import { CastStore } from '../../state/CastStore'
+import type { MediaState } from '../../state/media.slice'
+import { RemoteMediaClient } from '../RemoteMediaClient'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+function mediaStatus(streamPosition = 0): MediaStatus {
+  return {
+    streamPosition,
+    playbackRate: 1,
+    volume: 1,
+    isMuted: false,
+    queueItems: [],
+  }
+}
+
+const mediaInfo: MediaInfo = { contentUrl: 'https://example.com/a.mp4' }
+const loadRequest: MediaLoadRequest = { mediaInfo, autoplay: true }
+const seekOptions: MediaSeekOptions = { position: 42 }
+const textTrackStyle: TextTrackStyle = { fontScale: 1.2 }
+const queueItems: MediaQueueItem[] = [{ mediaInfo }]
+
+async function setup() {
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  await store.ready
+  return { transport, store }
+}
+
+/** A store with a single live session and its memoized client. */
+async function withSession() {
+  const { transport, store } = await setup()
+  transport.emitLifecycle({ type: 'started', session: session('s1') })
+  const client = RemoteMediaClient.current(store, transport)!
+  return { transport, store, client }
+}
+
+describe('RemoteMediaClient — reads (served from the media slice)', () => {
+  it('getMediaStatus is null until a status streams in', async () => {
+    const { client } = await withSession()
+    expect(client.getMediaStatus()).toBeNull()
+  })
+
+  it('getMediaStatus reflects the streamed status (same ref)', async () => {
+    const { client, transport } = await withSession()
+    const status = mediaStatus(10)
+    transport.emitMediaStatus(status)
+    expect(client.getMediaStatus()).toBe(status)
+  })
+
+  it('getStreamPosition reads the streamPosition, null when no status', async () => {
+    const { client, transport } = await withSession()
+    expect(client.getStreamPosition()).toBeNull()
+    transport.emitMediaStatus(mediaStatus(33))
+    expect(client.getStreamPosition()).toBe(33)
+  })
+})
+
+describe('RemoteMediaClient — mutation routing', () => {
+  const cases: Array<{
+    name: string
+    call: (c: RemoteMediaClient) => Promise<void>
+    expected: { method: string; args: unknown[] }
+  }> = [
+    {
+      name: 'loadMedia',
+      call: (c) => c.loadMedia(loadRequest),
+      expected: { method: 'loadMedia', args: [loadRequest] },
+    },
+    {
+      name: 'play',
+      call: (c) => c.play(),
+      expected: { method: 'play', args: [] },
+    },
+    {
+      name: 'pause',
+      call: (c) => c.pause(),
+      expected: { method: 'pause', args: [] },
+    },
+    {
+      name: 'stop',
+      call: (c) => c.stop(),
+      expected: { method: 'stop', args: [] },
+    },
+    {
+      name: 'seek',
+      call: (c) => c.seek(seekOptions),
+      expected: { method: 'seek', args: [seekOptions] },
+    },
+    {
+      name: 'setPlaybackRate',
+      call: (c) => c.setPlaybackRate(1.5),
+      expected: { method: 'setPlaybackRate', args: [1.5] },
+    },
+    {
+      name: 'setActiveTrackIds',
+      call: (c) => c.setActiveTrackIds([1, 2]),
+      expected: { method: 'setActiveTrackIds', args: [[1, 2]] },
+    },
+    {
+      name: 'setTextTrackStyle',
+      call: (c) => c.setTextTrackStyle(textTrackStyle),
+      expected: { method: 'setTextTrackStyle', args: [textTrackStyle] },
+    },
+    {
+      name: 'setStreamVolume',
+      call: (c) => c.setStreamVolume(0.4),
+      expected: { method: 'setStreamVolume', args: [0.4] },
+    },
+    {
+      name: 'setStreamMuted',
+      call: (c) => c.setStreamMuted(true),
+      expected: { method: 'setStreamMuted', args: [true] },
+    },
+    {
+      name: 'queueLoad',
+      call: (c) => c.queueLoad(queueItems, 1, 'all'),
+      expected: { method: 'queueLoad', args: [queueItems, 1, 'all'] },
+    },
+    {
+      name: 'queueInsertItems',
+      call: (c) => c.queueInsertItems(queueItems, 7),
+      expected: { method: 'queueInsertItems', args: [queueItems, 7] },
+    },
+    {
+      name: 'queueReorderItems',
+      call: (c) => c.queueReorderItems([3, 4], 7),
+      expected: { method: 'queueReorderItems', args: [[3, 4], 7] },
+    },
+    {
+      name: 'queueRemoveItems',
+      call: (c) => c.queueRemoveItems([3, 4]),
+      expected: { method: 'queueRemoveItems', args: [[3, 4]] },
+    },
+    {
+      name: 'queueNext',
+      call: (c) => c.queueNext(),
+      expected: { method: 'queueNext', args: [] },
+    },
+    {
+      name: 'queuePrev',
+      call: (c) => c.queuePrev(),
+      expected: { method: 'queuePrev', args: [] },
+    },
+    {
+      name: 'queueJumpToItem',
+      call: (c) => c.queueJumpToItem(9),
+      expected: { method: 'queueJumpToItem', args: [9] },
+    },
+    {
+      name: 'queueSetRepeatMode',
+      call: (c) => c.queueSetRepeatMode('single'),
+      expected: { method: 'queueSetRepeatMode', args: ['single'] },
+    },
+    {
+      name: 'requestStatus',
+      call: (c) => c.requestStatus(),
+      expected: { method: 'requestMediaStatus', args: [] },
+    },
+  ]
+
+  it('covers every transport mutation (drift guard)', () => {
+    // If T4a grows the surface, this list must grow too.
+    expect(cases).toHaveLength(19)
+  })
+
+  it.each(cases)(
+    'routes $name through the transport',
+    async ({ call, expected }) => {
+      const { client, transport } = await withSession()
+      await call(client)
+      expect(transport.mediaCalls).toEqual([expected])
+    }
+  )
+})
+
+describe('RemoteMediaClient — ergonomic defaults', () => {
+  it('setActiveTrackIds defaults to an empty array (clear)', async () => {
+    const { client, transport } = await withSession()
+    await client.setActiveTrackIds()
+    expect(transport.mediaCalls).toEqual([
+      { method: 'setActiveTrackIds', args: [[]] },
+    ])
+  })
+
+  it('queueInsertItems / queueReorderItems default beforeItemId to 0 (append)', async () => {
+    const { client, transport } = await withSession()
+    await client.queueInsertItems(queueItems)
+    await client.queueReorderItems([1])
+    expect(transport.mediaCalls).toEqual([
+      { method: 'queueInsertItems', args: [queueItems, 0] },
+      { method: 'queueReorderItems', args: [[1], 0] },
+    ])
+  })
+
+  it('queueLoad defaults startIndex to 0 and repeatMode to off', async () => {
+    const { client, transport } = await withSession()
+    await client.queueLoad(queueItems)
+    expect(transport.mediaCalls).toEqual([
+      { method: 'queueLoad', args: [queueItems, 0, 'off'] },
+    ])
+  })
+})
+
+describe('RemoteMediaClient — rejection propagation', () => {
+  it('rejects the CastError the transport rejects with', async () => {
+    const { client, transport } = await withSession()
+    transport.mediaBehavior.seek = async () => {
+      throw { code: 'network', message: 'unreachable' } as CastError
+    }
+    await expect(client.seek(seekOptions)).rejects.toMatchObject({
+      code: 'network',
+    })
+  })
+})
+
+describe('RemoteMediaClient — generation guard (Invariant 3, media flavour)', () => {
+  it('a stale client rejects mutations with noSession before crossing the bridge', async () => {
+    const { client, transport } = await withSession()
+    transport.emitLifecycle({ type: 'ended' })
+
+    await expect(client.play()).rejects.toMatchObject({ code: 'noSession' })
+    // Nothing reached the transport.
+    expect(transport.mediaCalls).toEqual([])
+  })
+
+  it('a stale client reads null (never another session’s status)', async () => {
+    const { client, store, transport } = await withSession()
+    transport.emitMediaStatus(mediaStatus(5))
+    expect(client.getMediaStatus()).not.toBeNull()
+
+    transport.emitLifecycle({ type: 'ended' })
+    expect(client.getMediaStatus()).toBeNull()
+    expect(client.getStreamPosition()).toBeNull()
+
+    // Even if a brand-new session reports a status, the stale handle stays null.
+    transport.emitLifecycle({ type: 'started', session: session('s2') })
+    transport.emitMediaStatus(mediaStatus(99))
+    expect(client.getMediaStatus()).toBeNull()
+    // ...while the store itself does hold the new session's status — proving the
+    // stale handle filters out a status that is genuinely present.
+    expect(
+      store.getSliceState<MediaState>('media').currentStatus?.streamPosition
+    ).toBe(99)
+  })
+
+  it('isActive flips false once the session ends', async () => {
+    const { client, transport } = await withSession()
+    expect(client.isActive).toBe(true)
+    transport.emitLifecycle({ type: 'ended' })
+    expect(client.isActive).toBe(false)
+  })
+})
+
+describe('RemoteMediaClient.current — per-generation memoization', () => {
+  it('returns null when there is no session', async () => {
+    const { store, transport } = await setup()
+    expect(RemoteMediaClient.current(store, transport)).toBeNull()
+  })
+
+  it('returns the same memoized client within a generation', async () => {
+    const { store, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const a = RemoteMediaClient.current(store, transport)
+    const b = RemoteMediaClient.current(store, transport)
+    expect(a).not.toBeNull()
+    expect(a).toBe(b)
+  })
+
+  it('returns a fresh client after the session changes', async () => {
+    const { store, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const first = RemoteMediaClient.current(store, transport)
+    transport.emitLifecycle({ type: 'ended' })
+    expect(RemoteMediaClient.current(store, transport)).toBeNull()
+    transport.emitLifecycle({ type: 'started', session: session('s2') })
+    const second = RemoteMediaClient.current(store, transport)
+    expect(second).not.toBe(first)
+    expect(second).not.toBeNull()
+  })
+})

--- a/src/api/__tests__/mediaHooks.test.ts
+++ b/src/api/__tests__/mediaHooks.test.ts
@@ -1,0 +1,110 @@
+import * as React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import type { Device, SessionInfo } from '../../transport/types'
+import type { MediaStatus } from '../../types/MediaStatus'
+import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import { castStore, castTransport } from '../../state/castStore.singleton'
+import { RemoteMediaClient } from '../RemoteMediaClient'
+import { useRemoteMediaClient } from '../useRemoteMediaClient'
+import { useMediaStatus } from '../useMediaStatus'
+import { useStreamPosition } from '../useStreamPosition'
+
+// The singleton normally wires to the native transport (which can't load under
+// jest). Swap it for a fake-backed store so the hooks exercise the real
+// useSyncExternalStore wiring against scriptable transport events.
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+const transport = castTransport as unknown as FakeCastTransport
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+function mediaStatus(streamPosition = 0): MediaStatus {
+  return {
+    streamPosition,
+    playbackRate: 1,
+    volume: 1,
+    isMuted: false,
+    queueItems: [],
+  }
+}
+
+let latest: {
+  client: RemoteMediaClient | null
+  status: MediaStatus | null
+  position: number | null
+}
+
+function Probe(): null {
+  latest = {
+    client: useRemoteMediaClient(),
+    status: useMediaStatus(),
+    position: useStreamPosition(),
+  }
+  return null
+}
+
+describe('media hooks — useSyncExternalStore wiring', () => {
+  beforeAll(async () => {
+    await castStore.ready
+  })
+
+  it('track the session + media status through the store', async () => {
+    let root!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      root = TestRenderer.create(React.createElement(Probe))
+    })
+
+    // No session yet → everything null.
+    expect(latest.client).toBeNull()
+    expect(latest.status).toBeNull()
+    expect(latest.position).toBeNull()
+
+    // Session starts → a client appears.
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    expect(latest.client).not.toBeNull()
+    const client = latest.client
+
+    // A status streams in → status/position hooks update; the client is the
+    // same memoized reference (a status change is not a generation change).
+    act(() => {
+      transport.emitMediaStatus(mediaStatus(12))
+    })
+    expect(latest.status?.streamPosition).toBe(12)
+    expect(latest.position).toBe(12)
+    expect(latest.client).toBe(client)
+
+    // Session ends → client/status/position all clear.
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+    expect(latest.client).toBeNull()
+    expect(latest.status).toBeNull()
+    expect(latest.position).toBeNull()
+
+    act(() => {
+      root.unmount()
+    })
+  })
+})

--- a/src/api/useMediaStatus.ts
+++ b/src/api/useMediaStatus.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react'
+import { castStore } from '../state/castStore.singleton'
+import { MEDIA_SLICE_KEY, type MediaState } from '../state/media.slice'
+import type { MediaStatus } from '../types/MediaStatus'
+
+/**
+ * Hook to retrieve the current media status.
+ *
+ * The status is pushed only when the stream's status changes, so
+ * `mediaStatus.streamPosition` reflects the time of the last update, not the
+ * live position — use {@link useStreamPosition} for the latter. Returns `null`
+ * when there is no active media (no session, or none loaded yet).
+ *
+ * @returns the current media status, or `null`.
+ */
+export function useMediaStatus(): MediaStatus | null {
+  return useSyncExternalStore(
+    castStore.subscribe,
+    () => castStore.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
+  )
+}

--- a/src/api/useMediaStatus.ts
+++ b/src/api/useMediaStatus.ts
@@ -7,9 +7,10 @@ import type { MediaStatus } from '../types/MediaStatus'
  * Hook to retrieve the current media status.
  *
  * The status is pushed only when the stream's status changes, so
- * `mediaStatus.streamPosition` reflects the time of the last update, not the
- * live position — use {@link useStreamPosition} for the latter. Returns `null`
- * when there is no active media (no session, or none loaded yet).
+ * `mediaStatus.streamPosition` reflects the time of the last update, not a
+ * live, ticking position — {@link useStreamPosition} is a convenience selector
+ * for that same field. Returns `null` when there is no active media (no
+ * session, or none loaded yet).
  *
  * @returns the current media status, or `null`.
  */

--- a/src/api/useRemoteMediaClient.ts
+++ b/src/api/useRemoteMediaClient.ts
@@ -13,11 +13,15 @@ import { RemoteMediaClient } from './RemoteMediaClient'
  *
  * @example
  * ```ts
+ * import { useEffect } from 'react'
  * import { useRemoteMediaClient } from 'react-native-google-cast'
  *
  * function MyComponent() {
  *   const client = useRemoteMediaClient()
- *   client?.loadMedia({ mediaInfo: { contentUrl: '…' } })
+ *
+ *   useEffect(() => {
+ *     client?.loadMedia({ mediaInfo: { contentUrl: '…' } })
+ *   }, [client])
  * }
  * ```
  */

--- a/src/api/useRemoteMediaClient.ts
+++ b/src/api/useRemoteMediaClient.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from 'react'
+import { castStore, castTransport } from '../state/castStore.singleton'
+import { RemoteMediaClient } from './RemoteMediaClient'
+
+/**
+ * Hook that provides the current {@link RemoteMediaClient}.
+ *
+ * Re-renders when the session changes: the same client reference is returned for
+ * the lifetime of a session (memoized per generation), then a fresh one once a
+ * new session starts, and `null` while there is none.
+ *
+ * @returns the current client, or `null` if there is no session connected.
+ *
+ * @example
+ * ```ts
+ * import { useRemoteMediaClient } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const client = useRemoteMediaClient()
+ *   client?.loadMedia({ mediaInfo: { contentUrl: '…' } })
+ * }
+ * ```
+ */
+export function useRemoteMediaClient(): RemoteMediaClient | null {
+  return useSyncExternalStore(castStore.subscribe, () =>
+    RemoteMediaClient.current(castStore, castTransport)
+  )
+}

--- a/src/api/useStreamPosition.ts
+++ b/src/api/useStreamPosition.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from 'react'
+import { castStore } from '../state/castStore.singleton'
+import { MEDIA_SLICE_KEY, type MediaState } from '../state/media.slice'
+
+/**
+ * Hook to retrieve the current stream position, in seconds.
+ *
+ * Driven by the media-status stream, so it updates whenever the receiver reports
+ * a new status (not on a real-time client tick). Returns `null` when there is no
+ * active media.
+ *
+ * @returns the current position in seconds, or `null`.
+ */
+export function useStreamPosition(): number | null {
+  return useSyncExternalStore(castStore.subscribe, () => {
+    const status =
+      castStore.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
+    return status ? status.streamPosition : null
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ export { CastContext }
 export { DiscoveryManager } from './api/DiscoveryManager'
 export { SessionManager } from './api/SessionManager'
 export { CastSession } from './api/CastSession'
+export { RemoteMediaClient } from './api/RemoteMediaClient'
+export { useRemoteMediaClient } from './api/useRemoteMediaClient'
+export { useMediaStatus } from './api/useMediaStatus'
+export { useStreamPosition } from './api/useStreamPosition'
 export type { SessionEventHandler } from './api/SessionManager'
 export type { EventSubscription } from './api/subscribeSelector'
 
@@ -23,3 +27,14 @@ export type {
   SessionEventType,
 } from './transport/types'
 export type { CastError, CastErrorCode } from './types/CastError'
+
+// RemoteMediaClient public types (method signatures, returns, status inspection).
+export type { MediaStatus } from './types/MediaStatus'
+export type { MediaInfo } from './types/MediaInfo'
+export type { MediaLoadRequest } from './types/MediaLoadRequest'
+export type { MediaSeekOptions } from './types/MediaSeekOptions'
+export type { MediaQueueItem } from './types/MediaQueueItem'
+export type { MediaRepeatMode } from './types/MediaRepeatMode'
+export type { TextTrackStyle } from './types/TextTrackStyle'
+export type { MediaPlayerState } from './types/MediaPlayerState'
+export type { MediaPlayerIdleReason } from './types/MediaPlayerIdleReason'

--- a/src/state/__tests__/media.slice.test.ts
+++ b/src/state/__tests__/media.slice.test.ts
@@ -49,8 +49,9 @@ describe('media slice', () => {
     expect(mediaState(store).currentStatus).toBeNull()
   })
 
-  it('caches the latest pushed media status', async () => {
+  it('caches the latest pushed media status while a session is live', async () => {
     const { store, transport } = await makeStore()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
 
     transport.emitMediaStatus(status(0))
     expect(mediaState(store).currentStatus).toMatchObject({ streamPosition: 0 })
@@ -61,13 +62,47 @@ describe('media slice', () => {
     })
   })
 
+  it('drops a status push when no session is live', async () => {
+    const { store, transport } = await makeStore()
+
+    // No session has started: a stray push must not populate the slice.
+    transport.emitMediaStatus(status(0))
+    expect(mediaState(store).currentStatus).toBeNull()
+  })
+
+  it('accepts a push when a session was already live at cold start', async () => {
+    // Already-casting at init: the seed is live, so the first status sticks.
+    const transport = new FakeCastTransport({
+      initialSnapshot: { currentSession: session('s1') },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+
+    transport.emitMediaStatus(status(5))
+    expect(mediaState(store).currentStatus).toMatchObject({ streamPosition: 5 })
+  })
+
   it('notifies subscribers when media status changes', async () => {
     const { store, transport } = await makeStore()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
     const listener = jest.fn()
     store.subscribe(listener)
 
     transport.emitMediaStatus(status(10))
     expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears a prior status when a new session replaces the live one', async () => {
+    const { store, transport } = await makeStore()
+
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status(7))
+    expect(mediaState(store).currentStatus).not.toBeNull()
+
+    // A replacement session starts: the previous session's media must not bleed
+    // into the new generation, even before the receiver pushes a fresh status.
+    transport.emitLifecycle({ type: 'started', session: session('s2') })
+    expect(mediaState(store).currentStatus).toBeNull()
   })
 
   it('clears the status when the session ends (no use-after-free)', async () => {
@@ -81,9 +116,11 @@ describe('media slice', () => {
     expect(mediaState(store).currentStatus).toBeNull()
   })
 
-  it('clears the status when a session start fails', async () => {
+  it('never retains a status across a failed session start', async () => {
     const { store, transport } = await makeStore()
 
+    // No session ever became live, so a status arriving during the attempt is
+    // dropped, and startFailed leaves the slice empty.
     transport.emitMediaStatus(status(7))
     transport.emitLifecycle({
       type: 'startFailed',
@@ -92,7 +129,7 @@ describe('media slice', () => {
     expect(mediaState(store).currentStatus).toBeNull()
   })
 
-  it('clears the status when an Android session is suspended', async () => {
+  it('clears the status and drops later pushes when a session is suspended', async () => {
     const { store, transport } = await makeStore()
 
     transport.emitLifecycle({ type: 'started', session: session('s1') })
@@ -101,20 +138,27 @@ describe('media slice', () => {
 
     transport.emitLifecycle({ type: 'suspended', reason: 'appBackgrounded' })
     expect(mediaState(store).currentStatus).toBeNull()
+
+    // A status racing in after the suspend (Android background path) must not
+    // resurrect media now that the session is gone.
+    transport.emitMediaStatus(status(99))
+    expect(mediaState(store).currentStatus).toBeNull()
   })
 
-  it('clears the status when an Android session resume fails', async () => {
+  it('clears the status and drops later pushes when a resume fails', async () => {
     const { store, transport } = await makeStore()
 
     transport.emitLifecycle({ type: 'started', session: session('s1') })
     transport.emitMediaStatus(status(7))
     transport.emitLifecycle({ type: 'suspended' })
-    // A stale status pushed during the suspended window must not survive a
-    // failed resume either.
     transport.emitLifecycle({
       type: 'resumeFailed',
       error: { code: 'timeout', message: 'gone' },
     })
+    expect(mediaState(store).currentStatus).toBeNull()
+
+    // Still no live session after the failed resume: a late push stays dropped.
+    transport.emitMediaStatus(status(99))
     expect(mediaState(store).currentStatus).toBeNull()
   })
 

--- a/src/state/__tests__/media.slice.test.ts
+++ b/src/state/__tests__/media.slice.test.ts
@@ -92,6 +92,32 @@ describe('media slice', () => {
     expect(mediaState(store).currentStatus).toBeNull()
   })
 
+  it('clears the status when an Android session is suspended', async () => {
+    const { store, transport } = await makeStore()
+
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status(7))
+    expect(mediaState(store).currentStatus).not.toBeNull()
+
+    transport.emitLifecycle({ type: 'suspended', reason: 'appBackgrounded' })
+    expect(mediaState(store).currentStatus).toBeNull()
+  })
+
+  it('clears the status when an Android session resume fails', async () => {
+    const { store, transport } = await makeStore()
+
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status(7))
+    transport.emitLifecycle({ type: 'suspended' })
+    // A stale status pushed during the suspended window must not survive a
+    // failed resume either.
+    transport.emitLifecycle({
+      type: 'resumeFailed',
+      error: { code: 'timeout', message: 'gone' },
+    })
+    expect(mediaState(store).currentStatus).toBeNull()
+  })
+
   it('keeps a stable reference on unrelated events (Invariant 2)', async () => {
     const { store, transport } = await makeStore()
 
@@ -100,8 +126,11 @@ describe('media slice', () => {
     transport.emitDevices([device('a')])
     expect(mediaState(store)).toBe(before)
 
-    // A clear on an already-empty slice must not allocate either.
+    // A clear on an already-empty slice must not allocate either — for any
+    // teardown event, not just `ended`.
     transport.emitLifecycle({ type: 'ended' })
+    transport.emitLifecycle({ type: 'suspended' })
+    transport.emitLifecycle({ type: 'resumeFailed', error: { code: 'network' } })
     expect(mediaState(store)).toBe(before)
   })
 })

--- a/src/state/media.slice.ts
+++ b/src/state/media.slice.ts
@@ -1,4 +1,5 @@
 import type { MediaStatus } from '../types/MediaStatus'
+import { SESSION_TEARDOWN_TYPES } from './session.slice'
 import type { Slice } from './slice'
 
 export const MEDIA_SLICE_KEY = 'media'
@@ -19,8 +20,10 @@ const EMPTY: MediaState = { currentStatus: null }
 /**
  * Core P4 slice: the streamed media status. Seeded empty (a fresh init never
  * carries media status — it only exists once a session is loading media), set
- * by the native `mediaStatus` push, and cleared the instant the session ends so
- * a stale status can never outlive its session (Invariant 3, media flavour).
+ * by the native `mediaStatus` push, and cleared the instant the session is torn
+ * down (any {@link SESSION_TEARDOWN_TYPES} event — `ended`, `startFailed`, and
+ * the Android background paths `suspended` / `resumeFailed`) so a stale status
+ * can never outlive its session (Invariant 3, media flavour).
  */
 export const mediaSlice: Slice<MediaState> = {
   key: MEDIA_SLICE_KEY,
@@ -32,9 +35,11 @@ export const mediaSlice: Slice<MediaState> = {
       return { currentStatus: event.status }
     }
     if (event.kind === 'lifecycle') {
-      // A status without a live session is a use-after-free waiting to happen.
-      const { type } = event.event
-      if (type === 'ended' || type === 'startFailed') {
+      // A status without a live session is a use-after-free waiting to happen,
+      // so clear on every teardown the session slice recognises — not a
+      // hand-copied subset that can silently drift (the Android `suspended` /
+      // `resumeFailed` paths drop the session too).
+      if (SESSION_TEARDOWN_TYPES.has(event.event.type)) {
         return state.currentStatus === null ? state : EMPTY
       }
     }

--- a/src/state/media.slice.ts
+++ b/src/state/media.slice.ts
@@ -1,5 +1,8 @@
 import type { MediaStatus } from '../types/MediaStatus'
-import { SESSION_TEARDOWN_TYPES } from './session.slice'
+import {
+  SESSION_ESTABLISH_TYPES,
+  SESSION_TEARDOWN_TYPES,
+} from './session.slice'
 import type { Slice } from './slice'
 
 export const MEDIA_SLICE_KEY = 'media'
@@ -13,36 +16,65 @@ export const MEDIA_SLICE_KEY = 'media'
  */
 export interface MediaState {
   readonly currentStatus: MediaStatus | null
+  /**
+   * Whether a live session currently exists. Mirrors `session.current !== null`
+   * — derived from the *same* lifecycle events and session payload the session
+   * slice uses, so the two can never disagree. Gates status application: a
+   * `mediaStatus` that races a teardown (e.g. Android `suspended → mediaStatus`)
+   * is dropped rather than allowed to resurrect stale media (Invariant 3).
+   */
+  readonly live: boolean
 }
 
-const EMPTY: MediaState = { currentStatus: null }
+const EMPTY_IDLE: MediaState = { currentStatus: null, live: false }
+const EMPTY_LIVE: MediaState = { currentStatus: null, live: true }
 
 /**
- * Core P4 slice: the streamed media status. Seeded empty (a fresh init never
- * carries media status — it only exists once a session is loading media), set
- * by the native `mediaStatus` push, and cleared the instant the session is torn
- * down (any {@link SESSION_TEARDOWN_TYPES} event — `ended`, `startFailed`, and
- * the Android background paths `suspended` / `resumeFailed`) so a stale status
- * can never outlive its session (Invariant 3, media flavour).
+ * Core P4 slice: the streamed media status, bound to live-session presence.
+ *
+ * Status exists only while a session is live, so the slice:
+ * - **accepts** a `mediaStatus` push only when `live` — a push arriving after
+ *   teardown is dropped, never relying on a later lifecycle event to clean up;
+ * - **clears** on session *establishment* (`started` / `resumed`) so a prior
+ *   session's status can't bleed into the new generation; and
+ * - **clears** on session *teardown* (`ended` / `startFailed` / `suspended` /
+ *   `resumeFailed`) so a status can never outlive its session.
+ *
+ * `live` tracks `session.current` exactly — same events ({@link
+ * SESSION_ESTABLISH_TYPES} / {@link SESSION_TEARDOWN_TYPES}) and the same
+ * "establish carries a session" rule the session slice applies — so the two
+ * lists can't drift (Invariant 3, media flavour).
  */
 export const mediaSlice: Slice<MediaState> = {
   key: MEDIA_SLICE_KEY,
 
-  seed: () => EMPTY,
+  // A fresh init never carries media status (cold-start status is a separate
+  // deferred concern); only liveness is known up front.
+  seed: (snapshot) => (snapshot.currentSession ? EMPTY_LIVE : EMPTY_IDLE),
 
   reduce: (state, event) => {
     if (event.kind === 'mediaStatus') {
-      return { currentStatus: event.status }
+      // Drop a status that arrives while no session is live — it would
+      // otherwise resurrect media the session slice has already let go.
+      if (!state.live) return state
+      return { currentStatus: event.status, live: true }
     }
+
     if (event.kind === 'lifecycle') {
-      // A status without a live session is a use-after-free waiting to happen,
-      // so clear on every teardown the session slice recognises — not a
-      // hand-copied subset that can silently drift (the Android `suspended` /
-      // `resumeFailed` paths drop the session too).
-      if (SESSION_TEARDOWN_TYPES.has(event.event.type)) {
-        return state.currentStatus === null ? state : EMPTY
+      const { type } = event.event
+      if (SESSION_ESTABLISH_TYPES.has(type)) {
+        // A new (or replacement) session: the prior status must not leak into
+        // the new generation. `live` mirrors the session slice — an establish
+        // event without a session payload yields no live session.
+        const live = event.event.session != null
+        const next = live ? EMPTY_LIVE : EMPTY_IDLE
+        return state.currentStatus === null && state.live === live ? state : next
+      }
+      if (SESSION_TEARDOWN_TYPES.has(type)) {
+        return state.currentStatus === null && !state.live ? state : EMPTY_IDLE
       }
     }
+
     return state
   },
 }

--- a/src/state/session.slice.ts
+++ b/src/state/session.slice.ts
@@ -30,8 +30,13 @@ export interface SessionState {
 
 /** Lifecycle events that bring a live, operable session into existence. */
 const ESTABLISHES = new Set(['started', 'resumed'])
-/** Lifecycle events that remove the live session. */
-const TEARS_DOWN = new Set([
+/**
+ * Lifecycle events that remove the live session. Exported so dependent slices
+ * (e.g. the media slice, which must drop its cached status the instant the
+ * session is gone) share this one list instead of keeping their own copy — the
+ * two drifting apart is exactly the bug this prevents.
+ */
+export const SESSION_TEARDOWN_TYPES = new Set([
   'ended',
   'startFailed',
   'resumeFailed',
@@ -75,7 +80,7 @@ export const sessionSlice: Slice<SessionState> = {
       return { current: session, generation: nextGeneration }
     }
 
-    if (TEARS_DOWN.has(type)) {
+    if (SESSION_TEARDOWN_TYPES.has(type)) {
       // Only a real transition if a session was live; otherwise nothing to
       // invalidate (avoids spurious generation bumps / snapshot churn).
       if (state.current === null) return state

--- a/src/state/session.slice.ts
+++ b/src/state/session.slice.ts
@@ -28,8 +28,13 @@ export interface SessionState {
   readonly generation: number
 }
 
-/** Lifecycle events that bring a live, operable session into existence. */
-const ESTABLISHES = new Set(['started', 'resumed'])
+/**
+ * Lifecycle events that bring a live, operable session into existence. Exported
+ * (alongside {@link SESSION_TEARDOWN_TYPES}) so dependent slices track session
+ * liveness off the same lists this slice uses, rather than keeping their own
+ * copies that can silently drift.
+ */
+export const SESSION_ESTABLISH_TYPES = new Set(['started', 'resumed'])
 /**
  * Lifecycle events that remove the live session. Exported so dependent slices
  * (e.g. the media slice, which must drop its cached status the instant the
@@ -70,7 +75,7 @@ export const sessionSlice: Slice<SessionState> = {
     if (event.kind !== 'lifecycle') return state
     const { type } = event.event
 
-    if (ESTABLISHES.has(type)) {
+    if (SESSION_ESTABLISH_TYPES.has(type)) {
       // A new live session (possibly replacing an existing one) — always a new
       // generation, so any façade from a prior session is stale.
       const nextGeneration = state.generation + 1

--- a/src/state/slice.ts
+++ b/src/state/slice.ts
@@ -11,8 +11,9 @@ import type { MediaStatus } from '../types/MediaStatus'
  * `mediaStatus` (P4) is the streamed `GCKMediaStatus` / `MediaStatus` of the
  * active session's RemoteMediaClient, pushed through the `onMediaStatus`
  * callback. There is no media status when no session is live, so the media
- * slice clears itself on every session-teardown lifecycle transition (the same
- * set the session slice uses to drop the live session).
+ * slice tracks session liveness (off the same lifecycle events the session
+ * slice uses): it accepts a push only while a session is live, and clears on
+ * both session establishment and teardown.
  */
 export type StoreEvent =
   | { readonly kind: 'state'; readonly castState: CastState }

--- a/src/state/slice.ts
+++ b/src/state/slice.ts
@@ -11,7 +11,8 @@ import type { MediaStatus } from '../types/MediaStatus'
  * `mediaStatus` (P4) is the streamed `GCKMediaStatus` / `MediaStatus` of the
  * active session's RemoteMediaClient, pushed through the `onMediaStatus`
  * callback. There is no media status when no session is live, so the media
- * slice clears itself on the `ended` / `startFailed` lifecycle transitions.
+ * slice clears itself on every session-teardown lifecycle transition (the same
+ * set the session slice uses to drop the live session).
  */
 export type StoreEvent =
   | { readonly kind: 'state'; readonly castState: CastState }


### PR DESCRIPTION
## Phase 4 — T4b: RemoteMediaClient TS façade + hooks (`v5-aug.2`)

Thin TS façade over the singleton transport, mirroring the `CastSession` generation-guard pattern: a handle retained across a disconnect is **stale** — mutations reject `noSession` before crossing the bridge, reads return `null` rather than leak a later session's status (Invariant 3, media flavour).

- `RemoteMediaClient`: all 19 transport mutations + 2 sync reads (`getMediaStatus`/`getStreamPosition`); per-store `WeakMap` memo keyed by generation.
- Hooks: `useRemoteMediaClient` / `useMediaStatus` / `useStreamPosition` via `useSyncExternalStore`.
- Reads served synchronously from the central store's media slice; mutations route through the T4a transport surface.
- Public API + media types exported from `src/index.ts`.

**Tests:** 34 new (façade routing/guard/factory via `FakeCastTransport` + hook render wiring). Full suite **92 green**, `yarn typescript` clean. Transport untouched.

**v4-parity reconcile notes:** `customData` survives only on `loadMedia`; listeners → hooks; `requestStatus` → `requestMediaStatus`; v4 convenience methods dropped. Tracked on `v5-aug.2`.

Stacked on the T4a foundation (already on `v5`). Disjoint from the iOS/Android PRs — independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a remote media client API for playback control, seeking, track/volume management, queue actions, and status refresh.
  * Introduced React hooks for the active remote media client, current media status, and stream position.
  * Expanded public exports with additional remote-media types.
* **Bug Fixes**
  * Improved stale-session behavior: reads return `null`, and outdated actions are rejected.
  * Prevented media status from reappearing across session changes, including additional lifecycle teardown paths.
* **Tests**
  * Added/updated unit and hook tests covering client memoization, lifecycle edge cases, defaults, and store update wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->