### PR TITLE
feat(v5): Phase 4 T4c — iOS RemoteMediaClient native impl

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -9,15 +9,23 @@ import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.CastState as GckCastState
 import com.google.android.gms.cast.framework.CastStateListener
 import com.google.android.gms.cast.framework.SessionManagerListener
+import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.PendingResult
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.googlecast.converters.CastRejection
+import com.margelo.nitro.googlecast.converters.castErrorCodeFromGckStatusCode
 import com.margelo.nitro.googlecast.converters.castErrorFromStatusCode
 import com.margelo.nitro.googlecast.converters.castRejectionJson
 import com.margelo.nitro.googlecast.converters.fromGckConnectionResult
 import com.margelo.nitro.googlecast.converters.toDevice
+import com.margelo.nitro.googlecast.converters.toGckMediaLoadRequestData
+import com.margelo.nitro.googlecast.converters.toGckMediaQueueItem
+import com.margelo.nitro.googlecast.converters.toGckMediaSeekOptions
+import com.margelo.nitro.googlecast.converters.toGckTextTrackStyle
+import com.margelo.nitro.googlecast.converters.toMediaStatus
 
 /**
  * Nitro implementation of the singleton Cast transport (Android), backed by the
@@ -44,11 +52,22 @@ class HybridCastTransport : HybridCastTransportSpec() {
   private var onState: ((CastState) -> Unit)? = null
   private var onDevices: ((Array<Device>) -> Unit)? = null
   private var onLifecycle: ((SessionLifecycleEvent) -> Unit)? = null
+  private var onMediaStatus: ((MediaStatus) -> Unit)? = null
 
   private var castStateListener: CastStateListener? = null
   private var sessionListener: SessionManagerListener<CastSession>? = null
   private var routerCallback: MediaRouter.Callback? = null
   private var listenersAttached = false
+
+  // The `RemoteMediaClient.Callback` currently registered, plus the exact client it is
+  // registered on (so it is removed from the right instance across session changes). Both
+  // are touched only on the main thread.
+  private var mediaCallback: RemoteMediaClient.Callback? = null
+  private var observedClient: RemoteMediaClient? = null
+
+  // In-flight media `PendingResult`s, so teardown can cancel them (and drop our settlement
+  // closures). Main-thread only — no extra synchronization needed.
+  private val pendingResults = mutableSetOf<PendingResult<RemoteMediaClient.MediaChannelResult>>()
 
   @Volatile private var cachedCastState: CastState = CastState.NOTCONNECTED
   @Volatile private var cachedDiscovering = false
@@ -72,11 +91,13 @@ class HybridCastTransport : HybridCastTransportSpec() {
   override fun initAndSubscribe(
     onState: (castState: CastState) -> Unit,
     onDevices: (devices: Array<Device>) -> Unit,
-    onLifecycle: (event: SessionLifecycleEvent) -> Unit
+    onLifecycle: (event: SessionLifecycleEvent) -> Unit,
+    onMediaStatus: (status: MediaStatus) -> Unit
   ): Promise<InitialSnapshot> {
     this.onState = onState
     this.onDevices = onDevices
     this.onLifecycle = onLifecycle
+    this.onMediaStatus = onMediaStatus
 
     val promise = Promise<InitialSnapshot>()
     runOnMain {
@@ -95,9 +116,14 @@ class HybridCastTransport : HybridCastTransportSpec() {
       }
       attachObservers(castContext)
       cachedCastState = mapState(castContext.castState)
-      val current = sessionInfo(castContext.sessionManager.currentCastSession)
+      val currentSession = castContext.sessionManager.currentCastSession
+      // GCK auto-resumes a session early in the process lifecycle — often *before* the JS
+      // bundle reaches `initAndSubscribe` — so `onSessionResumed` may have already fired with
+      // no media listener attached. Attach to the live client now; the `observedClient` guard
+      // keeps this idempotent against a later session callback.
+      attachMediaCallback(currentSession?.remoteMediaClient)
       promise.resolve(
-        InitialSnapshot(cachedCastState, playServicesState(), readDevices(), current)
+        InitialSnapshot(cachedCastState, playServicesState(), readDevices(), sessionInfo(currentSession))
       )
     }
     return promise
@@ -155,9 +181,14 @@ class HybridCastTransport : HybridCastTransportSpec() {
   override fun dispose() {
     runOnMain {
       detachObservers()
+      detachMediaCallback()
+      // Cancel any in-flight media requests; JS is going away so the promises need not settle.
+      pendingResults.forEach { it.cancel() }
+      pendingResults.clear()
       onState = null
       onDevices = null
       onLifecycle = null
+      onMediaStatus = null
     }
     super.dispose()
   }
@@ -209,6 +240,170 @@ class HybridCastTransport : HybridCastTransportSpec() {
     return promise
   }
 
+  // MARK: - media transport (route to the active session's RemoteMediaClient)
+  //
+  // Every call re-resolves the current `RemoteMediaClient` on the main thread (Invariant 1 —
+  // no cached handle), rejecting with `noSession` when none is active. The returned GCK
+  // `PendingResult<MediaChannelResult>` settles the promise exactly once via `mediaCall`.
+
+  override fun loadMedia(request: MediaLoadRequest): Promise<Unit> =
+    mediaCall { it.load(request.toGckMediaLoadRequestData()) }
+
+  override fun play(): Promise<Unit> = mediaCall { it.play() }
+
+  override fun pause(): Promise<Unit> = mediaCall { it.pause() }
+
+  override fun stop(): Promise<Unit> = mediaCall { it.stop() }
+
+  override fun seek(options: MediaSeekOptions): Promise<Unit> =
+    mediaCall { it.seek(options.toGckMediaSeekOptions()) }
+
+  override fun setPlaybackRate(playbackRate: Double): Promise<Unit> =
+    mediaCall { it.setPlaybackRate(playbackRate) }
+
+  override fun setActiveTrackIds(trackIds: DoubleArray): Promise<Unit> =
+    mediaCall { it.setActiveMediaTracks(LongArray(trackIds.size) { i -> trackIds[i].toLong() }) }
+
+  override fun setTextTrackStyle(textTrackStyle: TextTrackStyle): Promise<Unit> =
+    mediaCall { it.setTextTrackStyle(textTrackStyle.toGckTextTrackStyle()) }
+
+  override fun setStreamVolume(volume: Double): Promise<Unit> =
+    mediaCall { it.setStreamVolume(volume) }
+
+  override fun setStreamMuted(muted: Boolean): Promise<Unit> =
+    mediaCall { it.setStreamMute(muted) }
+
+  override fun queueLoad(
+    items: Array<MediaQueueItem>,
+    startIndex: Double,
+    repeatMode: MediaRepeatMode
+  ): Promise<Unit> =
+    mediaCall {
+      it.queueLoad(
+        Array(items.size) { i -> items[i].toGckMediaQueueItem() },
+        startIndex.toInt(),
+        gckRepeatMode(repeatMode),
+        null
+      )
+    }
+
+  override fun queueInsertItems(items: Array<MediaQueueItem>, beforeItemId: Double): Promise<Unit> =
+    mediaCall {
+      it.queueInsertItems(
+        Array(items.size) { i -> items[i].toGckMediaQueueItem() },
+        beforeItemId.toInt(),
+        null
+      )
+    }
+
+  override fun queueReorderItems(itemIds: DoubleArray, beforeItemId: Double): Promise<Unit> =
+    mediaCall {
+      it.queueReorderItems(
+        IntArray(itemIds.size) { i -> itemIds[i].toInt() },
+        beforeItemId.toInt(),
+        null
+      )
+    }
+
+  override fun queueRemoveItems(itemIds: DoubleArray): Promise<Unit> =
+    mediaCall { it.queueRemoveItems(IntArray(itemIds.size) { i -> itemIds[i].toInt() }, null) }
+
+  override fun queueNext(): Promise<Unit> = mediaCall { it.queueNext(null) }
+
+  override fun queuePrev(): Promise<Unit> = mediaCall { it.queuePrev(null) }
+
+  override fun queueJumpToItem(itemId: Double): Promise<Unit> =
+    mediaCall { it.queueJumpToItem(itemId.toInt(), null) }
+
+  override fun queueSetRepeatMode(repeatMode: MediaRepeatMode): Promise<Unit> =
+    mediaCall { it.queueSetRepeatMode(gckRepeatMode(repeatMode), null) }
+
+  override fun requestMediaStatus(): Promise<Unit> = mediaCall { it.requestStatus() }
+
+  /**
+   * Re-resolves the active `RemoteMediaClient` on the main thread, runs [op] to start a GCK
+   * media request, and settles the returned promise exactly once from the request's single
+   * result callback (status OK → resolve; otherwise reject with a typed `CastError` JSON).
+   * Rejects with `noSession` when no session is active, and `failed` if [op] throws
+   * synchronously (e.g. an illegal queue argument).
+   */
+  private fun mediaCall(
+    op: (RemoteMediaClient) -> PendingResult<RemoteMediaClient.MediaChannelResult>
+  ): Promise<Unit> {
+    val promise = Promise<Unit>()
+    runOnMain {
+      val client = remoteMediaClientOrNull()
+      if (client == null) {
+        promise.reject(
+          CastRejection(castRejectionJson("noSession", "No active Cast session.", null))
+        )
+        return@runOnMain
+      }
+      val pending =
+        try {
+          op(client)
+        } catch (e: Exception) {
+          promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+          return@runOnMain
+        }
+      pendingResults.add(pending)
+      pending.setResultCallback { result ->
+        pendingResults.remove(pending)
+        val status = result.status
+        if (status.isSuccess) {
+          promise.resolve(Unit)
+        } else {
+          promise.reject(
+            CastRejection(
+              castRejectionJson(
+                castErrorCodeFromGckStatusCode(status.statusCode),
+                status.statusMessage,
+                status.statusCode
+              )
+            )
+          )
+        }
+      }
+    }
+    return promise
+  }
+
+  private fun remoteMediaClientOrNull(): RemoteMediaClient? =
+    sharedCastContextOrNull()?.sessionManager?.currentCastSession?.remoteMediaClient
+
+  /** Register the media-status listener on [client], replacing any previous registration. */
+  private fun attachMediaCallback(client: RemoteMediaClient?) {
+    if (client == null || observedClient === client) return
+    detachMediaCallback()
+    val callback =
+      object : RemoteMediaClient.Callback() {
+        override fun onStatusUpdated() {
+          client.mediaStatus?.let { status -> onMediaStatus?.invoke(status.toMediaStatus()) }
+        }
+      }
+    client.registerCallback(callback)
+    mediaCallback = callback
+    observedClient = client
+    // Surface the current status immediately so the store reflects an already-playing session.
+    client.mediaStatus?.let { status -> onMediaStatus?.invoke(status.toMediaStatus()) }
+  }
+
+  private fun detachMediaCallback() {
+    val callback = mediaCallback ?: return
+    observedClient?.unregisterCallback(callback)
+    mediaCallback = null
+    observedClient = null
+  }
+
+  private fun gckRepeatMode(mode: MediaRepeatMode): Int =
+    when (mode) {
+      MediaRepeatMode.OFF -> com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_OFF
+      MediaRepeatMode.ALL -> com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_ALL
+      MediaRepeatMode.SINGLE -> com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_SINGLE
+      MediaRepeatMode.ALLANDSHUFFLE ->
+        com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE
+    }
+
   // MARK: - discovery controls (no-op on Android; MediaRouter drives discovery)
 
   override fun startDiscovery() {
@@ -229,25 +424,33 @@ class HybridCastTransport : HybridCastTransportSpec() {
     object : SessionManagerListener<CastSession> {
       override fun onSessionStarting(session: CastSession) =
         emit(SessionEventType.STARTING, deviceId = session.castDevice?.deviceId)
-      override fun onSessionStarted(session: CastSession, sessionId: String) =
+      override fun onSessionStarted(session: CastSession, sessionId: String) {
+        attachMediaCallback(session.remoteMediaClient)
         emit(SessionEventType.STARTED, session = sessionInfo(session, sessionId))
+      }
       override fun onSessionStartFailed(session: CastSession, error: Int) =
         emit(SessionEventType.STARTFAILED, error = castErrorFromStatusCode(error, null))
       override fun onSessionEnding(session: CastSession) =
         emit(SessionEventType.ENDING, session = sessionInfo(session))
-      override fun onSessionEnded(session: CastSession, error: Int) =
+      override fun onSessionEnded(session: CastSession, error: Int) {
+        detachMediaCallback()
         emit(
           SessionEventType.ENDED,
           error = if (error != 0) castErrorFromStatusCode(error, null) else null
         )
+      }
       override fun onSessionResuming(session: CastSession, sessionId: String) =
         emit(SessionEventType.RESUMING, sessionId = sessionId)
-      override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) =
+      override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+        attachMediaCallback(session.remoteMediaClient)
         emit(SessionEventType.RESUMED, session = sessionInfo(session))
+      }
       override fun onSessionResumeFailed(session: CastSession, error: Int) =
         emit(SessionEventType.RESUMEFAILED, error = castErrorFromStatusCode(error, null))
-      override fun onSessionSuspended(session: CastSession, reason: Int) =
+      override fun onSessionSuspended(session: CastSession, reason: Int) {
+        detachMediaCallback()
         emit(SessionEventType.SUSPENDED, reason = suspendReason(reason))
+      }
     }
 
   // MARK: - helpers

--- a/ios/NitroGoogleCast/CastRemoteMediaClientListener.swift
+++ b/ios/NitroGoogleCast/CastRemoteMediaClientListener.swift
@@ -1,0 +1,25 @@
+import Foundation
+import GoogleCast
+import NitroModules
+
+/// Forwards `GCKRemoteMediaClient` media-status updates to a closure as the
+/// generated `MediaStatus` struct.
+///
+/// GCK reports `nil` when no media is loaded; the generated `onMediaStatus`
+/// callback only carries a non-optional `MediaStatus`, so the `nil` case is
+/// dropped here and the TS façade derives "no media" from session state instead.
+/// `GCKRemoteMediaClient` retains its listeners weakly, so the transport owns the
+/// strong reference and attaches/detaches it across session lifecycle.
+final class CastRemoteMediaClientListener: NSObject, GCKRemoteMediaClientListener {
+  private let onUpdate: (MediaStatus) -> Void
+
+  init(onUpdate: @escaping (MediaStatus) -> Void) {
+    self.onUpdate = onUpdate
+    super.init()
+  }
+
+  func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
+    guard let mediaStatus else { return }
+    onUpdate(mediaStatus.toMediaStatus())
+  }
+}

--- a/ios/NitroGoogleCast/CastRequestDelegate.swift
+++ b/ios/NitroGoogleCast/CastRequestDelegate.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GoogleCast
+import NitroModules
+
+/// Bridges a single in-flight `GCKRequest` to one `Promise<Void>`, settling it
+/// **exactly once** (T6 async-request ownership).
+///
+/// Ownership model:
+/// - GCK retains its `GCKRequest`'s `delegate` only weakly, so this object
+///   `selfRetain`s itself while the request is in flight; the retain (and the
+///   transport's registry slot) are released the instant the promise settles.
+/// - The first of {success, failure, abort, external cancel} wins; every later
+///   callback is a no-op thanks to the `settled` guard.
+/// - `cancel` lets the transport reject still-pending requests on session
+///   teardown/disconnect. After it releases `selfRetain`, GCK's weak ref drops to
+///   nil and no further callback can reach a freed delegate.
+///
+/// All access is main-thread (every `GCKRequest` here is created on the main
+/// queue and GCK delivers these callbacks on the main queue), so the mutable
+/// `settled`/`selfRetain`/`promise` state needs no locking.
+final class CastRequestDelegate: NSObject, GCKRequestDelegate {
+  private var promise: Promise<Void>?
+  private var onSettle: ((CastRequestDelegate) -> Void)?
+  private var selfRetain: CastRequestDelegate?
+  private var settled = false
+
+  init(promise: Promise<Void>, onSettle: @escaping (CastRequestDelegate) -> Void) {
+    self.promise = promise
+    self.onSettle = onSettle
+    super.init()
+  }
+
+  /// Retain self and become the request's (weakly-held) delegate. Main thread.
+  func track(_ request: GCKRequest) {
+    selfRetain = self
+    request.delegate = self
+  }
+
+  /// Reject a still-pending request from outside (teardown / disconnect). No-op
+  /// once settled. Main thread.
+  func cancel(code: String, message: String) {
+    settle { $0?.reject(withError: castRejection(code: code, message: message, nativeCode: nil)) }
+  }
+
+  private func settle(_ body: (Promise<Void>?) -> Void) {
+    guard !settled else { return }
+    settled = true
+    body(promise)
+    promise = nil
+    onSettle?(self)
+    onSettle = nil
+    selfRetain = nil
+  }
+
+  // MARK: - GCKRequestDelegate
+
+  func requestDidComplete(_ request: GCKRequest) {
+    settle { $0?.resolve(withResult: ()) }
+  }
+
+  func request(_ request: GCKRequest, didFailWithError error: GCKError) {
+    settle {
+      $0?.reject(
+        withError: castRejection(
+          code: error.toCastErrorCode(),
+          message: error.localizedDescription,
+          nativeCode: error.code))
+    }
+  }
+
+  func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
+    let code = abortReason == .cancelled ? "cancelled" : "interrupted"
+    settle {
+      $0?.reject(
+        withError: castRejection(code: code, message: "The request was aborted.", nativeCode: nil))
+    }
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -74,7 +74,13 @@ final class HybridCastTransport: HybridCastTransportSpec {
 
     let promise = Promise<InitialSnapshot>()
     DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
+      guard let self else {
+        // Disposed before this block ran — settle so the caller never hangs.
+        promise.reject(
+          withError: castRejection(
+            code: "interrupted", message: "The Cast transport was disposed.", nativeCode: nil))
+        return
+      }
       let context = GCKCastContext.sharedInstance()
       self.attachObservers(context)
       // If a session was already current before we subscribed, bind the media
@@ -240,22 +246,31 @@ final class HybridCastTransport: HybridCastTransportSpec {
   func queueLoad(
     items: [MediaQueueItem], startIndex: Double, repeatMode: MediaRepeatMode
   ) throws -> Promise<Void> {
+    guard let start = Self.queueIndex(startIndex) else {
+      return Self.rejectedIndex("startIndex", startIndex)
+    }
     let gckItems = items.map { $0.toGckMediaQueueItem() }
     let options = GCKMediaQueueLoadOptions()
-    options.startIndex = UInt(startIndex)
+    options.startIndex = start
     options.repeatMode = repeatMode.toGckRepeatMode()
     return withClient { $0.queueLoad(gckItems, with: options) }
   }
 
   func queueInsertItems(items: [MediaQueueItem], beforeItemId: Double) throws -> Promise<Void> {
+    guard let before = Self.queueIndex(beforeItemId) else {
+      return Self.rejectedIndex("beforeItemId", beforeItemId)
+    }
     let gckItems = items.map { $0.toGckMediaQueueItem() }
-    return withClient { $0.queueInsert(gckItems, beforeItemWithID: UInt(beforeItemId)) }
+    return withClient { $0.queueInsert(gckItems, beforeItemWithID: before) }
   }
 
   func queueReorderItems(itemIds: [Double], beforeItemId: Double) throws -> Promise<Void> {
+    guard let before = Self.queueIndex(beforeItemId) else {
+      return Self.rejectedIndex("beforeItemId", beforeItemId)
+    }
     let ids = itemIds.map { NSNumber(value: $0) }
     return withClient {
-      $0.queueReorderItems(withIDs: ids, insertBeforeItemWithID: UInt(beforeItemId))
+      $0.queueReorderItems(withIDs: ids, insertBeforeItemWithID: before)
     }
   }
 
@@ -269,7 +284,10 @@ final class HybridCastTransport: HybridCastTransportSpec {
   func queuePrev() throws -> Promise<Void> { withClient { $0.queuePreviousItem() } }
 
   func queueJumpToItem(itemId: Double) throws -> Promise<Void> {
-    withClient { $0.queueJumpToItem(withID: UInt(itemId)) }
+    guard let id = Self.queueIndex(itemId) else {
+      return Self.rejectedIndex("itemId", itemId)
+    }
+    return withClient { $0.queueJumpToItem(withID: id) }
   }
 
   func queueSetRepeatMode(repeatMode: MediaRepeatMode) throws -> Promise<Void> {
@@ -290,7 +308,13 @@ final class HybridCastTransport: HybridCastTransportSpec {
   ) -> Promise<Void> {
     let promise = Promise<Void>()
     DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
+      guard let self else {
+        // Disposed before this block ran — settle so the caller never hangs.
+        promise.reject(
+          withError: castRejection(
+            code: "interrupted", message: "The Cast transport was disposed.", nativeCode: nil))
+        return
+      }
       guard
         let client = GCKCastContext.sharedInstance().sessionManager.currentCastSession?
           .remoteMediaClient
@@ -312,6 +336,21 @@ final class HybridCastTransport: HybridCastTransportSpec {
     }
     pendingRequests.insert(delegate)
     delegate.track(request)
+  }
+
+  /// Safely convert a JS-supplied queue index/id (`Double`) to `UInt`. `UInt(Double)`
+  /// *traps* on negative / NaN / infinite / fractional / overflow values, so the bridge
+  /// would crash before the request could be rejected — use `exactly:` and surface a Cast
+  /// error instead. `0` is valid (GCK's `kGCKMediaQueueInvalidItemID` append sentinel).
+  private static func queueIndex(_ value: Double) -> UInt? { UInt(exactly: value) }
+
+  /// A `Promise<Void>` already rejected with `invalidParameter` for an out-of-range index.
+  private static func rejectedIndex(_ name: String, _ value: Double) -> Promise<Void> {
+    let promise = Promise<Void>()
+    promise.reject(
+      withError: castRejection(
+        code: "invalidParameter", message: "Invalid \(name): \(value)", nativeCode: nil))
+    return promise
   }
 
   /// Bind the media-status listener to the current session's media client. Idempotent

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -545,6 +545,11 @@ private final class CastSessionListener: NSObject, GCKSessionManagerListener {
     _ sessionManager: GCKSessionManager, didSuspend session: GCKSession,
     withReason reason: GCKConnectionSuspendReason
   ) {
+    // TS treats `suspended` as a teardown (see `session.slice`), so detach the
+    // media listener and flush pending requests here too — otherwise a late
+    // media-status callback or a never-arriving request could repopulate / hang
+    // state JS already considers gone. Re-attached on `didResumeSession`.
+    onSessionInactive()
     emit(.suspended, reason: HybridCastTransport.suspendReason(reason))
   }
 }

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -30,11 +30,22 @@ final class HybridCastTransport: HybridCastTransportSpec {
   private var onState: ((CastState) -> Void)?
   private var onDevices: (([Device]) -> Void)?
   private var onLifecycle: ((SessionLifecycleEvent) -> Void)?
+  private var onMediaStatus: ((MediaStatus) -> Void)?
 
   private var castStateObserver: NSObjectProtocol?
   private var discoveryListener: CastDiscoveryListener?
   private var sessionListener: CastSessionListener?
   private var listenersAttached = false
+
+  // Media transport state (all touched on the main thread only — see Invariant 1).
+  // `mediaStatusListener` is the single strong owner of the GCK media-status
+  // adapter (GCK holds it weakly); `attachedMediaClient` tracks which client it is
+  // currently bound to so re-resolution across sessions never double-attaches.
+  // `pendingRequests` retains every in-flight `CastRequestDelegate` until it
+  // settles, so disconnect/teardown can reject the stragglers (T6).
+  private var mediaStatusListener: CastRemoteMediaClientListener?
+  private weak var attachedMediaClient: GCKRemoteMediaClient?
+  private var pendingRequests: Set<CastRequestDelegate> = []
 
   private var cachedCastState: CastState = .notconnected
   private var cachedDiscovering = false
@@ -53,17 +64,22 @@ final class HybridCastTransport: HybridCastTransportSpec {
   func initAndSubscribe(
     onState: @escaping (_ castState: CastState) -> Void,
     onDevices: @escaping (_ devices: [Device]) -> Void,
-    onLifecycle: @escaping (_ event: SessionLifecycleEvent) -> Void
+    onLifecycle: @escaping (_ event: SessionLifecycleEvent) -> Void,
+    onMediaStatus: @escaping (_ status: MediaStatus) -> Void
   ) throws -> Promise<InitialSnapshot> {
     self.onState = onState
     self.onDevices = onDevices
     self.onLifecycle = onLifecycle
+    self.onMediaStatus = onMediaStatus
 
     let promise = Promise<InitialSnapshot>()
     DispatchQueue.main.async { [weak self] in
       guard let self else { return }
       let context = GCKCastContext.sharedInstance()
       self.attachObservers(context)
+      // If a session was already current before we subscribed, bind the media
+      // listener now so status updates flow without waiting for the next start.
+      self.attachMediaListener()
 
       self.cachedCastState = Self.mapState(context.castState)
       self.cachedPassiveScan = context.discoveryManager.passiveScan
@@ -98,9 +114,13 @@ final class HybridCastTransport: HybridCastTransportSpec {
     context.discoveryManager.add(discovery)
     discoveryListener = discovery
 
-    let session = CastSessionListener { [weak self] event in
-      self?.onLifecycle?(event)
-    }
+    let session = CastSessionListener(
+      onEvent: { [weak self] event in self?.onLifecycle?(event) },
+      onSessionActive: { [weak self] in self?.attachMediaListener() },
+      onSessionInactive: { [weak self] in
+        self?.detachMediaListener()
+        self?.flushPendingRequests(code: "interrupted", message: "The Cast session ended.")
+      })
     context.sessionManager.add(session)
     sessionListener = session
   }
@@ -126,10 +146,15 @@ final class HybridCastTransport: HybridCastTransportSpec {
   /// Override of `HybridObject.dispose()` — detach every GCK observer.
   func dispose() {
     DispatchQueue.main.async { [weak self] in
-      self?.detachObservers()
-      self?.onState = nil
-      self?.onDevices = nil
-      self?.onLifecycle = nil
+      guard let self else { return }
+      self.detachObservers()
+      self.detachMediaListener()
+      self.flushPendingRequests(code: "interrupted", message: "The Cast transport was disposed.")
+      self.mediaStatusListener = nil
+      self.onState = nil
+      self.onDevices = nil
+      self.onLifecycle = nil
+      self.onMediaStatus = nil
     }
   }
 
@@ -173,6 +198,158 @@ final class HybridCastTransport: HybridCastTransportSpec {
       }
     }
     return promise
+  }
+
+  // MARK: - media transport (route to GCKRemoteMediaClient — Invariant 1)
+
+  func loadMedia(request: MediaLoadRequest) throws -> Promise<Void> {
+    withClient { $0.loadMedia(with: request.toGckMediaLoadRequestData()) }
+  }
+
+  func play() throws -> Promise<Void> { withClient { $0.play() } }
+
+  func pause() throws -> Promise<Void> { withClient { $0.pause() } }
+
+  func stop() throws -> Promise<Void> { withClient { $0.stop() } }
+
+  func seek(options: MediaSeekOptions) throws -> Promise<Void> {
+    withClient { $0.seek(with: options.toGckMediaSeekOptions()) }
+  }
+
+  func setPlaybackRate(playbackRate: Double) throws -> Promise<Void> {
+    withClient { $0.setPlaybackRate(Float(playbackRate)) }
+  }
+
+  func setActiveTrackIds(trackIds: [Double]) throws -> Promise<Void> {
+    let ids = trackIds.map { NSNumber(value: $0) }
+    return withClient { $0.setActiveTrackIDs(ids) }
+  }
+
+  func setTextTrackStyle(textTrackStyle: TextTrackStyle) throws -> Promise<Void> {
+    withClient { $0.setTextTrackStyle(textTrackStyle.toGckTextTrackStyle()) }
+  }
+
+  func setStreamVolume(volume: Double) throws -> Promise<Void> {
+    withClient { $0.setStreamVolume(Float(volume)) }
+  }
+
+  func setStreamMuted(muted: Bool) throws -> Promise<Void> {
+    withClient { $0.setStreamMuted(muted) }
+  }
+
+  func queueLoad(
+    items: [MediaQueueItem], startIndex: Double, repeatMode: MediaRepeatMode
+  ) throws -> Promise<Void> {
+    let gckItems = items.map { $0.toGckMediaQueueItem() }
+    let options = GCKMediaQueueLoadOptions()
+    options.startIndex = UInt(startIndex)
+    options.repeatMode = repeatMode.toGckRepeatMode()
+    return withClient { $0.queueLoad(gckItems, with: options) }
+  }
+
+  func queueInsertItems(items: [MediaQueueItem], beforeItemId: Double) throws -> Promise<Void> {
+    let gckItems = items.map { $0.toGckMediaQueueItem() }
+    return withClient { $0.queueInsert(gckItems, beforeItemWithID: UInt(beforeItemId)) }
+  }
+
+  func queueReorderItems(itemIds: [Double], beforeItemId: Double) throws -> Promise<Void> {
+    let ids = itemIds.map { NSNumber(value: $0) }
+    return withClient {
+      $0.queueReorderItems(withIDs: ids, insertBeforeItemWithID: UInt(beforeItemId))
+    }
+  }
+
+  func queueRemoveItems(itemIds: [Double]) throws -> Promise<Void> {
+    let ids = itemIds.map { NSNumber(value: $0) }
+    return withClient { $0.queueRemoveItems(withIDs: ids) }
+  }
+
+  func queueNext() throws -> Promise<Void> { withClient { $0.queueNextItem() } }
+
+  func queuePrev() throws -> Promise<Void> { withClient { $0.queuePreviousItem() } }
+
+  func queueJumpToItem(itemId: Double) throws -> Promise<Void> {
+    withClient { $0.queueJumpToItem(withID: UInt(itemId)) }
+  }
+
+  func queueSetRepeatMode(repeatMode: MediaRepeatMode) throws -> Promise<Void> {
+    let mode = repeatMode.toGckRepeatMode()
+    return withClient { $0.queueSetRepeatMode(mode) }
+  }
+
+  func requestMediaStatus() throws -> Promise<Void> {
+    withClient { $0.requestStatus() }
+  }
+
+  /// Re-resolves the current session's `GCKRemoteMediaClient` on the main thread
+  /// per call (never caches a handle — Invariant 1), runs `work` to issue the GCK
+  /// request, and tracks it for exactly-once settlement. No session → reject
+  /// `noSession`; never crashes.
+  private func withClient(
+    _ work: @escaping (GCKRemoteMediaClient) -> GCKRequest
+  ) -> Promise<Void> {
+    let promise = Promise<Void>()
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      guard
+        let client = GCKCastContext.sharedInstance().sessionManager.currentCastSession?
+          .remoteMediaClient
+      else {
+        promise.reject(
+          withError: castRejection(
+            code: "noSession", message: "There is no active Cast session.", nativeCode: nil))
+        return
+      }
+      let request = work(client)
+      self.track(request, promise)
+    }
+    return promise
+  }
+
+  private func track(_ request: GCKRequest, _ promise: Promise<Void>) {
+    let delegate = CastRequestDelegate(promise: promise) { [weak self] settled in
+      self?.pendingRequests.remove(settled)
+    }
+    pendingRequests.insert(delegate)
+    delegate.track(request)
+  }
+
+  /// Bind the media-status listener to the current session's media client. Idempotent
+  /// for a given client; re-resolves the client per call. Main thread.
+  private func attachMediaListener() {
+    guard
+      let client = GCKCastContext.sharedInstance().sessionManager.currentCastSession?
+        .remoteMediaClient
+    else { return }
+    guard attachedMediaClient !== client else { return }
+
+    let listener =
+      mediaStatusListener
+      ?? CastRemoteMediaClientListener { [weak self] status in self?.onMediaStatus?(status) }
+    mediaStatusListener = listener
+
+    if let previous = attachedMediaClient { previous.remove(listener) }
+    client.add(listener)
+    attachedMediaClient = client
+
+    // Emit the current status immediately so subscribers don't wait for the next
+    // change to learn what is already playing.
+    if let status = client.mediaStatus?.toMediaStatus() { onMediaStatus?(status) }
+  }
+
+  private func detachMediaListener() {
+    if let client = attachedMediaClient, let listener = mediaStatusListener {
+      client.remove(listener)
+    }
+    attachedMediaClient = nil
+  }
+
+  /// Reject every still-pending media request. Used on session end / teardown so a
+  /// caller's promise never hangs after the client it targeted is gone (T6). Main thread.
+  private func flushPendingRequests(code: String, message: String) {
+    let pending = pendingRequests
+    pendingRequests.removeAll()
+    for delegate in pending { delegate.cancel(code: code, message: message) }
   }
 
   // MARK: - discovery controls (iOS)
@@ -267,8 +444,21 @@ private final class CastDiscoveryListener: NSObject, GCKDiscoveryManagerListener
 /// bridged Swift selectors are a Phase 3 spike verification item.
 private final class CastSessionListener: NSObject, GCKSessionManagerListener {
   private let onEvent: (SessionLifecycleEvent) -> Void
-  init(onEvent: @escaping (SessionLifecycleEvent) -> Void) {
+  /// Fired when a session becomes current (started/resumed) and when it leaves —
+  /// the transport uses these to (re)bind/tear down its media-status listener and
+  /// flush pending media requests. Kept on this single session listener so the
+  /// foundation's session registration stays the only one.
+  private let onSessionActive: () -> Void
+  private let onSessionInactive: () -> Void
+
+  init(
+    onEvent: @escaping (SessionLifecycleEvent) -> Void,
+    onSessionActive: @escaping () -> Void = {},
+    onSessionInactive: @escaping () -> Void = {}
+  ) {
     self.onEvent = onEvent
+    self.onSessionActive = onSessionActive
+    self.onSessionInactive = onSessionInactive
     super.init()
   }
 
@@ -286,6 +476,7 @@ private final class CastSessionListener: NSObject, GCKSessionManagerListener {
     emit(.starting, deviceId: session.device.deviceID)
   }
   func sessionManager(_ sessionManager: GCKSessionManager, didStart session: GCKSession) {
+    onSessionActive()
     emit(.started, session: HybridCastTransport.sessionInfo(session))
   }
   func sessionManager(
@@ -294,17 +485,21 @@ private final class CastSessionListener: NSObject, GCKSessionManagerListener {
     emit(.startfailed, error: toCastError(error))
   }
   func sessionManager(_ sessionManager: GCKSessionManager, willEnd session: GCKSession) {
+    onSessionInactive()
     emit(.ending, session: HybridCastTransport.sessionInfo(session))
   }
   func sessionManager(
     _ sessionManager: GCKSessionManager, didEnd session: GCKSession, withError error: Error?
   ) {
+    // Idempotent with `willEnd`; covers an abrupt `didEnd` that skips `willEnd`.
+    onSessionInactive()
     emit(.ended, error: toCastError(error))
   }
   func sessionManager(_ sessionManager: GCKSessionManager, willResumeSession session: GCKSession) {
     emit(.resuming, sessionId: session.sessionID)
   }
   func sessionManager(_ sessionManager: GCKSessionManager, didResumeSession session: GCKSession) {
+    onSessionActive()
     emit(.resumed, session: HybridCastTransport.sessionInfo(session))
   }
   func sessionManager(


### PR DESCRIPTION
## Phase 4 — T4c: iOS RemoteMediaClient native impl (`v5-aug.3`)

Implements the T4a transport media surface on iOS, routing to `GCKRemoteMediaClient`.

- All media/queue methods re-resolve the active session's `remoteMediaClient` on the **main thread** per call (never caches a handle) — a call with no session rejects `noSession`, never crashes.
- `GCKRequest` ownership: exactly-once settlement via a new `CastRequestDelegate` (success resolves; failure/replacement/abort rejects).
- `onMediaStatus` wired via a `GCKRemoteMediaClientListener`, pushing the converted `MediaStatus` (reuses the Phase 2 `GCKMediaStatus → MediaStatus` converter).

**Verification:** NitroGoogleCast lib target **BUILD SUCCEEDED** against GoogleCast 4.8.4 on `iphonesimulator` (0 errors). CI runs the pod-install / hermes deployment guard.

Files: `ios/` only. Stacked on the T4a foundation (already on `v5`); disjoint from the façade/Android PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live media status updates during casting, including immediate status when a session is already active.
  * Improved media listener lifecycle so updates continue seamlessly across session start/resume and stop/ending events.
* **Bug Fixes**
  * Improved reliability by ensuring media operations settle exactly once and propagate consistent success/failure results.
  * Enhanced teardown: pending media requests are cancelled/interrupted when sessions end, suspend, or disconnect.
  * Refined handling for cancelled vs interrupted/aborted cast operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->