### PR TITLE
feat(v5): Phase 5 Slice 5.1 — CastSession detail (v5-8me.2/.3/.4)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -3,6 +3,7 @@ package com.margelo.nitro.googlecast
 import android.os.Handler
 import android.os.Looper
 import androidx.mediarouter.media.MediaRouter
+import com.google.android.gms.cast.Cast
 import com.google.android.gms.cast.CastDevice
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.CastSession
@@ -26,6 +27,7 @@ import com.margelo.nitro.googlecast.converters.toGckMediaQueueItem
 import com.margelo.nitro.googlecast.converters.toGckMediaSeekOptions
 import com.margelo.nitro.googlecast.converters.toGckTextTrackStyle
 import com.margelo.nitro.googlecast.converters.toMediaStatus
+import com.margelo.nitro.googlecast.converters.toSessionInfo
 
 /**
  * Nitro implementation of the singleton Cast transport (Android), backed by the
@@ -64,6 +66,13 @@ class HybridCastTransport : HybridCastTransportSpec() {
   // are touched only on the main thread.
   private var mediaCallback: RemoteMediaClient.Callback? = null
   private var observedClient: RemoteMediaClient? = null
+
+  // The `Cast.Listener` currently registered for device-detail changes (volume/mute,
+  // application metadata/status, standby, active-input), plus the exact session it is
+  // registered on (so it is removed from the right instance across session changes). Both
+  // are touched only on the main thread — mirrors the media-callback discipline above.
+  private var castListener: Cast.Listener? = null
+  private var observedCastSession: CastSession? = null
 
   // In-flight media `PendingResult`s, so teardown can cancel them (and drop our settlement
   // closures). Main-thread only — no extra synchronization needed.
@@ -122,6 +131,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
       // no media listener attached. Attach to the live client now; the `observedClient` guard
       // keeps this idempotent against a later session callback.
       attachMediaCallback(currentSession?.remoteMediaClient)
+      attachCastListener(currentSession)
       promise.resolve(
         InitialSnapshot(cachedCastState, playServicesState(), readDevices(), sessionInfo(currentSession))
       )
@@ -182,6 +192,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
     runOnMain {
       detachObservers()
       detachMediaCallback()
+      detachCastListener()
       // Cancel any in-flight media requests; JS is going away so the promises need not settle.
       pendingResults.forEach { it.cancel() }
       pendingResults.clear()
@@ -236,6 +247,42 @@ class HybridCastTransport : HybridCastTransportSpec() {
       }
       castContext.sessionManager.endCurrentSession(stopCasting)
       promise.resolve(Unit)
+    }
+    return promise
+  }
+
+  // MARK: - device-level volume/mute (act on the CastSession, not the media stream)
+
+  override fun setDeviceVolume(volume: Double): Promise<Unit> = sessionCall { it.setVolume(volume) }
+
+  override fun setDeviceMuted(muted: Boolean): Promise<Unit> = sessionCall { it.setMute(muted) }
+
+  /**
+   * Re-resolves the active [CastSession] on the main thread (Invariant 1 — no cached handle),
+   * runs the `void`/throwing setter [op], and settles the promise. Rejects with `noSession`
+   * when none is active, and `failed` (+ the exception message) if [op] throws — `CastSession`
+   * setters throw `IOException` / `IllegalStateException`, both `Exception` subtypes.
+   *
+   * This is the session-level analogue of [mediaCall], which cannot be reused: media requests
+   * return a `PendingResult` that settles asynchronously, whereas these setters return `void`
+   * and signal failure only by throwing synchronously.
+   */
+  private fun sessionCall(op: (CastSession) -> Unit): Promise<Unit> {
+    val promise = Promise<Unit>()
+    runOnMain {
+      val session = sharedCastContextOrNull()?.sessionManager?.currentCastSession
+      if (session == null) {
+        promise.reject(
+          CastRejection(castRejectionJson("noSession", "No active Cast session.", null))
+        )
+        return@runOnMain
+      }
+      try {
+        op(session)
+        promise.resolve(Unit)
+      } catch (e: Exception) {
+        promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+      }
     }
     return promise
   }
@@ -406,6 +453,51 @@ class HybridCastTransport : HybridCastTransportSpec() {
     observedClient = null
   }
 
+  /**
+   * Register the device-detail listener on [session], replacing any previous registration.
+   * Each callback re-reads a fresh `SessionInfo` and emits the matching lifecycle event so the
+   * store's device detail (volume/mute, app metadata/status, standby, active-input) stays live.
+   * Mirrors [attachMediaCallback]: nullable session + `observedCastSession` idempotency guard.
+   */
+  private fun attachCastListener(session: CastSession?) {
+    if (session == null || observedCastSession === session) return
+    detachCastListener()
+    val listener =
+      object : Cast.Listener() {
+        override fun onVolumeChanged() = emitDetail(SessionEventType.DEVICESTATUSCHANGED)
+        override fun onApplicationStatusChanged() = emitDetail(SessionEventType.DEVICESTATUSCHANGED)
+        // Fully-qualified param type: a bare `ApplicationMetadata` binds to the same-package Nitro
+        // struct and would silently fail to override the GCK callback.
+        override fun onApplicationMetadataChanged(
+          applicationMetadata: com.google.android.gms.cast.ApplicationMetadata?
+        ) = emitDetail(SessionEventType.DEVICESTATUSCHANGED)
+        override fun onStandbyStateChanged(standbyState: Int) =
+          emitDetail(SessionEventType.STANDBYSTATECHANGED)
+        override fun onActiveInputStateChanged(activeInputState: Int) =
+          emitDetail(SessionEventType.ACTIVEINPUTSTATECHANGED)
+      }
+    session.addCastListener(listener)
+    castListener = listener
+    observedCastSession = session
+  }
+
+  private fun detachCastListener() {
+    val listener = castListener ?: return
+    observedCastSession?.removeCastListener(listener)
+    castListener = null
+    observedCastSession = null
+  }
+
+  /**
+   * Emits [type] carrying a fresh full [SessionInfo] read from the *current* session (Invariant 1
+   * — re-resolved, not the closed-over handle from `attachCastListener`). A teardown race that
+   * nulls the session emits a null `sessionInfo`, consistent with how `ENDED` already emits null.
+   */
+  private fun emitDetail(type: SessionEventType) {
+    val session = sharedCastContextOrNull()?.sessionManager?.currentCastSession
+    emit(type, session = sessionInfo(session))
+  }
+
   // Queue/track IDs and indices cross the bridge as `Double`. A bare `toInt()` / `toLong()`
   // silently narrows NaN, ±Inf, fractional, and out-of-range values — quietly targeting the
   // *wrong* item — so validate before converting. Thrown from inside a `mediaCall` op lambda,
@@ -456,6 +548,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
         emit(SessionEventType.STARTING, deviceId = session.castDevice?.deviceId)
       override fun onSessionStarted(session: CastSession, sessionId: String) {
         attachMediaCallback(session.remoteMediaClient)
+        attachCastListener(session)
         emit(SessionEventType.STARTED, session = sessionInfo(session, sessionId))
       }
       override fun onSessionStartFailed(session: CastSession, error: Int) =
@@ -464,6 +557,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
         emit(SessionEventType.ENDING, session = sessionInfo(session))
       override fun onSessionEnded(session: CastSession, error: Int) {
         detachMediaCallback()
+        detachCastListener()
         emit(
           SessionEventType.ENDED,
           error = if (error != 0) castErrorFromStatusCode(error, null) else null
@@ -473,12 +567,14 @@ class HybridCastTransport : HybridCastTransportSpec() {
         emit(SessionEventType.RESUMING, sessionId = sessionId)
       override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
         attachMediaCallback(session.remoteMediaClient)
+        attachCastListener(session)
         emit(SessionEventType.RESUMED, session = sessionInfo(session))
       }
       override fun onSessionResumeFailed(session: CastSession, error: Int) =
         emit(SessionEventType.RESUMEFAILED, error = castErrorFromStatusCode(error, null))
       override fun onSessionSuspended(session: CastSession, reason: Int) {
         detachMediaCallback()
+        detachCastListener()
         emit(SessionEventType.SUSPENDED, reason = suspendReason(reason))
       }
     }
@@ -509,11 +605,8 @@ class HybridCastTransport : HybridCastTransportSpec() {
       .toTypedArray()
   }
 
-  private fun sessionInfo(session: CastSession?, sessionId: String? = null): SessionInfo? {
-    if (session == null) return null
-    val device = session.castDevice ?: return null
-    return SessionInfo(sessionId ?: session.sessionId ?: "", device.toDevice())
-  }
+  private fun sessionInfo(session: CastSession?, sessionId: String? = null): SessionInfo? =
+    session?.toSessionInfo(sessionId)
 
   private fun playServicesState(): PlayServicesState {
     val context = NitroModules.applicationContext ?: return PlayServicesState.INVALID

--- a/android/src/main/java/com/margelo/nitro/googlecast/converters/CastSession+toSessionInfo.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/converters/CastSession+toSessionInfo.kt
@@ -1,0 +1,50 @@
+package com.margelo.nitro.googlecast.converters
+
+import com.google.android.gms.cast.framework.CastSession
+import com.margelo.nitro.googlecast.ActiveInputState
+import com.margelo.nitro.googlecast.SessionInfo
+import com.margelo.nitro.googlecast.StandbyState
+
+/**
+ * Builds a fully-populated [SessionInfo] from a live [CastSession].
+ *
+ * Returns `null` when the session has no `castDevice` yet (preserves the prior
+ * `sessionInfo` contract — a device is the minimum a `SessionInfo` needs).
+ *
+ * Progressive enrichment: every device-detail getter on `CastSession`
+ * (`getVolume`/`isMute`/`getApplicationMetadata`/`getApplicationStatus`/
+ * `getStandbyState`/`getActiveInputState`) throws `IllegalStateException` until the
+ * session is fully connected, so each is read through the narrow [readWhenConnected]
+ * guard → `null`. A `STARTED` event may therefore carry null detail that a later
+ * `Cast.Listener` callback (e.g. `onVolumeChanged`) backfills.
+ *
+ * Semantic distinction: a *thrown* getter → `null` ("can't read yet"); a getter that
+ * *returns* `STANDBY_STATE_UNKNOWN`/`-1` → [StandbyState.UNKNOWN] ("connected, device
+ * reports unknown"). The two are deliberately different.
+ */
+internal fun CastSession.toSessionInfo(sessionId: String? = null): SessionInfo? {
+  val device = castDevice ?: return null
+  return SessionInfo(
+    sessionId = sessionId ?: this.sessionId ?: "",
+    device = device.toDevice(),
+    applicationMetadata = readWhenConnected { applicationMetadata }?.toApplicationMetadata(),
+    applicationStatus = readWhenConnected { applicationStatus },
+    deviceVolume = readWhenConnected { volume },
+    deviceMuted = readWhenConnected { isMute },
+    standbyState = readWhenConnected { standbyState }?.let { StandbyState.fromGckStandbyState(it) },
+    activeInputState =
+      readWhenConnected { activeInputState }?.let { ActiveInputState.fromGckActiveInputState(it) }
+  )
+}
+
+/**
+ * Runs [block] and maps its `IllegalStateException` (thrown by `CastSession` detail getters
+ * before the session is connected) to `null`. Local to this converter so `Hybrid*` stays free
+ * of read-guard clutter.
+ */
+private inline fun <T> readWhenConnected(block: () -> T): T? =
+  try {
+    block()
+  } catch (e: IllegalStateException) {
+    null
+  }

--- a/android/src/test/java/com/margelo/nitro/googlecast/converters/ApplicationMetadataConverterTest.kt
+++ b/android/src/test/java/com/margelo/nitro/googlecast/converters/ApplicationMetadataConverterTest.kt
@@ -1,0 +1,69 @@
+package com.margelo.nitro.googlecast.converters
+
+import com.margelo.nitro.googlecast.ApplicationMetadata
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Parity test for the ApplicationMetadata struct↔GCK converter (Android side of T1d).
+ *
+ * `ApplicationMetadata` becomes a *bridged* struct once it is nested in `SessionInfo`, so its
+ * app-facing reverse converter needs coverage. Mirrors `StandbyStateConverterTest` style: build
+ * a `GckApplicationMetadata` via the reflection test-seam (`toGckApplicationMetadata`), run the
+ * real reverse (`toApplicationMetadata`), and assert the round trip.
+ *
+ * Reconciliation reality the DRAFT `fixtures/converters/applicationMetadata.json` flagged:
+ * `getImages()` is deprecated and returns `null` in play-services-cast 22.x, so `images` is
+ * ALWAYS `[]` on Android regardless of input — the seam cannot represent images either. The
+ * fixture's `"full"` case still lists a populated `expectedRoundTrip.images`, which this test
+ * proves wrong; see the reported follow-up.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class ApplicationMetadataConverterTest {
+
+  @Test
+  fun reverseRoundTripPreservesScalarsAndNamespacesButDropsImages() {
+    val input =
+      ApplicationMetadata(
+        applicationId = "ABCD1234",
+        images = emptyArray(),
+        name = "My Cast App",
+        namespaces = arrayOf("urn:x-cast:com.example.custom", "urn:x-cast:com.google.cast.media")
+      )
+
+    val actual = input.toGckApplicationMetadata().toApplicationMetadata()
+
+    assertEquals("applicationId", "ABCD1234", actual.applicationId)
+    assertEquals("name", "My Cast App", actual.name)
+    assertArrayEquals(
+      "namespaces",
+      arrayOf("urn:x-cast:com.example.custom", "urn:x-cast:com.google.cast.media"),
+      actual.namespaces
+    )
+    assertTrue("images always [] on Android (getImages deprecated in 22.x)", actual.images.isEmpty())
+  }
+
+  @Test
+  fun minimalRoundTripEmptyNamespacesAndImages() {
+    val input =
+      ApplicationMetadata(
+        applicationId = "X1",
+        images = emptyArray(),
+        name = "App",
+        namespaces = emptyArray()
+      )
+
+    val actual = input.toGckApplicationMetadata().toApplicationMetadata()
+
+    assertEquals("applicationId", "X1", actual.applicationId)
+    assertEquals("name", "App", actual.name)
+    assertTrue("namespaces empty", actual.namespaces.isEmpty())
+    assertTrue("images empty", actual.images.isEmpty())
+  }
+}

--- a/docs/guides/migrating-v4-to-v5.md
+++ b/docs/guides/migrating-v4-to-v5.md
@@ -70,10 +70,32 @@ session operation on it throws/rejects `CastError` `noSession` _before_ anything
 crosses the native bridge, instead of crashing on a freed native object. Re-read
 `getCurrentCastSession()` to get the current session.
 
+## `CastSession` device detail is now synchronous
+
+`getVolume()`, `isMute()`, `getApplicationMetadata()`, `getApplicationStatus()`,
+`getStandbyState()`, and `getActiveInputState()` **return their value directly**
+instead of a `Promise` — they read the pushed session state from the store cache
+rather than crossing the bridge. Drop the `await`:
+
+```diff
+- const volume = await castSession.getVolume()
++ const volume = castSession.getVolume()
+```
+
+`setVolume()` / `setMute()` still return a `Promise` (they mutate the device),
+and — unlike v4, where `setVolume`/`setMute` did not resolve — they now settle
+when the request completes. They control the **device** volume/mute; for the
+media stream use `castSession.getClient()` →
+`setStreamVolume()` / `setStreamMuted()`. `onStandbyStateChanged` /
+`onActiveInputStateChanged` are unchanged from v4. `getClient()` now returns
+`null` when there is no live session (consistent with `useRemoteMediaClient`),
+so guard the result (`getClient()?.play()`).
+
 ## Deferred to later phases
 
 - `CastContext.showCastDialog()` / `showExpandedControls()` /
   `showIntroductoryOverlay()` / `showPlayServicesErrorDialog()` — **Phase 6**
   (they depend on the `CastButton` / cast activity).
-- `CastSession` volume / mute / `getClient()` — **Phase 5**.
+- Custom channels (`CastSession.addChannel` / `CastChannel`) — **Phase 5**
+  (slice 5.2).
 - Web / Chrome sender support — **Phase 8**.

--- a/example/ios/CastExample.xcodeproj/project.pbxproj
+++ b/example/ios/CastExample.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1668586AFE5EA5F6F2E7AE4C /* mediaInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = 56207C6DECEBF951ADFC44D5 /* mediaInfo.json */; };
 		187464540DC0627857A7D455 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 779854B72D9EB90F8D75DE24 /* Foundation.framework */; };
 		22EFC52CA9BDBE7206B9BBBB /* StateEnumConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ECD13393927F54CD7574E81 /* StateEnumConverterTests.swift */; };
+		3644FCF70720785683137ADB /* DeviceStatusListenerSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66E907FAE7BB1E54C860CA8 /* DeviceStatusListenerSelectorTests.swift */; };
 		3793168C11FD428477BD36D2 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0BC692AE34376D15117AB1 /* ObjCExceptionCatcher.m */; };
 		3A54B274C6391B2DF2F044B7 /* MediaLiveSeekableRangeConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6AC5B7F5FF4768DB12274F /* MediaLiveSeekableRangeConverterTests.swift */; };
 		458EC749E8545D5D14045EDF /* VideoInfoConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A304778A69B66DF7C7B92C51 /* VideoInfoConverterTests.swift */; };
@@ -98,6 +99,7 @@
 		AF59CECC66765DA0E4BBEAE4 /* NitroGoogleCastTests-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NitroGoogleCastTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B26E6F8FA09FA976940564B8 /* mediaLiveSeekableRange.json */ = {isa = PBXFileReference; includeInIndex = 1; name = mediaLiveSeekableRange.json; path = ../../fixtures/converters/mediaLiveSeekableRange.json; sourceTree = "<group>"; };
 		BE0BC692AE34376D15117AB1 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
+		C66E907FAE7BB1E54C860CA8 /* DeviceStatusListenerSelectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceStatusListenerSelectorTests.swift; sourceTree = "<group>"; };
 		CD5368DB3979F7BED0E02B18 /* webImage.json */ = {isa = PBXFileReference; includeInIndex = 1; name = webImage.json; path = ../../fixtures/converters/webImage.json; sourceTree = "<group>"; };
 		D238C1D4072D586851C1CAC7 /* mediaMetadata.json */ = {isa = PBXFileReference; includeInIndex = 1; name = mediaMetadata.json; path = ../../fixtures/converters/mediaMetadata.json; sourceTree = "<group>"; };
 		D7B3B0F935E6A6194186A0A6 /* mediaQueueItem.json */ = {isa = PBXFileReference; includeInIndex = 1; name = mediaQueueItem.json; path = ../../fixtures/converters/mediaQueueItem.json; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				5F6AC5B7F5FF4768DB12274F /* MediaLiveSeekableRangeConverterTests.swift */,
 				0EAE69B317C350F01C826A60 /* MediaStatusConverterTests.swift */,
 				2ECD13393927F54CD7574E81 /* StateEnumConverterTests.swift */,
+				C66E907FAE7BB1E54C860CA8 /* DeviceStatusListenerSelectorTests.swift */,
 			);
 			name = NitroGoogleCastTests;
 			path = NitroGoogleCastTests;
@@ -483,6 +486,7 @@
 				3A54B274C6391B2DF2F044B7 /* MediaLiveSeekableRangeConverterTests.swift in Sources */,
 				CE9BA8E4E6CB702EA00ACDC4 /* MediaStatusConverterTests.swift in Sources */,
 				22EFC52CA9BDBE7206B9BBBB /* StateEnumConverterTests.swift in Sources */,
+				3644FCF70720785683137ADB /* DeviceStatusListenerSelectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/NitroGoogleCastTests/DeviceStatusListenerSelectorTests.swift
+++ b/example/ios/NitroGoogleCastTests/DeviceStatusListenerSelectorTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import NitroGoogleCast
+
+/// Guards the `GCKCastDeviceStatusListener` selector wiring in
+/// `CastDeviceStatusListener`.
+///
+/// The two callbacks are *optional* protocol methods bridged from Objective-C: a
+/// Swift signature that does not match the requirement compiles clean but is
+/// assigned a *different* Obj-C selector, so GCK's `respondsToSelector:` never
+/// finds it and the event silently never fires. The build cannot catch this — it
+/// is exactly the "compiles-clean-but-silent" hazard the transport header warns
+/// about. These assertions pin the runtime selectors to the ones GCK actually
+/// calls (`castSession:didReceiveStandbyStatus:` /
+/// `castSession:didReceiveActiveInputStatus:`), so a future signature drift or a
+/// GCK-version rename fails here instead of going dark on-device.
+final class DeviceStatusListenerSelectorTests: XCTestCase {
+  func testRespondsToDeviceStatusSelectors() {
+    // `instancesRespond(to:)` is a class-level query — it needs only the type
+    // (reachable via `@testable import`), not an instance, so the test stays
+    // decoupled from the listener's initializer.
+    XCTAssertTrue(
+      CastDeviceStatusListener.instancesRespond(
+        to: NSSelectorFromString("castSession:didReceiveStandbyStatus:")),
+      "standby-status callback is not wired to its GCK selector — it will silently never fire")
+    XCTAssertTrue(
+      CastDeviceStatusListener.instancesRespond(
+        to: NSSelectorFromString("castSession:didReceiveActiveInputStatus:")),
+      "active-input callback is not wired to its GCK selector — it will silently never fire")
+  }
+}

--- a/ios/NitroGoogleCast/CastDeviceStatusListener.swift
+++ b/ios/NitroGoogleCast/CastDeviceStatusListener.swift
@@ -1,0 +1,45 @@
+import Foundation
+import GoogleCast
+import NitroModules
+
+/// Forwards `GCKCastDeviceStatusListener` standby / active-input status changes
+/// to a closure as `SessionLifecycleEvent`s.
+///
+/// This is a *different* GCK protocol from `GCKSessionManagerListener`: standby
+/// and active-input changes are pushed only to listeners registered directly on
+/// the `GCKCastSession` via `addDeviceStatusListener:` — the session manager
+/// never delivers them. GCK retains device-status listeners weakly, so the
+/// transport owns the single strong reference and attaches/detaches it across the
+/// session lifecycle (mirrors `CastRemoteMediaClientListener`).
+///
+/// Every event carries a full fresh `sessionInfo` built from the `castSession`
+/// GCK hands us (Invariant 1 forbids caching a handle, not using the argument).
+///
+/// These are *optional* protocol methods — a wrong bridged Swift signature
+/// compiles clean and silently never fires. The two signatures below are pinned
+/// against the installed GCK headers; real firing is device-gated (needs a
+/// physical Cast device).
+final class CastDeviceStatusListener: NSObject, GCKCastDeviceStatusListener {
+  private let onEvent: (SessionLifecycleEvent) -> Void
+
+  init(onEvent: @escaping (SessionLifecycleEvent) -> Void) {
+    self.onEvent = onEvent
+    super.init()
+  }
+
+  func castSession(_ castSession: GCKCastSession, didReceive standbyStatus: GCKStandbyStatus) {
+    onEvent(
+      SessionLifecycleEvent(
+        type: .standbystatechanged, session: HybridCastTransport.sessionInfo(castSession),
+        error: nil, sessionId: nil, deviceId: nil, reason: nil))
+  }
+
+  func castSession(
+    _ castSession: GCKCastSession, didReceive activeInputStatus: GCKActiveInputStatus
+  ) {
+    onEvent(
+      SessionLifecycleEvent(
+        type: .activeinputstatechanged, session: HybridCastTransport.sessionInfo(castSession),
+        error: nil, sessionId: nil, deviceId: nil, reason: nil))
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -47,6 +47,13 @@ final class HybridCastTransport: HybridCastTransportSpec {
   private weak var attachedMediaClient: GCKRemoteMediaClient?
   private var pendingRequests: Set<CastRequestDelegate> = []
 
+  // Device-status (standby / active-input) transport state — same ownership model
+  // as the media listener above. `deviceStatusListener` is the single strong
+  // owner of the GCK adapter (GCK holds it weakly); `attachedStatusSession` tracks
+  // which cast session it is bound to so re-resolution never double-attaches.
+  private var deviceStatusListener: CastDeviceStatusListener?
+  private weak var attachedStatusSession: GCKCastSession?
+
   private var cachedCastState: CastState = .notconnected
   private var cachedDiscovering = false
   private var cachedPassiveScan = false
@@ -84,8 +91,10 @@ final class HybridCastTransport: HybridCastTransportSpec {
       let context = GCKCastContext.sharedInstance()
       self.attachObservers(context)
       // If a session was already current before we subscribed, bind the media
-      // listener now so status updates flow without waiting for the next start.
+      // and device-status listeners now so updates flow without waiting for the
+      // next start.
       self.attachMediaListener()
+      self.attachDeviceStatusListener()
 
       self.cachedCastState = Self.mapState(context.castState)
       self.cachedPassiveScan = context.discoveryManager.passiveScan
@@ -122,9 +131,13 @@ final class HybridCastTransport: HybridCastTransportSpec {
 
     let session = CastSessionListener(
       onEvent: { [weak self] event in self?.onLifecycle?(event) },
-      onSessionActive: { [weak self] in self?.attachMediaListener() },
+      onSessionActive: { [weak self] in
+        self?.attachMediaListener()
+        self?.attachDeviceStatusListener()
+      },
       onSessionInactive: { [weak self] in
         self?.detachMediaListener()
+        self?.detachDeviceStatusListener()
         self?.flushPendingRequests(code: "interrupted", message: "The Cast session ended.")
       })
     context.sessionManager.add(session)
@@ -155,8 +168,10 @@ final class HybridCastTransport: HybridCastTransportSpec {
       guard let self else { return }
       self.detachObservers()
       self.detachMediaListener()
+      self.detachDeviceStatusListener()
       self.flushPendingRequests(code: "interrupted", message: "The Cast transport was disposed.")
       self.mediaStatusListener = nil
+      self.deviceStatusListener = nil
       self.onState = nil
       self.onDevices = nil
       self.onLifecycle = nil
@@ -204,6 +219,16 @@ final class HybridCastTransport: HybridCastTransportSpec {
       }
     }
     return promise
+  }
+
+  // MARK: - device volume / mute (route to GCKCastSession — Invariant 1)
+
+  func setDeviceVolume(volume: Double) throws -> Promise<Void> {
+    withCastSession { $0.setDeviceVolume(Float(volume)) }
+  }
+
+  func setDeviceMuted(muted: Bool) throws -> Promise<Void> {
+    withCastSession { $0.setDeviceMuted(muted) }
   }
 
   // MARK: - media transport (route to GCKRemoteMediaClient — Invariant 1)
@@ -330,6 +355,35 @@ final class HybridCastTransport: HybridCastTransportSpec {
     return promise
   }
 
+  /// Sibling of `withClient` for session-level (non-media) GCK requests:
+  /// re-resolves the current `GCKCastSession` on the main thread per call (never
+  /// caches a handle — Invariant 1), runs `work` to issue the `GCKRequest`, and
+  /// tracks it for exactly-once settlement (so teardown rejects it). No cast
+  /// session → reject `noSession`; disposed before the block runs → `interrupted`.
+  private func withCastSession(
+    _ work: @escaping (GCKCastSession) -> GCKRequest
+  ) -> Promise<Void> {
+    let promise = Promise<Void>()
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        // Disposed before this block ran — settle so the caller never hangs.
+        promise.reject(
+          withError: castRejection(
+            code: "interrupted", message: "The Cast transport was disposed.", nativeCode: nil))
+        return
+      }
+      guard let session = GCKCastContext.sharedInstance().sessionManager.currentCastSession else {
+        promise.reject(
+          withError: castRejection(
+            code: "noSession", message: "There is no active Cast session.", nativeCode: nil))
+        return
+      }
+      let request = work(session)
+      self.track(request, promise)
+    }
+    return promise
+  }
+
   private func track(_ request: GCKRequest, _ promise: Promise<Void>) {
     let delegate = CastRequestDelegate(promise: promise) { [weak self] settled in
       self?.pendingRequests.remove(settled)
@@ -381,6 +435,31 @@ final class HybridCastTransport: HybridCastTransportSpec {
       client.remove(listener)
     }
     attachedMediaClient = nil
+  }
+
+  /// Bind the device-status listener to the current cast session. Idempotent for
+  /// a given session; re-resolves the session per call (Invariant 1). Main thread.
+  /// Mirrors `attachMediaListener`.
+  private func attachDeviceStatusListener() {
+    guard let session = GCKCastContext.sharedInstance().sessionManager.currentCastSession
+    else { return }
+    guard attachedStatusSession !== session else { return }
+
+    let listener =
+      deviceStatusListener
+      ?? CastDeviceStatusListener { [weak self] event in self?.onLifecycle?(event) }
+    deviceStatusListener = listener
+
+    if let previous = attachedStatusSession { previous.remove(listener) }
+    session.add(listener)
+    attachedStatusSession = session
+  }
+
+  private func detachDeviceStatusListener() {
+    if let session = attachedStatusSession, let listener = deviceStatusListener {
+      session.remove(listener)
+    }
+    attachedStatusSession = nil
   }
 
   /// Reject every still-pending media request. Used on session end / teardown so a
@@ -442,9 +521,24 @@ final class HybridCastTransport: HybridCastTransportSpec {
     return nil
   }
 
-  fileprivate static func sessionInfo(_ session: GCKSession?) -> SessionInfo? {
+  /// Build the generated `SessionInfo` from a GCK session. `internal` (not
+  /// `fileprivate`) so the separate-file `CastDeviceStatusListener` can reuse it.
+  /// The six detail fields are cast-only, so they populate only when the session
+  /// is a `GCKCastSession`; a plain `GCKSession` leaves them `nil`. Reads the
+  /// current values off the handle GCK hands us — never a cached one (Invariant 1).
+  internal static func sessionInfo(_ session: GCKSession?) -> SessionInfo? {
     guard let session else { return nil }
-    return SessionInfo(sessionId: session.sessionID ?? "", device: session.device.toDevice())
+    let castSession = session as? GCKCastSession
+    return SessionInfo(
+      sessionId: session.sessionID ?? "",
+      device: session.device.toDevice(),
+      applicationMetadata: castSession?.applicationMetadata?.toApplicationMetadata(),
+      applicationStatus: session.deviceStatusText,
+      deviceVolume: castSession.map { Double($0.currentDeviceVolume) },
+      deviceMuted: castSession.map { $0.currentDeviceMuted },
+      standbyState: castSession?.standbyStatus.toStandbyState(),
+      activeInputState: castSession?.activeInputStatus.toActiveInputState()
+    )
   }
 
   private static func mapState(_ state: GCKCastState) -> CastState {
@@ -551,5 +645,43 @@ private final class CastSessionListener: NSObject, GCKSessionManagerListener {
     // state JS already considers gone. Re-attached on `didResumeSession`.
     onSessionInactive()
     emit(.suspended, reason: HybridCastTransport.suspendReason(reason))
+  }
+
+  // MARK: device-status (all collapse to `deviceStatusChanged`, carrying a fresh
+  // full `sessionInfo`). GCK declares each volume/status callback in two flavors —
+  // a generic `session:` and a cast-specific `castSession:`. Which one(s) GCK
+  // actually invokes for a cast session is device-gated and unverified here, so we
+  // implement BOTH: a silent miss (only one flavor fires and we skipped it) is a
+  // real bug, whereas a double-emit (both fire) is harmless — each rebuilds the
+  // same fresh full `sessionInfo`, an idempotent overwrite downstream.
+  // `didUpdateDevice:` has only a `session:` flavor. All are *optional* selectors
+  // pinned from the GCK headers (a wrong signature compiles clean and never fires).
+  func sessionManager(
+    _ sessionManager: GCKSessionManager, session: GCKSession, didReceiveDeviceVolume volume: Float,
+    muted: Bool
+  ) {
+    emit(.devicestatuschanged, session: HybridCastTransport.sessionInfo(session))
+  }
+  func sessionManager(
+    _ sessionManager: GCKSessionManager, castSession: GCKCastSession,
+    didReceiveDeviceVolume volume: Float, muted: Bool
+  ) {
+    emit(.devicestatuschanged, session: HybridCastTransport.sessionInfo(castSession))
+  }
+  func sessionManager(
+    _ sessionManager: GCKSessionManager, session: GCKSession, didReceiveDeviceStatus statusText: String?
+  ) {
+    emit(.devicestatuschanged, session: HybridCastTransport.sessionInfo(session))
+  }
+  func sessionManager(
+    _ sessionManager: GCKSessionManager, castSession: GCKCastSession,
+    didReceiveDeviceStatus statusText: String?
+  ) {
+    emit(.devicestatuschanged, session: HybridCastTransport.sessionInfo(castSession))
+  }
+  func sessionManager(
+    _ sessionManager: GCKSessionManager, session: GCKSession, didUpdate device: GCKDevice
+  ) {
+    emit(.devicestatuschanged, session: HybridCastTransport.sessionInfo(session))
   }
 }

--- a/src/api/CastSession.ts
+++ b/src/api/CastSession.ts
@@ -1,9 +1,26 @@
-import type { CastError, Device } from '../transport/types'
+import type { CastError, CastTransportApi, Device } from '../transport/types'
 import type { CastStore } from '../state/CastStore'
-import type { StoreSession } from '../state/session.slice'
+import {
+  SESSION_SLICE_KEY,
+  type SessionDetail,
+  type SessionState,
+  type StoreSession,
+} from '../state/session.slice'
+import type { ApplicationMetadata } from '../types/ApplicationMetadata'
+import type { StandbyState } from '../types/StandbyState'
+import type { ActiveInputState } from '../types/ActiveInputState'
+import type { EventSubscription } from './subscribeSelector'
+import { RemoteMediaClient } from './RemoteMediaClient'
 
-/** The store capability a session façade needs — just the live generation. */
-type GenerationSource = Pick<CastStore, 'getCurrentGeneration'>
+/** Fallback detail — unreachable after `assertActive` (a live session is seeded). */
+const DEFAULT_DETAIL: SessionDetail = {
+  deviceVolume: 0,
+  deviceMuted: false,
+  standbyState: 'unknown',
+  activeInputState: 'unknown',
+  applicationMetadata: null,
+  applicationStatus: null,
+}
 
 /**
  * A handle to a Cast session, created and memoized by {@link SessionManager}.
@@ -14,8 +31,27 @@ type GenerationSource = Pick<CastStore, 'getCurrentGeneration'>
  * `noSession` before any operation crosses the bridge — generation, not the
  * reused/absent `id`, is the identity (Invariant 3).
  *
- * Phase 3 scope is the guard itself: volume / mute / `getClient()` land in
- * Phase 5 and will each call {@link assertActive} first.
+ * Device detail (volume / mute / standby / active-input / application metadata &
+ * status) is served **synchronously** from the store's session slice — v4
+ * returned promises for these; v5 reads the pushed state cache. Volume/mute
+ * *mutations* (`setVolume` / `setMute`) route to the transport's **device**
+ * surface (`setDeviceVolume` / `setDeviceMuted`) — the receiver device level,
+ * distinct from the media-stream volume on {@link RemoteMediaClient}.
+ *
+ * @see [Android](https://developers.google.com/android/reference/com/google/android/gms/cast/framework/CastSession) | [iOS](https://developers.google.com/cast/docs/reference/ios/interface_g_c_k_cast_session) | [Chrome](https://developers.google.com/cast/docs/reference/chrome/cast.framework.CastSession)
+ *
+ * @example
+ * ```js
+ * import { useCastSession } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const castSession = useCastSession()
+ *   if (castSession) {
+ *     const volume = castSession.getVolume()
+ *     castSession.getClient()?.play()
+ *   }
+ * }
+ * ```
  */
 export class CastSession {
   /** Unique session id (may be reused across sessions — do not use as identity). */
@@ -23,11 +59,17 @@ export class CastSession {
   /** The connected receiver device (a snapshot; valid even once stale). */
   readonly device: Device
 
-  private readonly store: GenerationSource
+  private readonly store: CastStore
+  private readonly transport: CastTransportApi
   private readonly generation: number
 
-  constructor(store: GenerationSource, session: StoreSession) {
+  constructor(
+    store: CastStore,
+    transport: CastTransportApi,
+    session: StoreSession
+  ) {
     this.store = store
+    this.transport = transport
     this.generation = session.generation
     this.id = session.sessionId
     this.device = session.device
@@ -49,6 +91,134 @@ export class CastSession {
         message: 'This Cast session has ended.',
       }
       throw error
+    }
+  }
+
+  /** The live device detail (post-`assertActive`, so a session is present). */
+  private detail(): SessionDetail {
+    this.assertActive()
+    return (
+      this.store.getSliceState<SessionState>(SESSION_SLICE_KEY).detail ??
+      DEFAULT_DETAIL
+    )
+  }
+
+  // --- device detail (synchronous; served from the session slice cache) ---
+
+  /**
+   * The device's volume, in the range `[0, 1]`. (v4 returned a `Promise`.)
+   * @throws a {@link CastError} `noSession` if this handle is stale.
+   */
+  getVolume(): number {
+    return this.detail().deviceVolume
+  }
+
+  /**
+   * Whether the device's audio is muted. (v4 name `isMute`; returned a `Promise`.)
+   * @throws a {@link CastError} `noSession` if this handle is stale.
+   */
+  isMute(): boolean {
+    return this.detail().deviceMuted
+  }
+
+  /**
+   * The metadata for the currently running receiver application, or `null` if
+   * unavailable. (v4 returned a `Promise`.)
+   */
+  getApplicationMetadata(): ApplicationMetadata | null {
+    return this.detail().applicationMetadata
+  }
+
+  /**
+   * The current receiver application status text, or `null`. Localized to the
+   * Cast device's locale. (v4 returned a `Promise`.)
+   */
+  getApplicationStatus(): string | null {
+    return this.detail().applicationStatus
+  }
+
+  /**
+   * Whether the receiver's connected TV/AVR is in "standby" (CEC only).
+   * (v4 returned a `Promise`.)
+   */
+  getStandbyState(): StandbyState {
+    return this.detail().standbyState
+  }
+
+  /**
+   * Whether the receiver is currently the active video input (CEC only).
+   * (v4 returned a `Promise`.)
+   */
+  getActiveInputState(): ActiveInputState {
+    return this.detail().activeInputState
+  }
+
+  // --- mutations (async; route to the transport's device surface) ---
+
+  /**
+   * Set the device's volume. Values outside `[0, 1]` are clipped by GCK. Routes
+   * to the **device** volume (`setDeviceVolume`), not the media stream.
+   */
+  async setVolume(volume: number): Promise<void> {
+    this.assertActive()
+    return this.transport.setDeviceVolume(volume)
+  }
+
+  /**
+   * Mute or unmute the device's audio. Routes to the **device** mute
+   * (`setDeviceMuted`), not the media stream.
+   */
+  async setMute(muted: boolean): Promise<void> {
+    this.assertActive()
+    return this.transport.setDeviceMuted(muted)
+  }
+
+  // --- media client ---
+
+  /**
+   * The {@link RemoteMediaClient} controlling media on this session, or `null`
+   * if there is none. Memoized per generation (same ref as
+   * {@link useRemoteMediaClient} hands back).
+   */
+  getClient(): RemoteMediaClient | null {
+    this.assertActive()
+    return RemoteMediaClient.current(this.store, this.transport)
+  }
+
+  // --- detail change listeners (via the store's typed bus; never replayed) ---
+
+  /**
+   * Listen for changes to the receiver's standby state. The subscription fires
+   * only while this handle is live and auto-noops once it is stale, so a façade
+   * retained across a disconnect can never leak a later session's events.
+   */
+  onStandbyStateChanged(
+    listener: (state: StandbyState) => void
+  ): EventSubscription {
+    this.assertActive()
+    return {
+      remove: this.store.on('standbyStateChanged', (event) => {
+        if (this.isActive && event.session) {
+          listener(event.session.standbyState ?? 'unknown')
+        }
+      }),
+    }
+  }
+
+  /**
+   * Listen for changes to the receiver's active-input state. Same liveness
+   * scoping as {@link onStandbyStateChanged}.
+   */
+  onActiveInputStateChanged(
+    listener: (state: ActiveInputState) => void
+  ): EventSubscription {
+    this.assertActive()
+    return {
+      remove: this.store.on('activeInputStateChanged', (event) => {
+        if (this.isActive && event.session) {
+          listener(event.session.activeInputState ?? 'unknown')
+        }
+      }),
     }
   }
 }

--- a/src/api/SessionManager.ts
+++ b/src/api/SessionManager.ts
@@ -42,7 +42,7 @@ export class SessionManager {
     if (this.cached && this.cached.generation === current.generation) {
       return this.cached.session
     }
-    const session = new CastSession(this.store, current)
+    const session = new CastSession(this.store, this.transport, current)
     this.cached = { generation: current.generation, session }
     return session
   }

--- a/src/api/__tests__/facades.test.ts
+++ b/src/api/__tests__/facades.test.ts
@@ -3,6 +3,22 @@ import type { CastError, Device, SessionInfo } from '../../transport/types'
 import { CastStore } from '../../state/CastStore'
 import { SessionManager } from '../SessionManager'
 import { DiscoveryManager } from '../DiscoveryManager'
+import { RemoteMediaClient } from '../RemoteMediaClient'
+
+// `CastSession.getClient()` imports `RemoteMediaClient`, which transitively
+// pulls the singleton progress ticker + native `CastTransport` (unloadable under
+// jest). Swap the store singleton for a fake-backed one so the module loads;
+// these tests drive their own `setup()` store, not this singleton. Mirrors
+// `RemoteMediaClient.test.ts` / `mediaHooks.test.ts`.
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
 
 function device(id: string): Device {
   return {
@@ -15,8 +31,8 @@ function device(id: string): Device {
     modelName: 'TestCast',
   }
 }
-function session(id: string): SessionInfo {
-  return { sessionId: id, device: device(id) }
+function session(id: string, detail?: Partial<SessionInfo>): SessionInfo {
+  return { sessionId: id, device: device(id), ...detail }
 }
 
 async function setup(
@@ -159,6 +175,172 @@ describe('CastSession — generation guard (Invariant 3)', () => {
     transport.emitLifecycle({ type: 'started', session: session('s1') }) // reused id
     expect(stale.isActive).toBe(false)
     expect(sessionManager.getCurrentCastSession()!.isActive).toBe(true)
+  })
+})
+
+describe('CastSession — device detail (Phase 5)', () => {
+  const richSession = () =>
+    session('s1', {
+      deviceVolume: 0.4,
+      deviceMuted: true,
+      standbyState: 'active',
+      activeInputState: 'inactive',
+      applicationStatus: 'Ready to cast',
+      applicationMetadata: {
+        applicationId: 'APP1',
+        name: 'Test Receiver',
+        images: [],
+        namespaces: ['urn:x-cast:com.example'],
+      },
+    })
+
+  it('serves device detail synchronously from the store slice', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: richSession() })
+    const cs = sessionManager.getCurrentCastSession()!
+    expect(cs.getVolume()).toBe(0.4)
+    expect(cs.isMute()).toBe(true)
+    expect(cs.getStandbyState()).toBe('active')
+    expect(cs.getActiveInputState()).toBe('inactive')
+    expect(cs.getApplicationStatus()).toBe('Ready to cast')
+    expect(cs.getApplicationMetadata()?.applicationId).toBe('APP1')
+  })
+
+  it('applies defaults when the optional detail fields are absent', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    expect(cs.getVolume()).toBe(0)
+    expect(cs.isMute()).toBe(false)
+    expect(cs.getStandbyState()).toBe('unknown')
+    expect(cs.getActiveInputState()).toBe('unknown')
+    expect(cs.getApplicationMetadata()).toBeNull()
+    expect(cs.getApplicationStatus()).toBeNull()
+  })
+
+  it('reflects a detail-change event without churning the currentSession ref', async () => {
+    const { store, sessionManager, transport } = await setup()
+    transport.emitLifecycle({
+      type: 'started',
+      session: session('s1', { deviceVolume: 0.2 }),
+    })
+    const cs = sessionManager.getCurrentCastSession()!
+    const snapBefore = store.getSnapshot().currentSession
+    transport.emitLifecycle({
+      type: 'deviceStatusChanged',
+      session: session('s1', { deviceVolume: 0.9, deviceMuted: true }),
+    })
+    expect(cs.getVolume()).toBe(0.9)
+    expect(cs.isMute()).toBe(true)
+    // currentSession ref preserved → useCastSession does not re-render.
+    expect(store.getSnapshot().currentSession).toBe(snapBefore)
+  })
+
+  it('setVolume/setMute route to the DEVICE surface, never the media stream', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    await cs.setVolume(0.7)
+    await cs.setMute(true)
+    expect(transport.setDeviceVolumeCalls).toEqual([0.7])
+    expect(transport.setDeviceMutedCalls).toEqual([true])
+    const media = transport.mediaCalls.map((c) => c.method)
+    expect(media).not.toContain('setStreamVolume')
+    expect(media).not.toContain('setStreamMuted')
+  })
+
+  it('detail reads throw and mutations reject once the handle is stale', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    transport.emitLifecycle({ type: 'ended' })
+    expect(() => cs.getVolume()).toThrow()
+    await expect(cs.setVolume(0.5)).rejects.toMatchObject({ code: 'noSession' })
+    expect(transport.setDeviceVolumeCalls).toEqual([])
+  })
+})
+
+describe('CastSession — getClient (Phase 5)', () => {
+  it('returns a memoized RemoteMediaClient for the live session', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    const client = cs.getClient()
+    expect(client).toBeInstanceOf(RemoteMediaClient)
+    expect(cs.getClient()).toBe(client) // same ref within a generation
+  })
+
+  it('client mutations route through the transport', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const client = sessionManager.getCurrentCastSession()!.getClient()!
+    await client.play()
+    expect(transport.mediaCalls.map((c) => c.method)).toContain('play')
+  })
+
+  it('throws noSession on a stale handle', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    transport.emitLifecycle({ type: 'ended' })
+    expect(() => cs.getClient()).toThrow()
+  })
+})
+
+describe('CastSession — detail change listeners (Phase 5)', () => {
+  it('onStandbyStateChanged fires with the new state and stops after remove()', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    const handler = jest.fn()
+    const sub = cs.onStandbyStateChanged(handler)
+    transport.emitLifecycle({
+      type: 'standbyStateChanged',
+      session: session('s1', { standbyState: 'active' }),
+    })
+    expect(handler).toHaveBeenCalledWith('active')
+    sub.remove()
+    transport.emitLifecycle({
+      type: 'standbyStateChanged',
+      session: session('s1', { standbyState: 'inactive' }),
+    })
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('onActiveInputStateChanged fires with the new state', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    const handler = jest.fn()
+    cs.onActiveInputStateChanged(handler)
+    transport.emitLifecycle({
+      type: 'activeInputStateChanged',
+      session: session('s1', { activeInputState: 'active' }),
+    })
+    expect(handler).toHaveBeenCalledWith('active')
+  })
+
+  it('a listener on a now-stale handle does not fire for a later session', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    const handler = jest.fn()
+    cs.onStandbyStateChanged(handler)
+    transport.emitLifecycle({ type: 'ended' })
+    transport.emitLifecycle({ type: 'started', session: session('s2') })
+    transport.emitLifecycle({
+      type: 'standbyStateChanged',
+      session: session('s2', { standbyState: 'active' }),
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('subscribing on an already-stale handle throws noSession', async () => {
+    const { sessionManager, transport } = await setup()
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    const cs = sessionManager.getCurrentCastSession()!
+    transport.emitLifecycle({ type: 'ended' })
+    expect(() => cs.onStandbyStateChanged(jest.fn())).toThrow()
   })
 })
 

--- a/src/state/__tests__/session.slice.test.ts
+++ b/src/state/__tests__/session.slice.test.ts
@@ -1,0 +1,104 @@
+import type { SessionInfo } from '../../transport/types'
+import type { Device } from '../../types/Device'
+import type { StoreEvent } from '../slice'
+import {
+  SESSION_SLICE_KEY,
+  sessionSlice,
+  type SessionState,
+} from '../session.slice'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: id,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string, detail?: Partial<SessionInfo>): SessionInfo {
+  return { sessionId: id, device: device(id), ...detail }
+}
+function lifecycle(type: string, s?: SessionInfo): StoreEvent {
+  return { kind: 'lifecycle', event: { type: type as never, session: s } }
+}
+
+const EMPTY: SessionState = { current: null, generation: 0, detail: null }
+
+describe('sessionSlice — key + seed', () => {
+  it('uses the exported slice key', () => {
+    expect(sessionSlice.key).toBe(SESSION_SLICE_KEY)
+  })
+
+  it('seeds detail from a cold-start session', () => {
+    const seeded = sessionSlice.seed({
+      currentSession: session('s0', { deviceVolume: 0.5 }),
+    } as never)
+    expect(seeded.generation).toBe(1)
+    expect(seeded.detail?.deviceVolume).toBe(0.5)
+  })
+
+  it('seeds null detail with no cold-start session', () => {
+    expect(sessionSlice.seed({} as never).detail).toBeNull()
+  })
+})
+
+describe('sessionSlice — detail lifecycle', () => {
+  it('sets detail on establish and clears it on teardown', () => {
+    const started = sessionSlice.reduce(
+      EMPTY,
+      lifecycle('started', session('s1', { deviceVolume: 0.3 }))
+    )
+    expect(started.detail?.deviceVolume).toBe(0.3)
+    const ended = sessionSlice.reduce(started, lifecycle('ended'))
+    expect(ended.current).toBeNull()
+    expect(ended.detail).toBeNull()
+  })
+
+  it('replaces detail wholesale on a detail-change event, preserving current ref', () => {
+    const started = sessionSlice.reduce(
+      EMPTY,
+      lifecycle('started', session('s1', { deviceVolume: 0.1 }))
+    )
+    const changed = sessionSlice.reduce(
+      started,
+      lifecycle('deviceStatusChanged', session('s1', { deviceVolume: 0.8 }))
+    )
+    expect(changed.detail?.deviceVolume).toBe(0.8)
+    // generation unchanged; current is the SAME frozen object (Invariant 2).
+    expect(changed.generation).toBe(started.generation)
+    expect(changed.current).toBe(started.current)
+  })
+
+  it('drops a detail-change that races a teardown (no live session)', () => {
+    const started = sessionSlice.reduce(
+      EMPTY,
+      lifecycle('started', session('s1'))
+    )
+    const ended = sessionSlice.reduce(started, lifecycle('ended'))
+    const racing = sessionSlice.reduce(
+      ended,
+      lifecycle(
+        'standbyStateChanged',
+        session('s1', { standbyState: 'active' })
+      )
+    )
+    // No resurrection — same (torn-down) state ref returned.
+    expect(racing).toBe(ended)
+    expect(racing.detail).toBeNull()
+  })
+
+  it('returns the same state ref for unrelated events (Invariant 2)', () => {
+    const started = sessionSlice.reduce(
+      EMPTY,
+      lifecycle('started', session('s1'))
+    )
+    const same = sessionSlice.reduce(started, {
+      kind: 'devices',
+      devices: [],
+    } as StoreEvent)
+    expect(same).toBe(started)
+  })
+})

--- a/src/state/session.slice.ts
+++ b/src/state/session.slice.ts
@@ -1,7 +1,31 @@
 import type { Device, SessionInfo } from '../transport/types'
+import type { ApplicationMetadata } from '../types/ApplicationMetadata'
+import type { StandbyState } from '../types/StandbyState'
+import type { ActiveInputState } from '../types/ActiveInputState'
 import type { Slice } from './slice'
 
 export const SESSION_SLICE_KEY = 'session'
+
+/**
+ * Resolved device detail of the live session (Phase 5), served synchronously to
+ * the `CastSession` façade's `getVolume` / `isMute` / `getStandbyState` / … .
+ *
+ * Deliberately kept **separate** from {@link StoreSession} / {@link
+ * SessionState.current}: `current` is what the snapshot exposes as
+ * `currentSession` and must stay ref-stable across the frequent detail changes
+ * (device volume ticks, standby flips), or `useCastSession` would re-render on
+ * every one (Invariant 2). Detail is read via `getSliceState`, never through the
+ * snapshot. Values are resolved (defaults applied) from the optional
+ * {@link SessionInfo} detail fields native populates.
+ */
+export interface SessionDetail {
+  readonly deviceVolume: number
+  readonly deviceMuted: boolean
+  readonly standbyState: StandbyState
+  readonly activeInputState: ActiveInputState
+  readonly applicationMetadata: ApplicationMetadata | null
+  readonly applicationStatus: string | null
+}
 
 /**
  * The current live session as carried in the snapshot. Bound to a monotonic
@@ -26,6 +50,13 @@ export interface SessionState {
    * unreliable (absent while starting, reused on resume, out-of-order).
    */
   readonly generation: number
+  /**
+   * Device detail of the live session, or `null` when none is live. Tracks
+   * `current` (set on establish, cleared on teardown) and is replaced wholesale
+   * by the detail-change events. Kept off {@link current} to preserve its ref
+   * across detail changes (Invariant 2).
+   */
+  readonly detail: SessionDetail | null
 }
 
 /**
@@ -48,6 +79,18 @@ export const SESSION_TEARDOWN_TYPES = new Set([
   'suspended',
 ])
 
+/**
+ * Lifecycle events carrying an updated device detail for the *current* live
+ * session (Phase 5). They never change live-session presence or generation —
+ * only {@link SessionState.detail}. Exported for the same anti-drift reason as
+ * the establish/teardown lists.
+ */
+export const SESSION_DETAIL_CHANGE_TYPES = new Set([
+  'deviceStatusChanged',
+  'standbyStateChanged',
+  'activeInputStateChanged',
+])
+
 function freezeSession(info: SessionInfo, generation: number): StoreSession {
   return Object.freeze({
     sessionId: info.sessionId,
@@ -56,16 +99,32 @@ function freezeSession(info: SessionInfo, generation: number): StoreSession {
   })
 }
 
+/** Resolve the optional {@link SessionInfo} detail fields, applying defaults. */
+function freezeDetail(info: SessionInfo): SessionDetail {
+  return Object.freeze({
+    deviceVolume: info.deviceVolume ?? 0,
+    deviceMuted: info.deviceMuted ?? false,
+    standbyState: info.standbyState ?? 'unknown',
+    activeInputState: info.activeInputState ?? 'unknown',
+    applicationMetadata: info.applicationMetadata ?? null,
+    applicationStatus: info.applicationStatus ?? null,
+  })
+}
+
 function seed(snapshot: { currentSession?: SessionInfo }): SessionState {
   // A session already live at cold start (already-casting) starts at gen 1, so
   // a façade bound to it is valid (current generation === its generation).
   if (snapshot.currentSession) {
-    return { current: freezeSession(snapshot.currentSession, 1), generation: 1 }
+    return {
+      current: freezeSession(snapshot.currentSession, 1),
+      generation: 1,
+      detail: freezeDetail(snapshot.currentSession),
+    }
   }
-  return { current: null, generation: 0 }
+  return { current: null, generation: 0, detail: null }
 }
 
-/** Core slice: current session + lifecycle generation. */
+/** Core slice: current session + lifecycle generation + device detail. */
 export const sessionSlice: Slice<SessionState> = {
   key: SESSION_SLICE_KEY,
 
@@ -77,19 +136,36 @@ export const sessionSlice: Slice<SessionState> = {
 
     if (SESSION_ESTABLISH_TYPES.has(type)) {
       // A new live session (possibly replacing an existing one) — always a new
-      // generation, so any façade from a prior session is stale.
+      // generation, so any façade from a prior session is stale. Detail is
+      // seeded from the establishing session's payload.
       const nextGeneration = state.generation + 1
-      const session = event.event.session
-        ? freezeSession(event.event.session, nextGeneration)
-        : null
-      return { current: session, generation: nextGeneration }
+      const info = event.event.session
+      const session = info ? freezeSession(info, nextGeneration) : null
+      return {
+        current: session,
+        generation: nextGeneration,
+        detail: info ? freezeDetail(info) : null,
+      }
     }
 
     if (SESSION_TEARDOWN_TYPES.has(type)) {
       // Only a real transition if a session was live; otherwise nothing to
       // invalidate (avoids spurious generation bumps / snapshot churn).
       if (state.current === null) return state
-      return { current: null, generation: state.generation + 1 }
+      return { current: null, generation: state.generation + 1, detail: null }
+    }
+
+    if (SESSION_DETAIL_CHANGE_TYPES.has(type)) {
+      // Detail update for the live session. Dropped when no session is live —
+      // a detail change racing a teardown must not resurrect dead detail (the
+      // same live-gating the media slice applies). `current` / `generation` are
+      // preserved (same refs) so the snapshot's `currentSession` never churns.
+      if (state.current === null || !event.event.session) return state
+      return {
+        current: state.current,
+        generation: state.generation,
+        detail: freezeDetail(event.event.session),
+      }
     }
 
     // starting / resuming / ending: no change in live-session presence.


### PR DESCRIPTION
## Phase 5 · Slice 5.1 — CastSession detail (epic v5-8me)

Completes the CastSession device-detail surface on top of the **T1a barrier**
(`0a9de5e`, already on `v5`). This PR is the assembled b/c/d fan-out — it makes
`v5` native-complete again (the barrier intentionally left the two new spec
methods unimplemented, per the Phase 4 T4a convention).

### Beads
- `v5-8me.2` (T1b, TS façade + state)
- `v5-8me.3` (T1c, iOS)
- `v5-8me.4` (T1d, Android)

### What's here
- **TS (1b):** `CastSession` gains synchronous store-served reads (`getVolume` /
  `isMute` / `getApplicationMetadata` / `getApplicationStatus` /
  `getStandbyState` / `getActiveInputState`), device `setVolume` / `setMute`
  routed to the transport **device** surface (not the media stream),
  `getClient()`, and `onStandbyStateChanged` / `onActiveInputStateChanged` via
  the store's typed bus. Detail lives in a **separate `SessionState.detail`
  field** (kept off `current` to preserve the snapshot's ref-stability,
  Invariant 2), live-gated like media status. Migration guide updated.
- **iOS (1c):** `sessionInfo` enrichment; `setDeviceVolume` / `setDeviceMuted`
  via a GCKRequest-tracked `withCastSession` helper (per-call re-resolve,
  Invariant 1); `GCKCastDeviceStatusListener` for standby/active-input +
  `didReceiveDeviceVolume`/`didReceiveDeviceStatus` → detail-change events.
  Selector-lock test guards the optional GCK selectors.
- **Android (1d):** `CastSession.toSessionInfo` converter (progressive
  enrichment, throw→null vs unknown); `setDeviceVolume` / `setDeviceMuted` via a
  `sessionCall` helper; `Cast.Listener` → detail-change events. Robolectric
  metadata converter test.

### Verification
- `yarn typescript` (drift guard across the 3 transport surfaces) + **139 jest
  tests** + prettier clean on the assembled tree.
- iOS `build-for-testing` green + `NitroGoogleCastTests` 17/17 (sub-agent
  worktree); Android `compileDebugKotlin` + `testDebugUnitTest` green.
- Device-gated (real Cast device): actual detail-change event firing and device
  volume/mute setter behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x7of3gwAhCEwxUCoDq3HM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live updates for device volume, mute status, standby state, active input, and application details.
  * Added support for changing device volume and mute state through the Cast session.
  * Cast session details now remain current during session lifecycle changes.

* **Documentation**
  * Updated v4-to-v5 migration guidance to clarify synchronous device-detail reads and asynchronous volume/mute updates.
  * Clarified handling when no active media client is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->