### PR TITLE
feat(v5): Phase 4 T4d — Android RemoteMediaClient native impl

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -262,7 +262,9 @@ class HybridCastTransport : HybridCastTransportSpec() {
     mediaCall { it.setPlaybackRate(playbackRate) }
 
   override fun setActiveTrackIds(trackIds: DoubleArray): Promise<Unit> =
-    mediaCall { it.setActiveMediaTracks(LongArray(trackIds.size) { i -> trackIds[i].toLong() }) }
+    mediaCall {
+      it.setActiveMediaTracks(LongArray(trackIds.size) { i -> trackIds[i].toIdLong("trackId") })
+    }
 
   override fun setTextTrackStyle(textTrackStyle: TextTrackStyle): Promise<Unit> =
     mediaCall { it.setTextTrackStyle(textTrackStyle.toGckTextTrackStyle()) }
@@ -281,7 +283,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
     mediaCall {
       it.queueLoad(
         Array(items.size) { i -> items[i].toGckMediaQueueItem() },
-        startIndex.toInt(),
+        startIndex.toIdInt("startIndex"),
         gckRepeatMode(repeatMode),
         null
       )
@@ -291,7 +293,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
     mediaCall {
       it.queueInsertItems(
         Array(items.size) { i -> items[i].toGckMediaQueueItem() },
-        beforeItemId.toInt(),
+        beforeItemId.toIdInt("beforeItemId"),
         null
       )
     }
@@ -299,21 +301,23 @@ class HybridCastTransport : HybridCastTransportSpec() {
   override fun queueReorderItems(itemIds: DoubleArray, beforeItemId: Double): Promise<Unit> =
     mediaCall {
       it.queueReorderItems(
-        IntArray(itemIds.size) { i -> itemIds[i].toInt() },
-        beforeItemId.toInt(),
+        IntArray(itemIds.size) { i -> itemIds[i].toIdInt("itemId") },
+        beforeItemId.toIdInt("beforeItemId"),
         null
       )
     }
 
   override fun queueRemoveItems(itemIds: DoubleArray): Promise<Unit> =
-    mediaCall { it.queueRemoveItems(IntArray(itemIds.size) { i -> itemIds[i].toInt() }, null) }
+    mediaCall {
+      it.queueRemoveItems(IntArray(itemIds.size) { i -> itemIds[i].toIdInt("itemId") }, null)
+    }
 
   override fun queueNext(): Promise<Unit> = mediaCall { it.queueNext(null) }
 
   override fun queuePrev(): Promise<Unit> = mediaCall { it.queuePrev(null) }
 
   override fun queueJumpToItem(itemId: Double): Promise<Unit> =
-    mediaCall { it.queueJumpToItem(itemId.toInt(), null) }
+    mediaCall { it.queueJumpToItem(itemId.toIdInt("itemId"), null) }
 
   override fun queueSetRepeatMode(repeatMode: MediaRepeatMode): Promise<Unit> =
     mediaCall { it.queueSetRepeatMode(gckRepeatMode(repeatMode), null) }
@@ -377,14 +381,21 @@ class HybridCastTransport : HybridCastTransportSpec() {
     detachMediaCallback()
     val callback =
       object : RemoteMediaClient.Callback() {
-        override fun onStatusUpdated() {
-          client.mediaStatus?.let { status -> onMediaStatus?.invoke(status.toMediaStatus()) }
-        }
+        override fun onStatusUpdated() = emitMediaStatus(client)
+        // Queue-only mutations (queueInsertItems / queueReorderItems / queueRemoveItems and
+        // receiver-side queue edits) report via onQueueStatusUpdated, *not* onStatusUpdated —
+        // forward them through the same path so the cached status' queueItems never goes stale
+        // until an unrelated player-status update happens to arrive.
+        override fun onQueueStatusUpdated() = emitMediaStatus(client)
       }
     client.registerCallback(callback)
     mediaCallback = callback
     observedClient = client
     // Surface the current status immediately so the store reflects an already-playing session.
+    emitMediaStatus(client)
+  }
+
+  private fun emitMediaStatus(client: RemoteMediaClient) {
     client.mediaStatus?.let { status -> onMediaStatus?.invoke(status.toMediaStatus()) }
   }
 
@@ -393,6 +404,25 @@ class HybridCastTransport : HybridCastTransportSpec() {
     observedClient?.unregisterCallback(callback)
     mediaCallback = null
     observedClient = null
+  }
+
+  // Queue/track IDs and indices cross the bridge as `Double`. A bare `toInt()` / `toLong()`
+  // silently narrows NaN, ±Inf, fractional, and out-of-range values — quietly targeting the
+  // *wrong* item — so validate before converting. Thrown from inside a `mediaCall` op lambda,
+  // these surface to JS as a `failed` rejection (see `mediaCall`). Note: `0`/negatives are left
+  // to GCK, which uses `MediaQueueItem.INVALID_ITEM_ID == 0` as the "append at end" sentinel.
+  private fun Double.toIdInt(name: String): Int {
+    require(isFinite() && this % 1.0 == 0.0 && this >= Int.MIN_VALUE.toDouble() && this <= Int.MAX_VALUE.toDouble()) {
+      "$name must be a finite integer in Int range, got $this"
+    }
+    return toInt()
+  }
+
+  private fun Double.toIdLong(name: String): Long {
+    require(isFinite() && this % 1.0 == 0.0 && this >= Long.MIN_VALUE.toDouble() && this <= Long.MAX_VALUE.toDouble()) {
+      "$name must be a finite integer in Long range, got $this"
+    }
+    return toLong()
   }
 
   private fun gckRepeatMode(mode: MediaRepeatMode): Int =

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -9,15 +9,23 @@ import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.CastState as GckCastState
 import com.google.android.gms.cast.framework.CastStateListener
 import com.google.android.gms.cast.framework.SessionManagerListener
+import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.PendingResult
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.googlecast.converters.CastRejection
+import com.margelo.nitro.googlecast.converters.castErrorCodeFromGckStatusCode
 import com.margelo.nitro.googlecast.converters.castErrorFromStatusCode
 import com.margelo.nitro.googlecast.converters.castRejectionJson
 import com.margelo.nitro.googlecast.converters.fromGckConnectionResult
 import com.margelo.nitro.googlecast.converters.toDevice
+import com.margelo.nitro.googlecast.converters.toGckMediaLoadRequestData
+import com.margelo.nitro.googlecast.converters.toGckMediaQueueItem
+import com.margelo.nitro.googlecast.converters.toGckMediaSeekOptions
+import com.margelo.nitro.googlecast.converters.toGckTextTrackStyle
+import com.margelo.nitro.googlecast.converters.toMediaStatus
 
 /**
  * Nitro implementation of the singleton Cast transport (Android), backed by the
@@ -44,11 +52,22 @@ class HybridCastTransport : HybridCastTransportSpec() {
   private var onState: ((CastState) -> Unit)? = null
   private var onDevices: ((Array<Device>) -> Unit)? = null
   private var onLifecycle: ((SessionLifecycleEvent) -> Unit)? = null
+  private var onMediaStatus: ((MediaStatus) -> Unit)? = null
 
   private var castStateListener: CastStateListener? = null
   private var sessionListener: SessionManagerListener<CastSession>? = null
   private var routerCallback: MediaRouter.Callback? = null
   private var listenersAttached = false
+
+  // The `RemoteMediaClient.Callback` currently registered, plus the exact client it is
+  // registered on (so it is removed from the right instance across session changes). Both
+  // are touched only on the main thread.
+  private var mediaCallback: RemoteMediaClient.Callback? = null
+  private var observedClient: RemoteMediaClient? = null
+
+  // In-flight media `PendingResult`s, so teardown can cancel them (and drop our settlement
+  // closures). Main-thread only — no extra synchronization needed.
+  private val pendingResults = mutableSetOf<PendingResult<RemoteMediaClient.MediaChannelResult>>()
 
   @Volatile private var cachedCastState: CastState = CastState.NOTCONNECTED
   @Volatile private var cachedDiscovering = false
@@ -72,11 +91,13 @@ class HybridCastTransport : HybridCastTransportSpec() {
   override fun initAndSubscribe(
     onState: (castState: CastState) -> Unit,
     onDevices: (devices: Array<Device>) -> Unit,
-    onLifecycle: (event: SessionLifecycleEvent) -> Unit
+    onLifecycle: (event: SessionLifecycleEvent) -> Unit,
+    onMediaStatus: (status: MediaStatus) -> Unit
   ): Promise<InitialSnapshot> {
     this.onState = onState
     this.onDevices = onDevices
     this.onLifecycle = onLifecycle
+    this.onMediaStatus = onMediaStatus
 
     val promise = Promise<InitialSnapshot>()
     runOnMain {
@@ -95,9 +116,14 @@ class HybridCastTransport : HybridCastTransportSpec() {
       }
       attachObservers(castContext)
       cachedCastState = mapState(castContext.castState)
-      val current = sessionInfo(castContext.sessionManager.currentCastSession)
+      val currentSession = castContext.sessionManager.currentCastSession
+      // GCK auto-resumes a session early in the process lifecycle — often *before* the JS
+      // bundle reaches `initAndSubscribe` — so `onSessionResumed` may have already fired with
+      // no media listener attached. Attach to the live client now; the `observedClient` guard
+      // keeps this idempotent against a later session callback.
+      attachMediaCallback(currentSession?.remoteMediaClient)
       promise.resolve(
-        InitialSnapshot(cachedCastState, playServicesState(), readDevices(), current)
+        InitialSnapshot(cachedCastState, playServicesState(), readDevices(), sessionInfo(currentSession))
       )
     }
     return promise
@@ -155,9 +181,14 @@ class HybridCastTransport : HybridCastTransportSpec() {
   override fun dispose() {
     runOnMain {
       detachObservers()
+      detachMediaCallback()
+      // Cancel any in-flight media requests; JS is going away so the promises need not settle.
+      pendingResults.forEach { it.cancel() }
+      pendingResults.clear()
       onState = null
       onDevices = null
       onLifecycle = null
+      onMediaStatus = null
     }
     super.dispose()
   }
@@ -209,6 +240,170 @@ class HybridCastTransport : HybridCastTransportSpec() {
     return promise
   }
 
+  // MARK: - media transport (route to the active session's RemoteMediaClient)
+  //
+  // Every call re-resolves the current `RemoteMediaClient` on the main thread (Invariant 1 —
+  // no cached handle), rejecting with `noSession` when none is active. The returned GCK
+  // `PendingResult<MediaChannelResult>` settles the promise exactly once via `mediaCall`.
+
+  override fun loadMedia(request: MediaLoadRequest): Promise<Unit> =
+    mediaCall { it.load(request.toGckMediaLoadRequestData()) }
+
+  override fun play(): Promise<Unit> = mediaCall { it.play() }
+
+  override fun pause(): Promise<Unit> = mediaCall { it.pause() }
+
+  override fun stop(): Promise<Unit> = mediaCall { it.stop() }
+
+  override fun seek(options: MediaSeekOptions): Promise<Unit> =
+    mediaCall { it.seek(options.toGckMediaSeekOptions()) }
+
+  override fun setPlaybackRate(playbackRate: Double): Promise<Unit> =
+    mediaCall { it.setPlaybackRate(playbackRate) }
+
+  override fun setActiveTrackIds(trackIds: DoubleArray): Promise<Unit> =
+    mediaCall { it.setActiveMediaTracks(LongArray(trackIds.size) { i -> trackIds[i].toLong() }) }
+
+  override fun setTextTrackStyle(textTrackStyle: TextTrackStyle): Promise<Unit> =
+    mediaCall { it.setTextTrackStyle(textTrackStyle.toGckTextTrackStyle()) }
+
+  override fun setStreamVolume(volume: Double): Promise<Unit> =
+    mediaCall { it.setStreamVolume(volume) }
+
+  override fun setStreamMuted(muted: Boolean): Promise<Unit> =
+    mediaCall { it.setStreamMute(muted) }
+
+  override fun queueLoad(
+    items: Array<MediaQueueItem>,
+    startIndex: Double,
+    repeatMode: MediaRepeatMode
+  ): Promise<Unit> =
+    mediaCall {
+      it.queueLoad(
+        Array(items.size) { i -> items[i].toGckMediaQueueItem() },
+        startIndex.toInt(),
+        gckRepeatMode(repeatMode),
+        null
+      )
+    }
+
+  override fun queueInsertItems(items: Array<MediaQueueItem>, beforeItemId: Double): Promise<Unit> =
+    mediaCall {
+      it.queueInsertItems(
+        Array(items.size) { i -> items[i].toGckMediaQueueItem() },
+        beforeItemId.toInt(),
+        null
+      )
+    }
+
+  override fun queueReorderItems(itemIds: DoubleArray, beforeItemId: Double): Promise<Unit> =
+    mediaCall {
+      it.queueReorderItems(
+        IntArray(itemIds.size) { i -> itemIds[i].toInt() },
+        beforeItemId.toInt(),
+        null
+      )
+    }
+
+  override fun queueRemoveItems(itemIds: DoubleArray): Promise<Unit> =
+    mediaCall { it.queueRemoveItems(IntArray(itemIds.size) { i -> itemIds[i].toInt() }, null) }
+
+  override fun queueNext(): Promise<Unit> = mediaCall { it.queueNext(null) }
+
+  override fun queuePrev(): Promise<Unit> = mediaCall { it.queuePrev(null) }
+
+  override fun queueJumpToItem(itemId: Double): Promise<Unit> =
+    mediaCall { it.queueJumpToItem(itemId.toInt(), null) }
+
+  override fun queueSetRepeatMode(repeatMode: MediaRepeatMode): Promise<Unit> =
+    mediaCall { it.queueSetRepeatMode(gckRepeatMode(repeatMode), null) }
+
+  override fun requestMediaStatus(): Promise<Unit> = mediaCall { it.requestStatus() }
+
+  /**
+   * Re-resolves the active `RemoteMediaClient` on the main thread, runs [op] to start a GCK
+   * media request, and settles the returned promise exactly once from the request's single
+   * result callback (status OK → resolve; otherwise reject with a typed `CastError` JSON).
+   * Rejects with `noSession` when no session is active, and `failed` if [op] throws
+   * synchronously (e.g. an illegal queue argument).
+   */
+  private fun mediaCall(
+    op: (RemoteMediaClient) -> PendingResult<RemoteMediaClient.MediaChannelResult>
+  ): Promise<Unit> {
+    val promise = Promise<Unit>()
+    runOnMain {
+      val client = remoteMediaClientOrNull()
+      if (client == null) {
+        promise.reject(
+          CastRejection(castRejectionJson("noSession", "No active Cast session.", null))
+        )
+        return@runOnMain
+      }
+      val pending =
+        try {
+          op(client)
+        } catch (e: Exception) {
+          promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+          return@runOnMain
+        }
+      pendingResults.add(pending)
+      pending.setResultCallback { result ->
+        pendingResults.remove(pending)
+        val status = result.status
+        if (status.isSuccess) {
+          promise.resolve(Unit)
+        } else {
+          promise.reject(
+            CastRejection(
+              castRejectionJson(
+                castErrorCodeFromGckStatusCode(status.statusCode),
+                status.statusMessage,
+                status.statusCode
+              )
+            )
+          )
+        }
+      }
+    }
+    return promise
+  }
+
+  private fun remoteMediaClientOrNull(): RemoteMediaClient? =
+    sharedCastContextOrNull()?.sessionManager?.currentCastSession?.remoteMediaClient
+
+  /** Register the media-status listener on [client], replacing any previous registration. */
+  private fun attachMediaCallback(client: RemoteMediaClient?) {
+    if (client == null || observedClient === client) return
+    detachMediaCallback()
+    val callback =
+      object : RemoteMediaClient.Callback() {
+        override fun onStatusUpdated() {
+          client.mediaStatus?.let { status -> onMediaStatus?.invoke(status.toMediaStatus()) }
+        }
+      }
+    client.registerCallback(callback)
+    mediaCallback = callback
+    observedClient = client
+    // Surface the current status immediately so the store reflects an already-playing session.
+    client.mediaStatus?.let { status -> onMediaStatus?.invoke(status.toMediaStatus()) }
+  }
+
+  private fun detachMediaCallback() {
+    val callback = mediaCallback ?: return
+    observedClient?.unregisterCallback(callback)
+    mediaCallback = null
+    observedClient = null
+  }
+
+  private fun gckRepeatMode(mode: MediaRepeatMode): Int =
+    when (mode) {
+      MediaRepeatMode.OFF -> com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_OFF
+      MediaRepeatMode.ALL -> com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_ALL
+      MediaRepeatMode.SINGLE -> com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_SINGLE
+      MediaRepeatMode.ALLANDSHUFFLE ->
+        com.google.android.gms.cast.MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE
+    }
+
   // MARK: - discovery controls (no-op on Android; MediaRouter drives discovery)
 
   override fun startDiscovery() {
@@ -229,25 +424,33 @@ class HybridCastTransport : HybridCastTransportSpec() {
     object : SessionManagerListener<CastSession> {
       override fun onSessionStarting(session: CastSession) =
         emit(SessionEventType.STARTING, deviceId = session.castDevice?.deviceId)
-      override fun onSessionStarted(session: CastSession, sessionId: String) =
+      override fun onSessionStarted(session: CastSession, sessionId: String) {
+        attachMediaCallback(session.remoteMediaClient)
         emit(SessionEventType.STARTED, session = sessionInfo(session, sessionId))
+      }
       override fun onSessionStartFailed(session: CastSession, error: Int) =
         emit(SessionEventType.STARTFAILED, error = castErrorFromStatusCode(error, null))
       override fun onSessionEnding(session: CastSession) =
         emit(SessionEventType.ENDING, session = sessionInfo(session))
-      override fun onSessionEnded(session: CastSession, error: Int) =
+      override fun onSessionEnded(session: CastSession, error: Int) {
+        detachMediaCallback()
         emit(
           SessionEventType.ENDED,
           error = if (error != 0) castErrorFromStatusCode(error, null) else null
         )
+      }
       override fun onSessionResuming(session: CastSession, sessionId: String) =
         emit(SessionEventType.RESUMING, sessionId = sessionId)
-      override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) =
+      override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+        attachMediaCallback(session.remoteMediaClient)
         emit(SessionEventType.RESUMED, session = sessionInfo(session))
+      }
       override fun onSessionResumeFailed(session: CastSession, error: Int) =
         emit(SessionEventType.RESUMEFAILED, error = castErrorFromStatusCode(error, null))
-      override fun onSessionSuspended(session: CastSession, reason: Int) =
+      override fun onSessionSuspended(session: CastSession, reason: Int) {
+        detachMediaCallback()
         emit(SessionEventType.SUSPENDED, reason = suspendReason(reason))
+      }
     }
 
   // MARK: - helpers


### PR DESCRIPTION
## Phase 4 — T4d: Android RemoteMediaClient native impl (`v5-aug.4`)

Implements the T4a transport media surface on Android, routing to the active session's `RemoteMediaClient` (`play-services-cast`).

- All media/queue methods re-resolve `currentCastSession?.remoteMediaClient` on the **main thread** per call (never caches) — no session rejects `noSession`, never crashes.
- `PendingResult<MediaChannelResult>` settled **exactly once** per call.
- `onMediaStatus` wired via `RemoteMediaClient.Callback` (`onStatusUpdated`), pushing the converted `MediaStatus` (reuses the Phase 2 converter; GCK enum ints mapped by value, not ordinal).

**Verification:** `compileDebugKotlin` **green** (JBR 21).

Files: `android/` only. Stacked on the T4a foundation (already on `v5`); disjoint from the façade/iOS PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Google Cast media controls with broader, more responsive support for playback actions (play/pause/stop), seeking, rate control, track selection, volume/mute, and queue operations.
  * Media status updates now reliably forward through the active casting session to keep UI state in sync.

* **Bug Fixes**
  * Improved reliability of cast action handling, including clearer errors when no session is available or when requests fail.
  * Media control listeners and pending updates are cleaned up correctly on session end/suspend to reduce stale state and missed updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->