### PR TITLE
feat(v5): media-progress ticking — useStreamPosition(interval) + onMediaProgressUpdated (v5-aug.6)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-media-progress-ticking.md
+++ b/docs/superpowers/plans/2026-07-01-media-progress-ticking.md
@@ -1,0 +1,851 @@
+# Media-progress ticking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give v5 a locally-ticking `streamPosition` with interval arbitration and full v4 API parity (`useStreamPosition(interval)` + `RemoteMediaClient.onMediaProgressUpdated`), all in pure TS.
+
+**Architecture:** A single `ProgressTicker` (pure TS) reads the central store's media slice and derives position = last `MediaStatus.streamPosition` + elapsed × `playbackRate` while `playerState === 'playing'`, resyncing on every status push. It owns one `setInterval` running at the arbitrated **min** subscriber interval, active only while playing and subscribed. The hook and the façade method are thin wrappers over one module-level ticker singleton.
+
+**Tech Stack:** TypeScript, React (`useState`/`useEffect`), Jest + `react-test-renderer`, existing `CastStore` + `FakeCastTransport` test harness.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md`
+
+---
+
+## File Structure
+
+- **Create** `src/state/progressTicker.ts` — the `ProgressTicker` class (derivation + timer + arbitration). No native import; unit-tested directly with a `CastStore`+`FakeCastTransport`.
+- **Create** `src/state/progressTicker.singleton.ts` — `export const progressTicker = new ProgressTicker(castStore)`, mirroring `castStore.singleton.ts`. Isolates the native-backed singleton from the class's test path.
+- **Create** `src/state/__tests__/progressTicker.test.ts` — all derivation/arbitration/lifecycle unit tests.
+- **Modify** `src/api/useStreamPosition.ts` — rewrite to tick via the singleton, add `interval` param.
+- **Modify** `src/api/RemoteMediaClient.ts` — add `onMediaProgressUpdated(handler, interval?)`.
+- **Modify** `src/api/__tests__/mediaHooks.test.ts` — add a ticking test for `useStreamPosition(interval)`.
+- **Modify** `src/api/__tests__/RemoteMediaClient.test.ts` — add an `onMediaProgressUpdated` test.
+
+**Key types (locked; reused across tasks):**
+```ts
+// Store capability the ticker needs (both already on CastStore):
+type TickerStoreView = Pick<CastStore, 'getSliceState' | 'subscribe'>
+// Public handler shape (v4 parity):
+type ProgressHandler = (position: number, duration: number) => void
+```
+
+---
+
+## Task 1: `ProgressTicker` derivation (position/duration, no timer yet)
+
+**Files:**
+- Create: `src/state/progressTicker.ts`
+- Test: `src/state/__tests__/progressTicker.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/state/__tests__/progressTicker.test.ts`:
+
+```ts
+import { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import type { Device, SessionInfo } from '../../transport/types'
+import type { MediaStatus } from '../../types/MediaStatus'
+import { CastStore } from '../CastStore'
+import { ProgressTicker } from '../progressTicker'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+function status(over: Partial<MediaStatus> = {}): MediaStatus {
+  return {
+    streamPosition: 0,
+    playbackRate: 1,
+    volume: 1,
+    isMuted: false,
+    queueItems: [],
+    ...over,
+  }
+}
+
+// A controllable clock; ms since an arbitrary origin.
+function makeClock() {
+  const state = { ms: 0 }
+  return { now: () => state.ms, advance: (ms: number) => (state.ms += ms), state }
+}
+
+async function makeTicker(now: () => number) {
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  await store.ready
+  const ticker = new ProgressTicker(store, now)
+  return { transport, store, ticker }
+}
+
+describe('ProgressTicker — derivation', () => {
+  it('returns null when there is no media', async () => {
+    const clock = makeClock()
+    const { ticker } = await makeTicker(clock.now)
+    expect(ticker.getPosition()).toBeNull()
+    expect(ticker.getDuration()).toBe(0)
+  })
+
+  it('freezes at streamPosition when not playing', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {}) // activates the store subscription
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status({ streamPosition: 10, playerState: 'paused' }))
+
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(10)
+    off()
+  })
+
+  it('advances by elapsed × playbackRate while playing', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playbackRate: 2, playerState: 'playing' })
+    )
+
+    clock.advance(3000) // 3s real → 6s of media at 2×
+    expect(ticker.getPosition()).toBe(16)
+    off()
+  })
+
+  it('clamps to duration for VOD but leaves live un-clamped', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+
+    // VOD: streamDuration = 12 → clamp.
+    transport.emitMediaStatus(
+      status({
+        streamPosition: 10,
+        playerState: 'playing',
+        mediaInfo: { contentUrl: 'x', streamDuration: 12 },
+      })
+    )
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(12)
+
+    // Live: no streamDuration → un-clamped.
+    transport.emitMediaStatus(
+      status({ streamPosition: 100, playerState: 'playing' })
+    )
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(105)
+    off()
+  })
+
+  it('resyncs the anchor on every status push (no drift)', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status({ streamPosition: 10, playerState: 'playing' }))
+
+    clock.advance(4000)
+    expect(ticker.getPosition()).toBe(14)
+
+    // Receiver reports 20 (e.g. after a seek); position tracks the new base.
+    transport.emitMediaStatus(status({ streamPosition: 20, playerState: 'playing' }))
+    clock.advance(1000)
+    expect(ticker.getPosition()).toBe(21)
+    off()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest src/state/__tests__/progressTicker.test.ts`
+Expected: FAIL — `Cannot find module '../progressTicker'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/state/progressTicker.ts`:
+
+```ts
+import type { CastStore } from './CastStore'
+import { MEDIA_SLICE_KEY, type MediaState } from './media.slice'
+import type { MediaStatus } from '../types/MediaStatus'
+
+/** The store capability the ticker needs (both already on {@link CastStore}). */
+type TickerStoreView = Pick<CastStore, 'getSliceState' | 'subscribe'>
+
+/** A progress listener; pulls the current value via the ticker's getters. */
+type Listener = () => void
+
+/**
+ * Derives a locally-ticking stream position from the store's media slice — pure
+ * TS, no native timer. Position advances only while `playerState === 'playing'`,
+ * resyncing to the receiver's reported `streamPosition` on every status push, so
+ * clock drift never accumulates. One shared `setInterval` runs at the smallest
+ * subscriber interval and only while playing (added in Task 2).
+ */
+export class ProgressTicker {
+  private readonly store: TickerStoreView
+  private readonly now: () => number
+
+  private storeUnsub: (() => void) | null = null
+  private anchorStatus: MediaStatus | null = null
+  private anchorTime = 0
+
+  constructor(store: TickerStoreView, now: () => number = Date.now) {
+    this.store = store
+    this.now = now
+  }
+
+  /** Register a listener. Returns an unsubscribe. (Timer added in Task 2.) */
+  subscribe(listener: Listener): () => void {
+    // Placeholder membership until Task 2 introduces the subscriber map + timer.
+    if (!this.storeUnsub) {
+      this.storeUnsub = this.store.subscribe(() => this.onStoreChange())
+      this.reanchor()
+    }
+    return () => {
+      if (this.storeUnsub) {
+        this.storeUnsub()
+        this.storeUnsub = null
+      }
+      this.anchorStatus = null
+    }
+  }
+
+  /** Current derived position in seconds, or `null` when there is no media. */
+  getPosition(): number | null {
+    const status = this.status()
+    if (!status) return null
+    let pos = status.streamPosition
+    // Advance only when the *current* status is the one we anchored to.
+    if (status.playerState === 'playing' && status === this.anchorStatus) {
+      pos += ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
+    }
+    const duration = this.getDuration()
+    if (duration > 0) return Math.min(Math.max(pos, 0), duration)
+    return pos < 0 ? 0 : pos
+  }
+
+  /** Current media duration in seconds; `0` when unknown/live. */
+  getDuration(): number {
+    return this.status()?.mediaInfo?.streamDuration ?? 0
+  }
+
+  private status(): MediaStatus | null {
+    return this.store.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
+  }
+
+  private onStoreChange(): void {
+    const status = this.status()
+    if (status !== this.anchorStatus) this.reanchor()
+  }
+
+  private reanchor(): void {
+    this.anchorStatus = this.status()
+    this.anchorTime = this.now()
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn jest src/state/__tests__/progressTicker.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/state/progressTicker.ts src/state/__tests__/progressTicker.test.ts
+git commit -m "feat(v5): ProgressTicker position derivation (v5-aug.6)"
+```
+
+---
+
+## Task 2: Shared timer + min-interval arbitration + play/teardown lifecycle
+
+**Files:**
+- Modify: `src/state/progressTicker.ts`
+- Test: `src/state/__tests__/progressTicker.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/state/__tests__/progressTicker.test.ts`:
+
+```ts
+describe('ProgressTicker — timer & arbitration', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.useRealTimers())
+
+  async function playing() {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status({ streamPosition: 0, playerState: 'playing' }))
+    return { clock, ticker, transport }
+  }
+
+  it('notifies a subscriber once per interval while playing', async () => {
+    const { clock, ticker } = await playing()
+    const listener = jest.fn()
+    ticker.subscribe(listener, 1)
+
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs ONE timer at the min interval for differing subscribers', async () => {
+    const { clock, ticker } = await playing()
+    const fast = jest.fn()
+    const slow = jest.fn()
+    ticker.subscribe(fast, 1)
+    ticker.subscribe(slow, 5)
+
+    // Min interval is 1s → both fire every second (tick-all policy).
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+    expect(fast).toHaveBeenCalledTimes(1)
+    expect(slow).toHaveBeenCalledTimes(1)
+    // Only one underlying interval exists.
+    expect(jest.getTimerCount()).toBe(1)
+  })
+
+  it('recomputes the min interval and stops on last unsubscribe', async () => {
+    const { ticker } = await playing()
+    const a = jest.fn()
+    const b = jest.fn()
+    const offA = ticker.subscribe(a, 1)
+    const offB = ticker.subscribe(b, 3)
+    expect(jest.getTimerCount()).toBe(1)
+
+    offA() // now only the 3s subscriber remains → timer restarts at 3s
+    expect(jest.getTimerCount()).toBe(1)
+
+    offB() // last one gone → timer stops
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('stops the timer when playback pauses and restarts on resume', async () => {
+    const { ticker, transport } = await playing()
+    ticker.subscribe(jest.fn(), 1)
+    expect(jest.getTimerCount()).toBe(1)
+
+    transport.emitMediaStatus(status({ streamPosition: 5, playerState: 'paused' }))
+    expect(jest.getTimerCount()).toBe(0)
+
+    transport.emitMediaStatus(status({ streamPosition: 5, playerState: 'playing' }))
+    expect(jest.getTimerCount()).toBe(1)
+  })
+
+  it('stops the timer and returns null on session teardown', async () => {
+    const { ticker, transport } = await playing()
+    ticker.subscribe(jest.fn(), 1)
+    expect(jest.getTimerCount()).toBe(1)
+
+    transport.emitLifecycle({ type: 'ended' })
+    expect(jest.getTimerCount()).toBe(0)
+    expect(ticker.getPosition()).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn jest src/state/__tests__/progressTicker.test.ts -t "timer & arbitration"`
+Expected: FAIL — subscribers not ticked / `getTimerCount` mismatches (timer not implemented).
+
+- [ ] **Step 3: Implement the timer + arbitration**
+
+Replace the subscriber/timer internals of `src/state/progressTicker.ts`. Full file:
+
+```ts
+import type { CastStore } from './CastStore'
+import { MEDIA_SLICE_KEY, type MediaState } from './media.slice'
+import type { MediaStatus } from '../types/MediaStatus'
+
+/** The store capability the ticker needs (both already on {@link CastStore}). */
+type TickerStoreView = Pick<CastStore, 'getSliceState' | 'subscribe'>
+
+/** A progress listener; pulls the current value via the ticker's getters. */
+type Listener = () => void
+
+interface Subscriber {
+  readonly listener: Listener
+  readonly interval: number
+}
+
+/**
+ * Derives a locally-ticking stream position from the store's media slice — pure
+ * TS, no native timer. Position advances only while `playerState === 'playing'`,
+ * resyncing to the receiver's reported `streamPosition` on every status push, so
+ * clock drift never accumulates.
+ *
+ * One shared `setInterval` runs at the smallest subscriber interval and only
+ * while playing + subscribed; it is recomputed on every membership change and on
+ * play-state transitions, and torn down when the last subscriber leaves.
+ */
+export class ProgressTicker {
+  private readonly store: TickerStoreView
+  private readonly now: () => number
+
+  private readonly subs = new Map<object, Subscriber>()
+  private storeUnsub: (() => void) | null = null
+  private timer: ReturnType<typeof setInterval> | null = null
+  private timerInterval = 0
+
+  private anchorStatus: MediaStatus | null = null
+  private anchorTime = 0
+
+  constructor(store: TickerStoreView, now: () => number = Date.now) {
+    this.store = store
+    this.now = now
+  }
+
+  /**
+   * Register a progress listener at a given update interval (seconds, default 1).
+   * The listener is invoked on each shared tick while playing and whenever the
+   * media slice changes (a new status push, pause/resume, or teardown). Returns
+   * an unsubscribe.
+   */
+  subscribe(listener: Listener, interval = 1): () => void {
+    const key = {}
+    this.subs.set(key, { listener, interval })
+    if (!this.storeUnsub) {
+      this.storeUnsub = this.store.subscribe(() => this.onStoreChange())
+      this.reanchor()
+    }
+    this.reconcileTimer()
+    return () => {
+      if (!this.subs.delete(key)) return
+      if (this.subs.size === 0) this.teardown()
+      else this.reconcileTimer()
+    }
+  }
+
+  /** Current derived position in seconds, or `null` when there is no media. */
+  getPosition(): number | null {
+    const status = this.status()
+    if (!status) return null
+    let pos = status.streamPosition
+    if (status.playerState === 'playing' && status === this.anchorStatus) {
+      pos += ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
+    }
+    const duration = this.getDuration()
+    if (duration > 0) return Math.min(Math.max(pos, 0), duration)
+    return pos < 0 ? 0 : pos
+  }
+
+  /** Current media duration in seconds; `0` when unknown/live. */
+  getDuration(): number {
+    return this.status()?.mediaInfo?.streamDuration ?? 0
+  }
+
+  private status(): MediaStatus | null {
+    return this.store.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
+  }
+
+  private onStoreChange(): void {
+    const status = this.status()
+    if (status !== this.anchorStatus) this.reanchor()
+    this.reconcileTimer()
+    this.notify()
+  }
+
+  private reanchor(): void {
+    this.anchorStatus = this.status()
+    this.anchorTime = this.now()
+  }
+
+  private isPlaying(): boolean {
+    return this.status()?.playerState === 'playing'
+  }
+
+  private minInterval(): number {
+    let min = Infinity
+    for (const { interval } of this.subs.values()) min = Math.min(min, interval)
+    return min === Infinity ? 1 : min
+  }
+
+  private reconcileTimer(): void {
+    const want = this.subs.size > 0 && this.isPlaying()
+    const min = this.minInterval()
+    if (want && (this.timer === null || min !== this.timerInterval)) {
+      if (this.timer !== null) clearInterval(this.timer)
+      this.timerInterval = min
+      this.timer = setInterval(() => this.notify(), min * 1000)
+    } else if (!want && this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+      this.timerInterval = 0
+    }
+  }
+
+  private notify(): void {
+    for (const { listener } of [...this.subs.values()]) listener()
+  }
+
+  private teardown(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    this.timerInterval = 0
+    if (this.storeUnsub) {
+      this.storeUnsub()
+      this.storeUnsub = null
+    }
+    this.anchorStatus = null
+  }
+}
+```
+
+- [ ] **Step 4: Run the whole ticker suite**
+
+Run: `yarn jest src/state/__tests__/progressTicker.test.ts`
+Expected: PASS (all derivation + timer/arbitration tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/state/progressTicker.ts src/state/__tests__/progressTicker.test.ts
+git commit -m "feat(v5): ProgressTicker shared timer + min-interval arbitration (v5-aug.6)"
+```
+
+---
+
+## Task 3: Ticker singleton
+
+**Files:**
+- Create: `src/state/progressTicker.singleton.ts`
+
+- [ ] **Step 1: Write the singleton**
+
+Create `src/state/progressTicker.singleton.ts`:
+
+```ts
+import { castStore } from './castStore.singleton'
+import { ProgressTicker } from './progressTicker'
+
+/**
+ * The process-wide progress ticker, bound to the {@link castStore} singleton.
+ * Imported only by the façade layer (`useStreamPosition`,
+ * `RemoteMediaClient.onMediaProgressUpdated`) — never by the ticker's own tests,
+ * which construct a {@link ProgressTicker} over a `FakeCastTransport`-backed
+ * store so this module's native import stays out of their path.
+ */
+export const progressTicker = new ProgressTicker(castStore)
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `yarn typescript`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/state/progressTicker.singleton.ts
+git commit -m "feat(v5): progressTicker singleton bound to castStore (v5-aug.6)"
+```
+
+---
+
+## Task 4: `useStreamPosition(interval)` ticks via the ticker
+
+**Files:**
+- Modify: `src/api/useStreamPosition.ts`
+- Test: `src/api/__tests__/mediaHooks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/api/__tests__/mediaHooks.test.ts`. First extend the `mediaStatus` helper and the `Probe` so an interval + playing state can be exercised. Add a **new** test block after the existing `describe`:
+
+```ts
+describe('useStreamPosition — ticking', () => {
+  beforeAll(async () => {
+    await castStore.ready
+  })
+
+  it('advances between status pushes while playing', async () => {
+    jest.useFakeTimers()
+    const positions: (number | null)[] = []
+    function Ticking(): null {
+      positions.push(useStreamPosition(1))
+      return null
+    }
+
+    let root!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      root = TestRenderer.create(React.createElement(Ticking))
+    })
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('tick') })
+      transport.emitMediaStatus({
+        streamPosition: 30,
+        playbackRate: 1,
+        volume: 1,
+        isMuted: false,
+        queueItems: [],
+        playerState: 'playing',
+      })
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    // The last observed position is >= the pushed base (it ticked forward).
+    expect(positions[positions.length - 1]!).toBeGreaterThanOrEqual(30)
+
+    act(() => {
+      root.unmount()
+    })
+    jest.useRealTimers()
+  })
+})
+```
+
+> Note: this test asserts the wiring (hook re-renders off the ticker); exact
+> arithmetic is covered deterministically in `progressTicker.test.ts` with an
+> injected clock. Under fake timers the singleton's default `Date.now` is also
+> faked, so `advanceTimersByTime` moves both the interval and the clock.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest src/api/__tests__/mediaHooks.test.ts -t "ticking"`
+Expected: FAIL — `useStreamPosition` (current impl) never advances; last value stays `30` only because of the push, and with no interval arg it won't re-render on a tick. (Failure may be a timeout or a stale value depending on the current impl.)
+
+- [ ] **Step 3: Rewrite the hook**
+
+Replace `src/api/useStreamPosition.ts` entirely:
+
+```ts
+import { useEffect, useState } from 'react'
+import { progressTicker } from '../state/progressTicker.singleton'
+
+/**
+ * Hook returning the current stream position in seconds, ticking locally between
+ * receiver status pushes while playback is `playing`. Returns `null` when there
+ * is no active media.
+ *
+ * @param interval update interval in seconds (default `1`). Multiple subscribers
+ *   with differing intervals share a single timer at the smallest interval.
+ * @returns the current position in seconds, or `null`.
+ */
+export function useStreamPosition(interval = 1): number | null {
+  const [position, setPosition] = useState<number | null>(() =>
+    progressTicker.getPosition()
+  )
+  useEffect(() => {
+    const update = () => setPosition(progressTicker.getPosition())
+    update()
+    return progressTicker.subscribe(update, interval)
+  }, [interval])
+  return position
+}
+```
+
+- [ ] **Step 4: Run the media-hook tests**
+
+Run: `yarn jest src/api/__tests__/mediaHooks.test.ts`
+Expected: PASS — both the pre-existing `useSyncExternalStore wiring` test (no-arg `useStreamPosition()` still returns `12` then `null`) and the new ticking test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/useStreamPosition.ts src/api/__tests__/mediaHooks.test.ts
+git commit -m "feat(v5): useStreamPosition ticks via ProgressTicker with interval (v5-aug.6)"
+```
+
+---
+
+## Task 5: `RemoteMediaClient.onMediaProgressUpdated`
+
+**Files:**
+- Modify: `src/api/RemoteMediaClient.ts`
+- Test: `src/api/__tests__/RemoteMediaClient.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/api/__tests__/RemoteMediaClient.test.ts`. This test drives the real singleton store + ticker (mock the singleton the same way `mediaHooks.test.ts` does — copy that `jest.mock('../../state/castStore.singleton', ...)` block to the top of this file **if it is not already present**). Then:
+
+```ts
+describe('RemoteMediaClient — onMediaProgressUpdated', () => {
+  beforeAll(async () => {
+    await castStore.ready
+  })
+
+  it('delivers (position, duration) and stops after remove()', async () => {
+    jest.useFakeTimers()
+    transport.emitLifecycle({ type: 'started', session: session('rmc') })
+    const client = RemoteMediaClient.current(castStore, castTransport)!
+    expect(client).not.toBeNull()
+
+    const calls: Array<[number, number]> = []
+    const sub = client.onMediaProgressUpdated((p, d) => calls.push([p, d]), 1)
+
+    transport.emitMediaStatus({
+      streamPosition: 0,
+      playbackRate: 1,
+      volume: 1,
+      isMuted: false,
+      queueItems: [],
+      playerState: 'playing',
+      mediaInfo: { contentUrl: 'x', streamDuration: 100 },
+    })
+    jest.advanceTimersByTime(2000)
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[calls.length - 1]![1]).toBe(100) // duration threaded through
+
+    const before = calls.length
+    sub.remove()
+    jest.advanceTimersByTime(3000)
+    expect(calls.length).toBe(before) // no more deliveries after remove()
+
+    transport.emitLifecycle({ type: 'ended' })
+    jest.useRealTimers()
+  })
+})
+```
+
+> Ensure the file imports `castStore`, `castTransport` from
+> `'../../state/castStore.singleton'` and the `session` helper (copy from
+> `mediaHooks.test.ts` if absent).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest src/api/__tests__/RemoteMediaClient.test.ts -t "onMediaProgressUpdated"`
+Expected: FAIL — `client.onMediaProgressUpdated is not a function`.
+
+- [ ] **Step 3: Implement the method**
+
+In `src/api/RemoteMediaClient.ts`:
+
+1. Add imports near the top (after the existing type imports):
+
+```ts
+import type { EventSubscription } from './subscribeSelector'
+import { progressTicker } from '../state/progressTicker.singleton'
+```
+
+2. Add the method inside the `RemoteMediaClient` class, immediately after `getStreamPosition()` (around line 124):
+
+```ts
+  /**
+   * Listen for ticking progress of the currently playing media. The handler
+   * receives `(position, duration)` in seconds, driven by a shared TS ticker
+   * (position advances locally while playing, resyncing on each status push).
+   *
+   * Unlike v4 (single listener), v5 supports multiple concurrent listeners;
+   * differing intervals share one timer at the smallest interval.
+   *
+   * @param handler called with `(position, duration)` on each update.
+   * @param interval update frequency in seconds (default `1`).
+   * @returns a subscription; call `remove()` to stop listening.
+   */
+  onMediaProgressUpdated(
+    handler: (position: number, duration: number) => void,
+    interval = 1
+  ): EventSubscription {
+    const unsubscribe = progressTicker.subscribe(() => {
+      const position = progressTicker.getPosition()
+      if (position !== null) handler(position, progressTicker.getDuration())
+    }, interval)
+    return { remove: unsubscribe }
+  }
+```
+
+> The subscription is intentionally *not* generation-gated: progress is inherently
+> "the current session's media", and the ticker stops emitting the instant the
+> media slice clears on teardown — matching v4's "currently playing media"
+> semantics.
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn jest src/api/__tests__/RemoteMediaClient.test.ts`
+Expected: PASS (existing tests + the new `onMediaProgressUpdated` test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/RemoteMediaClient.ts src/api/__tests__/RemoteMediaClient.test.ts
+git commit -m "feat(v5): RemoteMediaClient.onMediaProgressUpdated via shared ticker (v5-aug.6)"
+```
+
+---
+
+## Task 6: Full verification + spec note
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md` (mark native scope confirmed)
+
+- [ ] **Step 1: Run the full TS test suite**
+
+Run: `yarn jest`
+Expected: PASS — all suites green (previous 95 + the new ticker/hook/RMC tests).
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `yarn typescript && yarn lint`
+Expected: no errors.
+
+- [ ] **Step 3: Confirm public exports**
+
+Verify `src/index.ts` still exports `useStreamPosition` (unchanged named export) and that `RemoteMediaClient` is exported. No new top-level export is required (`onMediaProgressUpdated` is a method; `progressTicker` stays internal).
+
+Run: `grep -nE "useStreamPosition|RemoteMediaClient" src/index.ts`
+Expected: both already present; if `useStreamPosition` is missing, add `export { useStreamPosition } from './api/useStreamPosition'`.
+
+- [ ] **Step 4: Append a closing note to the spec**
+
+Add to the end of `docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md`:
+
+```markdown
+## Implementation note (2026-07-01)
+
+Delivered in pure TS as designed: `ProgressTicker` + singleton, `useStreamPosition(interval)`,
+`RemoteMediaClient.onMediaProgressUpdated`. No native (Swift/Kotlin) changes were needed —
+the existing `MediaStatus` push stream is sufficient. All tests green via `yarn jest`.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
+git commit -m "docs(v5): confirm media-progress ticking shipped TS-only (v5-aug.6)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- TS-derived ticking → Task 1 (derivation) + Task 2 (timer). ✓
+- Min-interval, tick-all arbitration → Task 2. ✓
+- `useStreamPosition(interval)` → Task 4. ✓
+- `onMediaProgressUpdated(handler, interval)` full v4 parity → Task 5. ✓
+- Resync-on-push (no drift) → Task 1 test + Task 2 impl. ✓
+- Pause freezes / timer off; resume restarts → Task 2. ✓
+- VOD clamp; live un-clamped (judgment A) → Task 1. ✓
+- Teardown → null, timer stopped → Task 2. ✓
+- `playbackRate` scaling → Task 1. ✓
+- No native changes (scope) → Task 6 note. ✓
+- Testing matrix (spec §Testing) → Tasks 1–2 cover single/multi/unsubscribe/resync/pause/clamp/teardown/rate; hook + RMC wiring in Tasks 4–5. ✓
+
+**Placeholder scan:** none — every code step shows complete code; commands include expected output.
+
+**Type consistency:** `TickerStoreView`, `ProgressHandler`/`(position, duration)`, `subscribe(listener, interval)`, `getPosition()`, `getDuration()`, `progressTicker` singleton, `EventSubscription { remove() }` — used identically across Tasks 1–5. The Task 1 stub `subscribe(listener)` is intentionally superseded by the full `subscribe(listener, interval = 1)` in Task 2 (Task 1's tests pass an interval-less call, which still type-checks against the default param).

--- a/docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
+++ b/docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
@@ -63,7 +63,7 @@ the store itself isolates the single long-lived native subscription.
 
 ## Derivation math
 
-```
+```text
 base     = status.streamPosition            // reset on every MediaStatus push
 anchor   = now()                            // reset on every MediaStatus push
 elapsed  = (now() - anchor) / 1000          // seconds

--- a/docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
+++ b/docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
@@ -1,0 +1,137 @@
+# Media-progress ticking — design
+
+**Bead:** `v5-aug.6` — Media-progress throttling: local streamPosition ticking + `onMediaProgressUpdated` + interval arbitration (TS + iOS + Android)
+**Phase:** 4 (RemoteMediaClient), under epic `v5-aug`
+**Date:** 2026-07-01
+**Supersedes:** the duplicated interval-arbitration item from `v5-m3i` (T8, closed) and item (1) of `v5-aug.5`.
+
+## Problem
+
+v5 today exposes `useStreamPosition()` and `useMediaStatus()` as pure **status-push** selectors over the
+central store's media slice — they update only when the receiver reports a new `MediaStatus`, so the
+position does **not** advance between pushes.
+
+v4 provided a *ticking* position via the **native** GCK progress listener
+(`RemoteMediaClient.setProgressUpdateInterval` + a `MEDIA_PROGRESS_UPDATED` native event) surfaced as:
+
+- `useStreamPosition(interval = 1)` → `number | null`
+- `client.onMediaProgressUpdated(handler: (progress, duration) => void, interval = 1)` — **single** listener
+  (attaching another replaced the previous); the interval was a single global via `setProgressUpdateInterval`.
+
+v5 must reintroduce a ticking position while honouring the v5 architecture: a **TS central state machine +
+singleton transport, not stateful native objects**.
+
+## Decisions (locked during brainstorming)
+
+1. **Tick source: TS-derived.** No native timer. Position is derived in pure TS from the last `MediaStatus`
+   plus a monotonic clock, resynced on every status push. Fits the v5 architecture, is fully unit-testable,
+   and adds zero per-tick bridge crossings.
+2. **API: full v4 parity.** Keep both the hook (`useStreamPosition(interval?)`) and the imperative
+   `RemoteMediaClient.onMediaProgressUpdated(handler, interval?)`, both backed by one shared ticker.
+3. **Arbitration: min-interval, tick-all.** One timer at the smallest requested interval; every subscriber is
+   invoked on each tick. React consumers dedupe on the derived number, so over-delivery to slower subscribers
+   is harmless.
+4. **Live streams (judgment call A): un-clamped.** For live content with no finite duration, the derived
+   position is left un-clamped (not clamped to `liveSeekableRange.end`).
+5. **Paused behaviour (judgment call B): timer off while paused.** No redundant frozen-value emissions; the
+   last value stands and the timer resumes when playback resumes.
+
+## Architecture — one shared TS ticker
+
+A new singleton module `src/state/progressTicker.ts`, beside the store:
+
+- Reads the latest `MediaStatus` and play-state from the `castStore` **media slice**
+  (`getSliceState<MediaState>(MEDIA_SLICE_KEY)`), subscribing to the store to observe changes.
+- Owns a **single** `setInterval`. The timer is active only while `subscribers > 0 AND playerState === 'playing'`.
+- Public surface:
+  ```ts
+  interface ProgressSubscriberOptions { readonly interval?: number } // seconds, default 1
+  type ProgressHandler = (position: number, duration: number) => void
+  function subscribeProgress(handler: ProgressHandler, interval?: number): () => void
+  ```
+- On every `subscribe`/`unsubscribe`: recompute the min interval and restart the timer at the new rate (or
+  stop it when the last subscriber leaves).
+- On every `MediaStatus` push observed from the store: reset the derivation anchor (see below).
+- Accepts an injectable `now: () => number` (default `Date.now`) so tests control time deterministically.
+
+Both public APIs are thin wrappers over `subscribeProgress`; no timing logic is duplicated.
+
+### Why this module and not the media slice
+Slices are pure reducers over discrete events; a wall-clock timer is a side-effecting subscription, not a
+reduction. Keeping it in a dedicated singleton preserves the slice's purity and testability and mirrors how
+the store itself isolates the single long-lived native subscription.
+
+## Derivation math
+
+```
+base     = status.streamPosition            // reset on every MediaStatus push
+anchor   = now()                            // reset on every MediaStatus push
+elapsed  = (now() - anchor) / 1000          // seconds
+position = playing ? base + elapsed * playbackRate : base
+duration = status.mediaInfo?.streamDuration ?? 0
+```
+
+- **Resync** `base` and `anchor` on every status push — continuous correction, so drift never accumulates.
+- **Freeze** at `base` when `playerState` is not `playing` (paused / buffering / idle).
+- **Clamp** to `[0, duration]` when `duration > 0` (VOD). For live (`duration === 0` / no finite
+  `streamDuration`), leave un-clamped (decision 4).
+- `playbackRate` scales elapsed time (e.g. 2× advances twice as fast).
+- When there is no media (`currentStatus === null`), the derived position is `null` and the timer is idle.
+
+## Public API (full v4 parity)
+
+### Hook
+```ts
+// src/api/useStreamPosition.ts
+function useStreamPosition(interval?: number): number | null // default interval = 1 (second)
+```
+- Returns `null` when there is no active media; otherwise the ticking position in seconds.
+- Implemented with `useState` + `useEffect` over `subscribeProgress`, keyed on `interval` so a changed
+  interval re-subscribes. (Deliberately *not* `useSyncExternalStore`: a live, time-derived value has no
+  stable `getSnapshot` — the ticker pushes new values on each tick, which the `useState` setter absorbs.)
+
+### Imperative (RemoteMediaClient façade)
+```ts
+// src/api/RemoteMediaClient.ts
+onMediaProgressUpdated(
+  handler: (position: number, duration: number) => void,
+  interval?: number, // default 1 (second)
+): EventSubscription // { remove(): void }
+```
+- v4 signature preserved. **Difference from v4:** v5 supports **multiple** concurrent listeners via the
+  shared ticker (v4 allowed only one). Documented in the migration guide.
+
+## Timer lifecycle & arbitration
+
+- Timer starts when the **first** subscriber is added **and** playback is `playing`.
+- Timer stops when the **last** subscriber unsubscribes, when media clears (`currentStatus → null` on
+  session/media teardown), or when `playerState` leaves `playing`.
+- Play-state transitions are observed via the ticker's store subscription: entering `playing` (re)starts the
+  timer if subscribers exist; leaving `playing` stops it.
+- Interval arbitration: the active interval is `min(intervals of all current subscribers)`; recomputed on
+  every membership change; the timer is restarted at the new rate when it changes.
+- On teardown the media slice becomes `null`, the ticker emits nothing further, and both hooks return `null`.
+
+## Testing (pure TS, no native)
+
+Unit tests drive `subscribeProgress` / `CastStore` with a `FakeCastTransport` and an injected `now()`:
+
+- single subscriber: position advances by `interval * playbackRate` per tick while playing;
+- two subscribers with different intervals → exactly one timer at the min interval; both handlers invoked;
+- unsubscribe recomputes the min interval; last unsubscribe stops the timer;
+- resync-on-push: a status push mid-tick corrects the base/anchor (no accumulated drift);
+- pause freezes the value and stops the timer; resume restarts it;
+- VOD clamp: position never exceeds `duration`; live (`duration === 0`) is un-clamped;
+- `playbackRate` scaling (e.g. 2×);
+- session/media teardown → position `null`, timer stopped;
+- hook: `useStreamPosition(interval)` returns `null` with no media, ticks with media, re-subscribes on
+  interval change.
+
+## Scope / non-goals
+
+- **No native changes.** iOS and Android already push `MediaStatus`; the TS-derived approach needs nothing
+  more from native. (The bead title mentions "iOS + Android" for completeness — this design records that the
+  native side is already sufficient, so no Swift/Kotlin work is required.)
+- Not in this bead (remain in `v5-aug.5`): `customData` on non-`loadMedia` mutations; dropped v4 convenience
+  methods (`queueInsertAndPlayItem`, `setActiveMediaTracks` alias).
+- No hybrid native-interpolation ticking (considered and rejected as YAGNI).

--- a/docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
+++ b/docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md
@@ -135,3 +135,9 @@ Unit tests drive `subscribeProgress` / `CastStore` with a `FakeCastTransport` an
 - Not in this bead (remain in `v5-aug.5`): `customData` on non-`loadMedia` mutations; dropped v4 convenience
   methods (`queueInsertAndPlayItem`, `setActiveMediaTracks` alias).
 - No hybrid native-interpolation ticking (considered and rejected as YAGNI).
+
+## Implementation note (2026-07-01)
+
+Delivered in pure TS as designed: `ProgressTicker` + singleton, `useStreamPosition(interval)`,
+`RemoteMediaClient.onMediaProgressUpdated`. No native (Swift/Kotlin) changes were needed —
+the existing `MediaStatus` push stream is sufficient. All tests green via `yarn jest`.

--- a/src/api/RemoteMediaClient.ts
+++ b/src/api/RemoteMediaClient.ts
@@ -1,5 +1,7 @@
 import type { CastError, CastTransportApi } from '../transport/types'
 import type { CastStore } from '../state/CastStore'
+import type { EventSubscription } from './subscribeSelector'
+import { progressTicker } from '../state/progressTicker.singleton'
 import { MEDIA_SLICE_KEY, type MediaState } from '../state/media.slice'
 import type { MediaLoadRequest } from '../types/MediaLoadRequest'
 import type { MediaQueueItem } from '../types/MediaQueueItem'
@@ -121,6 +123,29 @@ export class RemoteMediaClient {
   getStreamPosition(): number | null {
     const status = this.getMediaStatus()
     return status ? status.streamPosition : null
+  }
+
+  /**
+   * Listen for ticking progress of the currently playing media. The handler
+   * receives `(position, duration)` in seconds, driven by a shared TS ticker
+   * (position advances locally while playing, resyncing on each status push).
+   *
+   * Unlike v4 (single listener), v5 supports multiple concurrent listeners;
+   * differing intervals share one timer at the smallest interval.
+   *
+   * @param handler called with `(position, duration)` on each update.
+   * @param interval update frequency in seconds (default `1`).
+   * @returns a subscription; call `remove()` to stop listening.
+   */
+  onMediaProgressUpdated(
+    handler: (position: number, duration: number) => void,
+    interval = 1
+  ): EventSubscription {
+    const unsubscribe = progressTicker.subscribe(() => {
+      const position = progressTicker.getPosition()
+      if (position !== null) handler(position, progressTicker.getDuration())
+    }, interval)
+    return { remove: unsubscribe }
   }
 
   // --- mutations (async; route to the transport, status streams back) ---

--- a/src/api/RemoteMediaClient.ts
+++ b/src/api/RemoteMediaClient.ts
@@ -133,6 +133,10 @@ export class RemoteMediaClient {
    * Unlike v4 (single listener), v5 supports multiple concurrent listeners;
    * differing intervals share one timer at the smallest interval.
    *
+   * Scoped to this handle's generation like every other read: a stale client
+   * returns a no-op subscription, and a live one auto-unsubscribes the instant
+   * its session ends, so it can never leak a later session's progress.
+   *
    * @param handler called with `(position, duration)` on each update.
    * @param interval update frequency in seconds (default `1`).
    * @returns a subscription; call `remove()` to stop listening.
@@ -141,7 +145,14 @@ export class RemoteMediaClient {
     handler: (position: number, duration: number) => void,
     interval = 1
   ): EventSubscription {
-    const unsubscribe = progressTicker.subscribe(() => {
+    if (!this.isActive) return { remove: () => {} }
+
+    let unsubscribe = () => {}
+    unsubscribe = progressTicker.subscribe(() => {
+      if (!this.isActive) {
+        unsubscribe()
+        return
+      }
       const position = progressTicker.getPosition()
       if (position !== null) handler(position, progressTicker.getDuration())
     }, interval)

--- a/src/api/__tests__/RemoteMediaClient.test.ts
+++ b/src/api/__tests__/RemoteMediaClient.test.ts
@@ -8,7 +8,33 @@ import type { MediaQueueItem } from '../../types/MediaQueueItem'
 import type { TextTrackStyle } from '../../types/TextTrackStyle'
 import { CastStore } from '../../state/CastStore'
 import type { MediaState } from '../../state/media.slice'
+import { castStore, castTransport } from '../../state/castStore.singleton'
 import { RemoteMediaClient } from '../RemoteMediaClient'
+
+// `RemoteMediaClient` now imports the singleton progress ticker, which
+// transitively pulls in the native `CastTransport` (unloadable under jest).
+// Swap the store singleton for a fake-backed one so the module — and every
+// test in this file — loads. Mirrors `mediaHooks.test.ts`.
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore: Store } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new Store(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+// The singleton ticker captures Date.now at module load — before
+// jest.useFakeTimers() — so its clock can't be advanced by the test. Inject a
+// controllable clock (a mock-prefixed name, permitted by jest's hoist plugin)
+// bound to the SAME mocked castStore.singleton the progress test drives.
+let mockNow = 0
+jest.mock('../../state/progressTicker.singleton', () => {
+  const { ProgressTicker } = require('../../state/progressTicker')
+  const { castStore: store } = require('../../state/castStore.singleton')
+  return { progressTicker: new ProgressTicker(store, () => mockNow) }
+})
 
 function device(id: string): Device {
   return {
@@ -297,5 +323,64 @@ describe('RemoteMediaClient.current — per-generation memoization', () => {
     const second = RemoteMediaClient.current(store, transport)
     expect(second).not.toBe(first)
     expect(second).not.toBeNull()
+  })
+})
+
+describe('RemoteMediaClient.onMediaProgressUpdated — shared ticker', () => {
+  // This suite drives the mocked singleton store (the one the shared ticker is
+  // bound to), not a local store, since onMediaProgressUpdated reads the
+  // process-wide progressTicker.
+  beforeAll(async () => {
+    await castStore.ready
+  })
+
+  it('ticks (position, duration) forward while playing, silent after remove', () => {
+    // Fake timers BEFORE the playing status: the ticker's setInterval is created
+    // on that push, so it must already be a fake timer to be advanceable.
+    jest.useFakeTimers()
+    mockNow = 0
+
+    const transport = castTransport as unknown as FakeCastTransport
+    transport.emitLifecycle({ type: 'started', session: session('rmc') })
+
+    const client = RemoteMediaClient.current(castStore, castTransport)
+    expect(client).not.toBeNull()
+
+    const calls: Array<[number, number]> = []
+    const sub = client!.onMediaProgressUpdated((p, d) => calls.push([p, d]), 1)
+
+    // Playing status anchored at mockNow=0: base position 0, duration 100.
+    transport.emitMediaStatus({
+      streamPosition: 0,
+      playerState: 'playing',
+      playbackRate: 1,
+      volume: 1,
+      isMuted: false,
+      queueItems: [],
+      mediaInfo: { contentUrl: 'x', streamDuration: 100 },
+    })
+
+    // The status push notifies once at the anchor time → position 0.
+    expect(calls).toEqual([[0, 100]])
+
+    // Advance the injected clock and the timer in lockstep: interval 1s over 2s
+    // fires twice, both observing mockNow=2000 → position 2 (0 + 2s × rate 1).
+    mockNow = 2000
+    jest.advanceTimersByTime(2000)
+
+    expect(calls.length).toBe(3)
+    const [lastPos, lastDur] = calls[calls.length - 1]!
+    expect(lastDur).toBe(100)
+    expect(lastPos).toBe(2)
+
+    // After remove, further ticks are silent (the shared timer is torn down).
+    const frozen = calls.length
+    sub.remove()
+    mockNow = 5000
+    jest.advanceTimersByTime(5000)
+    expect(calls.length).toBe(frozen)
+
+    transport.emitLifecycle({ type: 'ended' })
+    jest.useRealTimers()
   })
 })

--- a/src/api/__tests__/RemoteMediaClient.test.ts
+++ b/src/api/__tests__/RemoteMediaClient.test.ts
@@ -383,4 +383,85 @@ describe('RemoteMediaClient.onMediaProgressUpdated — shared ticker', () => {
     transport.emitLifecycle({ type: 'ended' })
     jest.useRealTimers()
   })
+
+  it('a stale client returns a no-op subscription (never a later session)', () => {
+    jest.useFakeTimers()
+    mockNow = 0
+    const transport = castTransport as unknown as FakeCastTransport
+
+    transport.emitLifecycle({ type: 'started', session: session('stale1') })
+    const client = RemoteMediaClient.current(castStore, castTransport)!
+    // The session ends → this handle is now stale.
+    transport.emitLifecycle({ type: 'ended' })
+    expect(client.isActive).toBe(false)
+
+    const calls: number[] = []
+    const sub = client.onMediaProgressUpdated((p) => calls.push(p), 1)
+
+    // A brand-new session starts playing; the stale handle must stay silent.
+    transport.emitLifecycle({ type: 'started', session: session('stale2') })
+    transport.emitMediaStatus({
+      streamPosition: 5,
+      playerState: 'playing',
+      playbackRate: 1,
+      volume: 1,
+      isMuted: false,
+      queueItems: [],
+      mediaInfo: { contentUrl: 'x', streamDuration: 100 },
+    })
+    mockNow = 3000
+    jest.advanceTimersByTime(3000)
+    expect(calls).toEqual([])
+
+    sub.remove() // no-op, safe to call
+    transport.emitLifecycle({ type: 'ended' })
+    jest.useRealTimers()
+  })
+
+  it('auto-unsubscribes once its own session ends, never leaking the next', () => {
+    jest.useFakeTimers()
+    mockNow = 0
+    const transport = castTransport as unknown as FakeCastTransport
+
+    transport.emitLifecycle({ type: 'started', session: session('live1') })
+    const client = RemoteMediaClient.current(castStore, castTransport)!
+
+    const calls: number[] = []
+    client.onMediaProgressUpdated((p) => calls.push(p), 1)
+    transport.emitMediaStatus({
+      streamPosition: 0,
+      playerState: 'playing',
+      playbackRate: 1,
+      volume: 1,
+      isMuted: false,
+      queueItems: [],
+      mediaInfo: { contentUrl: 'x', streamDuration: 100 },
+    })
+    mockNow = 1000
+    jest.advanceTimersByTime(1000)
+    const whileLive = calls.length
+    expect(whileLive).toBeGreaterThan(0)
+
+    // Its session ends: the teardown notification runs the callback once more,
+    // which sees the stale handle and self-unsubscribes.
+    transport.emitLifecycle({ type: 'ended' })
+
+    // A fresh session plays; the now-detached handler must not fire again.
+    transport.emitLifecycle({ type: 'started', session: session('live2') })
+    transport.emitMediaStatus({
+      streamPosition: 50,
+      playerState: 'playing',
+      playbackRate: 1,
+      volume: 1,
+      isMuted: false,
+      queueItems: [],
+      mediaInfo: { contentUrl: 'y', streamDuration: 100 },
+    })
+    mockNow = 5000
+    jest.advanceTimersByTime(4000)
+    expect(calls.length).toBe(whileLive)
+
+    transport.emitLifecycle({ type: 'ended' })
+    jest.useRealTimers()
+  })
 })

--- a/src/api/__tests__/mediaHooks.test.ts
+++ b/src/api/__tests__/mediaHooks.test.ts
@@ -166,4 +166,73 @@ describe('useStreamPosition — ticking', () => {
     })
     jest.useRealTimers()
   })
+
+  it('returns null when there is no media', async () => {
+    jest.useFakeTimers()
+    mockNow = 0
+    // The mocked singleton store persists between tests; a prior test may have
+    // left a session active. Force a clean no-media state before rendering.
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+
+    const observed: (number | null)[] = []
+    function Probe(): null {
+      observed.push(useStreamPosition(1))
+      return null
+    }
+
+    let root!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      root = TestRenderer.create(React.createElement(Probe))
+    })
+
+    expect(observed[observed.length - 1]).toBeNull()
+
+    act(() => {
+      root.unmount()
+    })
+    jest.useRealTimers()
+  })
+
+  it('re-subscribes when the interval changes', async () => {
+    jest.useFakeTimers()
+    mockNow = 0
+    const observed: (number | null)[] = []
+    function Probe({ interval }: { interval: number }): null {
+      observed.push(useStreamPosition(interval))
+      return null
+    }
+
+    let root!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      root = TestRenderer.create(React.createElement(Probe, { interval: 1 }))
+    })
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('ivl') })
+      transport.emitMediaStatus({ ...mediaStatus(30), playerState: 'playing' })
+    })
+
+    // Re-render with a new interval → the effect deps change, so it must tear
+    // down the old subscription and re-subscribe (not stay torn down).
+    await act(async () => {
+      root.update(React.createElement(Probe, { interval: 2 }))
+    })
+
+    // Advance the ticker's clock + fire the timer; the position must still be a
+    // live (non-null) value that ticked forward, proving re-subscription.
+    mockNow = 1000
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+
+    const last = observed[observed.length - 1]
+    expect(last).not.toBeNull()
+    expect(last).toBe(31)
+
+    act(() => {
+      root.unmount()
+    })
+    jest.useRealTimers()
+  })
 })

--- a/src/api/__tests__/mediaHooks.test.ts
+++ b/src/api/__tests__/mediaHooks.test.ts
@@ -22,6 +22,17 @@ jest.mock('../../state/castStore.singleton', () => {
   return { castStore: store, castTransport: transport }
 })
 
+// The singleton ticker captures Date.now at module load — before
+// jest.useFakeTimers() — so its clock can't be moved by the test. Inject a
+// controllable clock (a mock-prefixed name, permitted by jest's hoist plugin)
+// bound to the SAME mocked castStore.singleton the test already drives.
+let mockNow = 0
+jest.mock('../../state/progressTicker.singleton', () => {
+  const { ProgressTicker } = require('../../state/progressTicker')
+  const { castStore } = require('../../state/castStore.singleton')
+  return { progressTicker: new ProgressTicker(castStore, () => mockNow) }
+})
+
 const transport = castTransport as unknown as FakeCastTransport
 
 function device(id: string): Device {
@@ -116,6 +127,7 @@ describe('useStreamPosition — ticking', () => {
 
   it('advances between status pushes while playing', async () => {
     jest.useFakeTimers()
+    mockNow = 0
     const positions: (number | null)[] = []
     function Ticking(): null {
       positions.push(useStreamPosition(1))
@@ -138,12 +150,16 @@ describe('useStreamPosition — ticking', () => {
       })
     })
 
+    // Advance the ticker's clock, then fire the interval → derived position ticks.
+    mockNow = 1000
     act(() => {
       jest.advanceTimersByTime(1000)
     })
 
-    // The last observed position is >= the pushed base (it ticked forward).
-    expect(positions[positions.length - 1]!).toBeGreaterThanOrEqual(30)
+    // 30 (pushed base) + 1s × rate 1 = 31: it ticked strictly forward.
+    const last = positions[positions.length - 1]!
+    expect(last).toBeGreaterThan(30)
+    expect(last).toBe(31)
 
     act(() => {
       root.unmount()

--- a/src/api/__tests__/mediaHooks.test.ts
+++ b/src/api/__tests__/mediaHooks.test.ts
@@ -108,3 +108,46 @@ describe('media hooks — useSyncExternalStore wiring', () => {
     })
   })
 })
+
+describe('useStreamPosition — ticking', () => {
+  beforeAll(async () => {
+    await castStore.ready
+  })
+
+  it('advances between status pushes while playing', async () => {
+    jest.useFakeTimers()
+    const positions: (number | null)[] = []
+    function Ticking(): null {
+      positions.push(useStreamPosition(1))
+      return null
+    }
+
+    let root!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      root = TestRenderer.create(React.createElement(Ticking))
+    })
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('tick') })
+      transport.emitMediaStatus({
+        streamPosition: 30,
+        playbackRate: 1,
+        volume: 1,
+        isMuted: false,
+        queueItems: [],
+        playerState: 'playing',
+      })
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    // The last observed position is >= the pushed base (it ticked forward).
+    expect(positions[positions.length - 1]!).toBeGreaterThanOrEqual(30)
+
+    act(() => {
+      root.unmount()
+    })
+    jest.useRealTimers()
+  })
+})

--- a/src/api/useStreamPosition.ts
+++ b/src/api/useStreamPosition.ts
@@ -1,20 +1,23 @@
-import { useSyncExternalStore } from 'react'
-import { castStore } from '../state/castStore.singleton'
-import { MEDIA_SLICE_KEY, type MediaState } from '../state/media.slice'
+import { useEffect, useState } from 'react'
+import { progressTicker } from '../state/progressTicker.singleton'
 
 /**
- * Hook to retrieve the current stream position, in seconds.
+ * Hook returning the current stream position in seconds, ticking locally between
+ * receiver status pushes while playback is `playing`. Returns `null` when there
+ * is no active media.
  *
- * Driven by the media-status stream, so it updates whenever the receiver reports
- * a new status (not on a real-time client tick). Returns `null` when there is no
- * active media.
- *
+ * @param interval update interval in seconds (default `1`). Multiple subscribers
+ *   with differing intervals share a single timer at the smallest interval.
  * @returns the current position in seconds, or `null`.
  */
-export function useStreamPosition(): number | null {
-  return useSyncExternalStore(castStore.subscribe, () => {
-    const status =
-      castStore.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
-    return status ? status.streamPosition : null
-  })
+export function useStreamPosition(interval = 1): number | null {
+  const [position, setPosition] = useState<number | null>(() =>
+    progressTicker.getPosition()
+  )
+  useEffect(() => {
+    const update = () => setPosition(progressTicker.getPosition())
+    update()
+    return progressTicker.subscribe(update, interval)
+  }, [interval])
+  return position
 }

--- a/src/state/__tests__/media.slice.test.ts
+++ b/src/state/__tests__/media.slice.test.ts
@@ -174,7 +174,10 @@ describe('media slice', () => {
     // teardown event, not just `ended`.
     transport.emitLifecycle({ type: 'ended' })
     transport.emitLifecycle({ type: 'suspended' })
-    transport.emitLifecycle({ type: 'resumeFailed', error: { code: 'network' } })
+    transport.emitLifecycle({
+      type: 'resumeFailed',
+      error: { code: 'network' },
+    })
     expect(mediaState(store)).toBe(before)
   })
 })

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -58,7 +58,7 @@ describe('ProgressTicker — derivation', () => {
   it('freezes at streamPosition when not playing', async () => {
     const clock = makeClock()
     const { ticker, transport } = await makeTicker(clock.now)
-    const off = ticker.subscribe(() => {}) // activates the store subscription
+    const off = ticker.subscribe(() => {}) // store subscription is already live
     transport.emitLifecycle({ type: 'started', session: session('s1') })
     transport.emitMediaStatus(
       status({ streamPosition: 10, playerState: 'paused' })
@@ -150,6 +150,48 @@ describe('ProgressTicker — derivation', () => {
     clock.advance(2000)
     expect(ticker.getPosition()).toBe(14)
     off()
+  })
+
+  it('a late subscriber reads the live position, not a stale re-anchor', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    // Playback runs 30s with NO listener attached — the store subscription is
+    // lifetime-bound, so the anchor stays pinned to the status push at clock 0.
+    clock.advance(30000)
+
+    // The first listener attaches only now. Position must reflect real elapsed
+    // time (10 + 30 = 40), NOT re-anchor the wall clock to the pushed base (10).
+    const off = ticker.subscribe(() => {})
+    expect(ticker.getPosition()).toBe(40)
+    off()
+  })
+
+  it('resubscribe after the timer went idle does not jump backward', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    const off1 = ticker.subscribe(() => {})
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(15)
+
+    // Last subscriber leaves: the shared timer stops, but the anchor persists.
+    off1()
+    clock.advance(5000)
+
+    // Resubscribing 5s later keeps the position climbing (10 + 10 = 20) rather
+    // than resetting to the last-pushed base (10).
+    const off2 = ticker.subscribe(() => {})
+    expect(ticker.getPosition()).toBe(20)
+    off2()
   })
 })
 
@@ -250,15 +292,46 @@ describe('ProgressTicker — timer & arbitration', () => {
     expect(listener).toHaveBeenCalledTimes(1)
   })
 
+  it('clamps a tiny positive interval to the 0.25s floor (no busy loop)', async () => {
+    const { clock, ticker } = await playing()
+    const listener = jest.fn()
+    ticker.subscribe(listener, 0.001) // floored to 0.25s, not setInterval(fn, 1)
+
+    expect(jest.getTimerCount()).toBe(1)
+
+    // Just under the floor: no tick yet (an unclamped 1ms interval would have
+    // fired hundreds of times by now).
+    clock.advance(240)
+    jest.advanceTimersByTime(240)
+    expect(listener).not.toHaveBeenCalled()
+
+    // Crossing 250ms fires exactly once.
+    clock.advance(10)
+    jest.advanceTimersByTime(10)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not notify listeners on an unrelated store change', async () => {
+    const { ticker, transport } = await playing()
+    const listener = jest.fn()
+    ticker.subscribe(listener, 1)
+    // subscribe() does not itself notify; start from a clean slate.
+    listener.mockClear()
+
+    // Cast-state churn leaves the media slice untouched → no progress callback.
+    transport.emitState('connected')
+    expect(listener).not.toHaveBeenCalled()
+  })
+
   it('a second subscriber joining mid-play does NOT reanchor the position', async () => {
     const { clock, ticker } = await playing()
-    ticker.subscribe(jest.fn(), 1) // first subscriber anchors at clock 0
+    ticker.subscribe(jest.fn(), 1) // anchor was set by the status push at clock 0
 
     clock.advance(2000)
     expect(ticker.getPosition()).toBe(2)
 
-    // A second subscriber must NOT re-anchor (the `if (!this.storeUnsub)`
-    // guard means only the first subscriber anchors); position stays at 2.
+    // subscribe() never anchors (the anchor is owned by the lifetime-bound store
+    // subscription), so a second subscriber can't reset it; position stays at 2.
     ticker.subscribe(jest.fn(), 5)
     expect(ticker.getPosition()).toBe(2)
 

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -32,7 +32,11 @@ function status(over: Partial<MediaStatus> = {}): MediaStatus {
 // A controllable clock; ms since an arbitrary origin.
 function makeClock() {
   const state = { ms: 0 }
-  return { now: () => state.ms, advance: (ms: number) => (state.ms += ms), state }
+  return {
+    now: () => state.ms,
+    advance: (ms: number) => (state.ms += ms),
+    state,
+  }
 }
 
 async function makeTicker(now: () => number) {
@@ -56,7 +60,9 @@ describe('ProgressTicker — derivation', () => {
     const { ticker, transport } = await makeTicker(clock.now)
     const off = ticker.subscribe(() => {}) // activates the store subscription
     transport.emitLifecycle({ type: 'started', session: session('s1') })
-    transport.emitMediaStatus(status({ streamPosition: 10, playerState: 'paused' }))
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'paused' })
+    )
 
     clock.advance(5000)
     expect(ticker.getPosition()).toBe(10)
@@ -108,15 +114,41 @@ describe('ProgressTicker — derivation', () => {
     const { ticker, transport } = await makeTicker(clock.now)
     const off = ticker.subscribe(() => {})
     transport.emitLifecycle({ type: 'started', session: session('s1') })
-    transport.emitMediaStatus(status({ streamPosition: 10, playerState: 'playing' }))
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
 
     clock.advance(4000)
     expect(ticker.getPosition()).toBe(14)
 
     // Receiver reports 20 (e.g. after a seek); position tracks the new base.
-    transport.emitMediaStatus(status({ streamPosition: 20, playerState: 'playing' }))
+    transport.emitMediaStatus(
+      status({ streamPosition: 20, playerState: 'playing' })
+    )
     clock.advance(1000)
     expect(ticker.getPosition()).toBe(21)
+    off()
+  })
+
+  it('does not reanchor on an unrelated store change (media slice unchanged)', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    clock.advance(2000)
+    expect(ticker.getPosition()).toBe(12)
+
+    // Unrelated store change (cast-state) leaves the media slice untouched, so
+    // the `status === anchorStatus` guard must keep the ORIGINAL anchor: the
+    // position keeps advancing continuously rather than resetting to 12.
+    transport.emitState('connected')
+
+    clock.advance(2000)
+    expect(ticker.getPosition()).toBe(14)
     off()
   })
 })

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -152,3 +152,88 @@ describe('ProgressTicker — derivation', () => {
     off()
   })
 })
+
+describe('ProgressTicker — timer & arbitration', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.useRealTimers())
+
+  async function playing() {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 0, playerState: 'playing' })
+    )
+    return { clock, ticker, transport }
+  }
+
+  it('notifies a subscriber once per interval while playing', async () => {
+    const { clock, ticker } = await playing()
+    const listener = jest.fn()
+    ticker.subscribe(listener, 1)
+
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs ONE timer at the min interval for differing subscribers', async () => {
+    const { clock, ticker } = await playing()
+    const fast = jest.fn()
+    const slow = jest.fn()
+    ticker.subscribe(fast, 1)
+    ticker.subscribe(slow, 5)
+
+    // Min interval is 1s → both fire every second (tick-all policy).
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+    expect(fast).toHaveBeenCalledTimes(1)
+    expect(slow).toHaveBeenCalledTimes(1)
+    // Only one underlying interval exists.
+    expect(jest.getTimerCount()).toBe(1)
+  })
+
+  it('recomputes the min interval and stops on last unsubscribe', async () => {
+    const { ticker } = await playing()
+    const a = jest.fn()
+    const b = jest.fn()
+    const offA = ticker.subscribe(a, 1)
+    const offB = ticker.subscribe(b, 3)
+    expect(jest.getTimerCount()).toBe(1)
+
+    offA() // now only the 3s subscriber remains → timer restarts at 3s
+    expect(jest.getTimerCount()).toBe(1)
+
+    offB() // last one gone → timer stops
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('stops the timer when playback pauses and restarts on resume', async () => {
+    const { ticker, transport } = await playing()
+    ticker.subscribe(jest.fn(), 1)
+    expect(jest.getTimerCount()).toBe(1)
+
+    transport.emitMediaStatus(
+      status({ streamPosition: 5, playerState: 'paused' })
+    )
+    expect(jest.getTimerCount()).toBe(0)
+
+    transport.emitMediaStatus(
+      status({ streamPosition: 5, playerState: 'playing' })
+    )
+    expect(jest.getTimerCount()).toBe(1)
+  })
+
+  it('stops the timer and returns null on session teardown', async () => {
+    const { ticker, transport } = await playing()
+    ticker.subscribe(jest.fn(), 1)
+    expect(jest.getTimerCount()).toBe(1)
+
+    transport.emitLifecycle({ type: 'ended' })
+    expect(jest.getTimerCount()).toBe(0)
+    expect(ticker.getPosition()).toBeNull()
+  })
+})

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -1,0 +1,122 @@
+import { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import type { Device, SessionInfo } from '../../transport/types'
+import type { MediaStatus } from '../../types/MediaStatus'
+import { CastStore } from '../CastStore'
+import { ProgressTicker } from '../progressTicker'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+function status(over: Partial<MediaStatus> = {}): MediaStatus {
+  return {
+    streamPosition: 0,
+    playbackRate: 1,
+    volume: 1,
+    isMuted: false,
+    queueItems: [],
+    ...over,
+  }
+}
+
+// A controllable clock; ms since an arbitrary origin.
+function makeClock() {
+  const state = { ms: 0 }
+  return { now: () => state.ms, advance: (ms: number) => (state.ms += ms), state }
+}
+
+async function makeTicker(now: () => number) {
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  await store.ready
+  const ticker = new ProgressTicker(store, now)
+  return { transport, store, ticker }
+}
+
+describe('ProgressTicker — derivation', () => {
+  it('returns null when there is no media', async () => {
+    const clock = makeClock()
+    const { ticker } = await makeTicker(clock.now)
+    expect(ticker.getPosition()).toBeNull()
+    expect(ticker.getDuration()).toBe(0)
+  })
+
+  it('freezes at streamPosition when not playing', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {}) // activates the store subscription
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status({ streamPosition: 10, playerState: 'paused' }))
+
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(10)
+    off()
+  })
+
+  it('advances by elapsed × playbackRate while playing', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playbackRate: 2, playerState: 'playing' })
+    )
+
+    clock.advance(3000) // 3s real → 6s of media at 2×
+    expect(ticker.getPosition()).toBe(16)
+    off()
+  })
+
+  it('clamps to duration for VOD but leaves live un-clamped', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+
+    // VOD: streamDuration = 12 → clamp.
+    transport.emitMediaStatus(
+      status({
+        streamPosition: 10,
+        playerState: 'playing',
+        mediaInfo: { contentUrl: 'x', streamDuration: 12 },
+      })
+    )
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(12)
+
+    // Live: no streamDuration → un-clamped.
+    transport.emitMediaStatus(
+      status({ streamPosition: 100, playerState: 'playing' })
+    )
+    clock.advance(5000)
+    expect(ticker.getPosition()).toBe(105)
+    off()
+  })
+
+  it('resyncs the anchor on every status push (no drift)', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    const off = ticker.subscribe(() => {})
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(status({ streamPosition: 10, playerState: 'playing' }))
+
+    clock.advance(4000)
+    expect(ticker.getPosition()).toBe(14)
+
+    // Receiver reports 20 (e.g. after a seek); position tracks the new base.
+    transport.emitMediaStatus(status({ streamPosition: 20, playerState: 'playing' }))
+    clock.advance(1000)
+    expect(ticker.getPosition()).toBe(21)
+    off()
+  })
+})

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -236,4 +236,33 @@ describe('ProgressTicker — timer & arbitration', () => {
     expect(jest.getTimerCount()).toBe(0)
     expect(ticker.getPosition()).toBeNull()
   })
+
+  it('clamps a non-positive interval (no zero-delay busy loop)', async () => {
+    const { clock, ticker } = await playing()
+    const listener = jest.fn()
+    ticker.subscribe(listener, 0) // must be floored to 1s, not setInterval(fn, 0)
+
+    // Exactly one shared timer, running at the 1s floor.
+    expect(jest.getTimerCount()).toBe(1)
+
+    clock.advance(1000)
+    jest.advanceTimersByTime(1000)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('a second subscriber joining mid-play does NOT reanchor the position', async () => {
+    const { clock, ticker } = await playing()
+    ticker.subscribe(jest.fn(), 1) // first subscriber anchors at clock 0
+
+    clock.advance(2000)
+    expect(ticker.getPosition()).toBe(2)
+
+    // A second subscriber must NOT re-anchor (the `if (!this.storeUnsub)`
+    // guard means only the first subscriber anchors); position stays at 2.
+    ticker.subscribe(jest.fn(), 5)
+    expect(ticker.getPosition()).toBe(2)
+
+    clock.advance(1000)
+    expect(ticker.getPosition()).toBe(3)
+  })
 })

--- a/src/state/media.slice.ts
+++ b/src/state/media.slice.ts
@@ -68,7 +68,9 @@ export const mediaSlice: Slice<MediaState> = {
         // event without a session payload yields no live session.
         const live = event.event.session != null
         const next = live ? EMPTY_LIVE : EMPTY_IDLE
-        return state.currentStatus === null && state.live === live ? state : next
+        return state.currentStatus === null && state.live === live
+          ? state
+          : next
       }
       if (SESSION_TEARDOWN_TYPES.has(type)) {
         return state.currentStatus === null && !state.live ? state : EMPTY_IDLE

--- a/src/state/progressTicker.singleton.ts
+++ b/src/state/progressTicker.singleton.ts
@@ -1,0 +1,11 @@
+import { castStore } from './castStore.singleton'
+import { ProgressTicker } from './progressTicker'
+
+/**
+ * The process-wide progress ticker, bound to the {@link castStore} singleton.
+ * Imported only by the façade layer (`useStreamPosition`,
+ * `RemoteMediaClient.onMediaProgressUpdated`) — never by the ticker's own tests,
+ * which construct a {@link ProgressTicker} over a `FakeCastTransport`-backed
+ * store so this module's native import stays out of their path.
+ */
+export const progressTicker = new ProgressTicker(castStore)

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -47,8 +47,10 @@ export class ProgressTicker {
    * an unsubscribe.
    */
   subscribe(listener: Listener, interval = 1): () => void {
+    const safeInterval =
+      interval > 0 && Number.isFinite(interval) ? interval : 1
     const key = {}
-    this.subs.set(key, { listener, interval })
+    this.subs.set(key, { listener, interval: safeInterval })
     if (!this.storeUnsub) {
       this.storeUnsub = this.store.subscribe(() => this.onStoreChange())
       this.reanchor()
@@ -68,7 +70,7 @@ export class ProgressTicker {
     let pos = status.streamPosition
     if (status.playerState === 'playing' && status === this.anchorStatus) {
       pos +=
-        ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
+        ((this.now() - this.anchorTime) / 1000) * (status.playbackRate ?? 1)
     }
     const duration = this.getDuration()
     if (duration > 0) return Math.min(Math.max(pos, 0), duration)

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -51,7 +51,8 @@ export class ProgressTicker {
     let pos = status.streamPosition
     // Advance only when the *current* status is the one we anchored to.
     if (status.playerState === 'playing' && status === this.anchorStatus) {
-      pos += ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
+      pos +=
+        ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
     }
     const duration = this.getDuration()
     if (duration > 0) return Math.min(Math.max(pos, 0), duration)

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -14,6 +14,15 @@ interface Subscriber {
 }
 
 /**
+ * Floor for a subscriber's update interval (seconds). A tiny positive interval
+ * (e.g. `0.001`) would otherwise drive a near-busy timer; `interval` is public
+ * API, so clamp it. A non-positive/NaN interval still falls back to {@link
+ * DEFAULT_INTERVAL}.
+ */
+const MIN_INTERVAL = 0.25
+const DEFAULT_INTERVAL = 1
+
+/**
  * Derives a locally-ticking stream position from the store's media slice — pure
  * TS, no native timer. Position advances only while `playerState === 'playing'`,
  * resyncing to the receiver's reported `streamPosition` on every status push, so
@@ -22,13 +31,19 @@ interface Subscriber {
  * One shared `setInterval` runs at the smallest subscriber interval and only
  * while playing + subscribed; it is recomputed on every membership change and on
  * play-state transitions, and torn down when the last subscriber leaves.
+ *
+ * The store subscription, by contrast, is lifetime-bound (opened in the
+ * constructor, never closed): the anchor must resync on every media-status push
+ * even with zero listeners, so a listener attaching mid-playback — or a
+ * resubscribe after the timer went idle — reads a live position instead of
+ * re-anchoring the wall clock to a stale `streamPosition`. The ticker and its
+ * store are paired singletons, so this holds no resource open beyond the store.
  */
 export class ProgressTicker {
   private readonly store: TickerStoreView
   private readonly now: () => number
 
   private readonly subs = new Map<object, Subscriber>()
-  private storeUnsub: (() => void) | null = null
   private timer: ReturnType<typeof setInterval> | null = null
   private timerInterval = 0
 
@@ -38,6 +53,11 @@ export class ProgressTicker {
   constructor(store: TickerStoreView, now: () => number = Date.now) {
     this.store = store
     this.now = now
+    // Lifetime-bound (never unsubscribed): keep the anchor resynced to the last
+    // media-status push even while there are no listeners (see class doc). The
+    // ticker and its store are paired singletons, so this leaks nothing.
+    this.store.subscribe(() => this.onStoreChange())
+    this.reanchor()
   }
 
   /**
@@ -46,20 +66,19 @@ export class ProgressTicker {
    * media slice changes (a new status push, pause/resume, or teardown). Returns
    * an unsubscribe.
    */
-  subscribe(listener: Listener, interval = 1): () => void {
+  subscribe(listener: Listener, interval = DEFAULT_INTERVAL): () => void {
     const safeInterval =
-      interval > 0 && Number.isFinite(interval) ? interval : 1
+      interval > 0 && Number.isFinite(interval)
+        ? Math.max(interval, MIN_INTERVAL)
+        : DEFAULT_INTERVAL
     const key = {}
     this.subs.set(key, { listener, interval: safeInterval })
-    if (!this.storeUnsub) {
-      this.storeUnsub = this.store.subscribe(() => this.onStoreChange())
-      this.reanchor()
-    }
     this.reconcileTimer()
     return () => {
       if (!this.subs.delete(key)) return
-      if (this.subs.size === 0) this.teardown()
-      else this.reconcileTimer()
+      // The store subscription and anchor are lifetime-bound; only the shared
+      // timer is reconciled (and stopped once the last listener leaves).
+      this.reconcileTimer()
     }
   }
 
@@ -87,8 +106,13 @@ export class ProgressTicker {
   }
 
   private onStoreChange(): void {
+    // The ticker observes the whole store; ignore churn that leaves the media
+    // slice untouched (cast-state/device changes) so progress listeners only
+    // fire on their own interval, never off an unrelated store write. A real
+    // status push always yields a fresh `currentStatus` reference.
     const status = this.status()
-    if (status !== this.anchorStatus) this.reanchor()
+    if (status === this.anchorStatus) return
+    this.reanchor()
     this.reconcileTimer()
     this.notify()
   }
@@ -124,18 +148,5 @@ export class ProgressTicker {
 
   private notify(): void {
     for (const { listener } of [...this.subs.values()]) listener()
-  }
-
-  private teardown(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer)
-      this.timer = null
-    }
-    this.timerInterval = 0
-    if (this.storeUnsub) {
-      this.storeUnsub()
-      this.storeUnsub = null
-    }
-    this.anchorStatus = null
   }
 }

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -8,18 +8,30 @@ type TickerStoreView = Pick<CastStore, 'getSliceState' | 'subscribe'>
 /** A progress listener; pulls the current value via the ticker's getters. */
 type Listener = () => void
 
+interface Subscriber {
+  readonly listener: Listener
+  readonly interval: number
+}
+
 /**
  * Derives a locally-ticking stream position from the store's media slice — pure
  * TS, no native timer. Position advances only while `playerState === 'playing'`,
  * resyncing to the receiver's reported `streamPosition` on every status push, so
- * clock drift never accumulates. One shared `setInterval` runs at the smallest
- * subscriber interval and only while playing (added in Task 2).
+ * clock drift never accumulates.
+ *
+ * One shared `setInterval` runs at the smallest subscriber interval and only
+ * while playing + subscribed; it is recomputed on every membership change and on
+ * play-state transitions, and torn down when the last subscriber leaves.
  */
 export class ProgressTicker {
   private readonly store: TickerStoreView
   private readonly now: () => number
 
+  private readonly subs = new Map<object, Subscriber>()
   private storeUnsub: (() => void) | null = null
+  private timer: ReturnType<typeof setInterval> | null = null
+  private timerInterval = 0
+
   private anchorStatus: MediaStatus | null = null
   private anchorTime = 0
 
@@ -28,19 +40,24 @@ export class ProgressTicker {
     this.now = now
   }
 
-  /** Register a listener. Returns an unsubscribe. (Timer added in Task 2.) */
-  subscribe(_listener: Listener): () => void {
-    // Placeholder membership until Task 2 introduces the subscriber map + timer.
+  /**
+   * Register a progress listener at a given update interval (seconds, default 1).
+   * The listener is invoked on each shared tick while playing and whenever the
+   * media slice changes (a new status push, pause/resume, or teardown). Returns
+   * an unsubscribe.
+   */
+  subscribe(listener: Listener, interval = 1): () => void {
+    const key = {}
+    this.subs.set(key, { listener, interval })
     if (!this.storeUnsub) {
       this.storeUnsub = this.store.subscribe(() => this.onStoreChange())
       this.reanchor()
     }
+    this.reconcileTimer()
     return () => {
-      if (this.storeUnsub) {
-        this.storeUnsub()
-        this.storeUnsub = null
-      }
-      this.anchorStatus = null
+      if (!this.subs.delete(key)) return
+      if (this.subs.size === 0) this.teardown()
+      else this.reconcileTimer()
     }
   }
 
@@ -49,7 +66,6 @@ export class ProgressTicker {
     const status = this.status()
     if (!status) return null
     let pos = status.streamPosition
-    // Advance only when the *current* status is the one we anchored to.
     if (status.playerState === 'playing' && status === this.anchorStatus) {
       pos +=
         ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
@@ -71,10 +87,53 @@ export class ProgressTicker {
   private onStoreChange(): void {
     const status = this.status()
     if (status !== this.anchorStatus) this.reanchor()
+    this.reconcileTimer()
+    this.notify()
   }
 
   private reanchor(): void {
     this.anchorStatus = this.status()
     this.anchorTime = this.now()
+  }
+
+  private isPlaying(): boolean {
+    return this.status()?.playerState === 'playing'
+  }
+
+  private minInterval(): number {
+    let min = Infinity
+    for (const { interval } of this.subs.values()) min = Math.min(min, interval)
+    return min === Infinity ? 1 : min
+  }
+
+  private reconcileTimer(): void {
+    const want = this.subs.size > 0 && this.isPlaying()
+    const min = this.minInterval()
+    if (want && (this.timer === null || min !== this.timerInterval)) {
+      if (this.timer !== null) clearInterval(this.timer)
+      this.timerInterval = min
+      this.timer = setInterval(() => this.notify(), min * 1000)
+    } else if (!want && this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+      this.timerInterval = 0
+    }
+  }
+
+  private notify(): void {
+    for (const { listener } of [...this.subs.values()]) listener()
+  }
+
+  private teardown(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    this.timerInterval = 0
+    if (this.storeUnsub) {
+      this.storeUnsub()
+      this.storeUnsub = null
+    }
+    this.anchorStatus = null
   }
 }

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -23,6 +23,19 @@ const MIN_INTERVAL = 0.25
 const DEFAULT_INTERVAL = 1
 
 /**
+ * A monotonic millisecond clock for measuring *elapsed* media time. `Date.now()`
+ * tracks the wall clock, so an NTP sync or a manual time change mid-playback
+ * would corrupt the `now() - anchorTime` delta and snap the derived position
+ * backward/forward until the next status push. `performance.now()` is monotonic
+ * (RN ≥0.72 / Hermes expose it), so deltas stay well-behaved; fall back to
+ * `Date.now` only where it is somehow unavailable.
+ */
+const monotonicNow: () => number =
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? () => performance.now()
+    : () => Date.now()
+
+/**
  * Derives a locally-ticking stream position from the store's media slice — pure
  * TS, no native timer. Position advances only while `playerState === 'playing'`,
  * resyncing to the receiver's reported `streamPosition` on every status push, so
@@ -50,7 +63,7 @@ export class ProgressTicker {
   private anchorStatus: MediaStatus | null = null
   private anchorTime = 0
 
-  constructor(store: TickerStoreView, now: () => number = Date.now) {
+  constructor(store: TickerStoreView, now: () => number = monotonicNow) {
     this.store = store
     this.now = now
     // Lifetime-bound (never unsubscribed): keep the anchor resynced to the last

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -1,0 +1,79 @@
+import type { CastStore } from './CastStore'
+import { MEDIA_SLICE_KEY, type MediaState } from './media.slice'
+import type { MediaStatus } from '../types/MediaStatus'
+
+/** The store capability the ticker needs (both already on {@link CastStore}). */
+type TickerStoreView = Pick<CastStore, 'getSliceState' | 'subscribe'>
+
+/** A progress listener; pulls the current value via the ticker's getters. */
+type Listener = () => void
+
+/**
+ * Derives a locally-ticking stream position from the store's media slice — pure
+ * TS, no native timer. Position advances only while `playerState === 'playing'`,
+ * resyncing to the receiver's reported `streamPosition` on every status push, so
+ * clock drift never accumulates. One shared `setInterval` runs at the smallest
+ * subscriber interval and only while playing (added in Task 2).
+ */
+export class ProgressTicker {
+  private readonly store: TickerStoreView
+  private readonly now: () => number
+
+  private storeUnsub: (() => void) | null = null
+  private anchorStatus: MediaStatus | null = null
+  private anchorTime = 0
+
+  constructor(store: TickerStoreView, now: () => number = Date.now) {
+    this.store = store
+    this.now = now
+  }
+
+  /** Register a listener. Returns an unsubscribe. (Timer added in Task 2.) */
+  subscribe(_listener: Listener): () => void {
+    // Placeholder membership until Task 2 introduces the subscriber map + timer.
+    if (!this.storeUnsub) {
+      this.storeUnsub = this.store.subscribe(() => this.onStoreChange())
+      this.reanchor()
+    }
+    return () => {
+      if (this.storeUnsub) {
+        this.storeUnsub()
+        this.storeUnsub = null
+      }
+      this.anchorStatus = null
+    }
+  }
+
+  /** Current derived position in seconds, or `null` when there is no media. */
+  getPosition(): number | null {
+    const status = this.status()
+    if (!status) return null
+    let pos = status.streamPosition
+    // Advance only when the *current* status is the one we anchored to.
+    if (status.playerState === 'playing' && status === this.anchorStatus) {
+      pos += ((this.now() - this.anchorTime) / 1000) * (status.playbackRate || 1)
+    }
+    const duration = this.getDuration()
+    if (duration > 0) return Math.min(Math.max(pos, 0), duration)
+    return pos < 0 ? 0 : pos
+  }
+
+  /** Current media duration in seconds; `0` when unknown/live. */
+  getDuration(): number {
+    return this.status()?.mediaInfo?.streamDuration ?? 0
+  }
+
+  private status(): MediaStatus | null {
+    return this.store.getSliceState<MediaState>(MEDIA_SLICE_KEY).currentStatus
+  }
+
+  private onStoreChange(): void {
+    const status = this.status()
+    if (status !== this.anchorStatus) this.reanchor()
+  }
+
+  private reanchor(): void {
+    this.anchorStatus = this.status()
+    this.anchorTime = this.now()
+  }
+}


### PR DESCRIPTION
## Summary

Reintroduces a locally-**ticking** media `streamPosition` for v5 (Phase 4 follow-up, bead `v5-aug.6`), in **pure TS** — honouring the v5 "TS state machine + singleton transport, not stateful native objects" architecture. No native (Swift/Kotlin) changes: the existing `MediaStatus` push stream is sufficient.

- **`ProgressTicker`** (`src/state/progressTicker.ts`) — derives position = last `streamPosition` + elapsed × `playbackRate` while `playing`, resyncing to the receiver on every status push (no drift). One shared `setInterval` at the **min** subscriber interval, active only while playing + subscribed; torn down on last unsubscribe / pause / session teardown. Interval clamped against a busy-loop.
- **`useStreamPosition(interval = 1)`** — now ticks (was status-push only). Backward compatible: no-arg call still works.
- **`RemoteMediaClient.onMediaProgressUpdated(handler, interval = 1)`** — v4 signature preserved; unlike v4, v5 supports **multiple** concurrent listeners sharing one timer.

Both public APIs are thin wrappers over a singleton ticker; no timing logic duplicated.

### Design decisions (locked during brainstorming)
- TS-derived tick (not native GCK listener); min-interval **tick-all** arbitration; live streams **un-clamped**; timer **off while paused** (no frozen re-emits).

Spec + plan included: `docs/superpowers/specs/2026-07-01-media-progress-ticking-design.md`, `docs/superpowers/plans/2026-07-01-media-progress-ticking.md`.

### Bead reconciliation
Consolidates the interval-arbitration work that was duplicated across `v5-m3i` (T8, audited done + closed) and `v5-aug.5` item (1). Phase 3 epic `v5-8y8` closed in the process (both children complete).

## Test Plan
- [x] `yarn jest` — 8 suites, **114 tests** green (new `progressTicker` suite + hook/façade ticking tests via injected clock)
- [x] `yarn typescript` — clean
- [x] `prettier --check src/**/*.ts` — clean
- [ ] CI (Robolectric/emulator/XCTest unaffected — TS-only change)

## Known follow-up (filed as a bead under `v5-aug`)
Re-subscribe **anchor staleness**: the ticker anchors elapsed=0 against the last-pushed position, so a subscriber attaching after an idle gap under-reports until the next push (strictly better than the old non-ticking hook; self-corrects). Fix: request a fresh `MediaStatus` on first-subscriber attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media progress now advances smoothly between media-status updates while playback is active.
  * Added periodic progress callbacks via `onMediaProgressUpdated(handler, interval?)`.
  * `useStreamPosition(interval?)` now supports a configurable tick interval for smoother, continuous position updates.

* **Bug Fixes**
  * Progress correctly pauses when playback is paused and resumes when playing resumes.
  * Live playback no longer clamps unexpectedly; VOD progress is constrained to the stream duration.
  * Progress stops promptly after unsubscription, including for stale handles, and clears when playback ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->