### PR TITLE
feat(v5): Phase 5 Slice 5.2 — CastChannel (v5-8me.6/.7/.8/.9)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -14,6 +14,7 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.api.PendingResult
+import com.google.android.gms.common.api.Status
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.googlecast.converters.CastRejection
@@ -55,6 +56,18 @@ class HybridCastTransport : HybridCastTransportSpec() {
   private var onDevices: ((Array<Device>) -> Unit)? = null
   private var onLifecycle: ((SessionLifecycleEvent) -> Unit)? = null
   private var onMediaStatus: ((MediaStatus) -> Unit)? = null
+  private var onChannelMessage: ((String, String) -> Unit)? = null
+  private var onChannelStatus: ((String, Boolean, Boolean) -> Unit)? = null
+
+  // Registered custom channels by namespace (Phase 5.2). Cleared explicitly on
+  // session end/suspend and on dispose (A1) so a dead session's callbacks never
+  // leak into the next one. Main thread only.
+  private val channels = mutableMapOf<String, Cast.MessageReceivedCallback>()
+
+  // In-flight sendMessage results, so dispose can cancel them (mirrors
+  // `pendingResults`; sendMessage returns PendingResult<Status>, not
+  // MediaChannelResult, hence the separate set).
+  private val pendingChannelResults = mutableSetOf<PendingResult<Status>>()
 
   private var castStateListener: CastStateListener? = null
   private var sessionListener: SessionManagerListener<CastSession>? = null
@@ -101,12 +114,16 @@ class HybridCastTransport : HybridCastTransportSpec() {
     onState: (castState: CastState) -> Unit,
     onDevices: (devices: Array<Device>) -> Unit,
     onLifecycle: (event: SessionLifecycleEvent) -> Unit,
-    onMediaStatus: (status: MediaStatus) -> Unit
+    onMediaStatus: (status: MediaStatus) -> Unit,
+    onChannelMessage: (namespace: String, message: String) -> Unit,
+    onChannelStatus: (namespace: String, connected: Boolean, writable: Boolean) -> Unit
   ): Promise<InitialSnapshot> {
     this.onState = onState
     this.onDevices = onDevices
     this.onLifecycle = onLifecycle
     this.onMediaStatus = onMediaStatus
+    this.onChannelMessage = onChannelMessage
+    this.onChannelStatus = onChannelStatus
 
     val promise = Promise<InitialSnapshot>()
     runOnMain {
@@ -193,13 +210,18 @@ class HybridCastTransport : HybridCastTransportSpec() {
       detachObservers()
       detachMediaCallback()
       detachCastListener()
+      clearChannels(sharedCastContextOrNull()?.sessionManager?.currentCastSession)
       // Cancel any in-flight media requests; JS is going away so the promises need not settle.
       pendingResults.forEach { it.cancel() }
       pendingResults.clear()
+      pendingChannelResults.forEach { it.cancel() }
+      pendingChannelResults.clear()
       onState = null
       onDevices = null
       onLifecycle = null
       onMediaStatus = null
+      onChannelMessage = null
+      onChannelStatus = null
     }
     super.dispose()
   }
@@ -282,6 +304,116 @@ class HybridCastTransport : HybridCastTransportSpec() {
         promise.resolve(Unit)
       } catch (e: Exception) {
         promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+      }
+    }
+    return promise
+  }
+
+  // MARK: - custom channels (Phase 5.2 — registry owned here, Invariant 1 for the session)
+
+  override fun addChannel(namespace: String): Promise<Unit> {
+    val promise = Promise<Unit>()
+    runOnMain {
+      val session = sharedCastContextOrNull()?.sessionManager?.currentCastSession
+      if (session == null) {
+        promise.reject(
+          CastRejection(castRejectionJson("noSession", "No active Cast session.", null))
+        )
+        return@runOnMain
+      }
+      if (channels.containsKey(namespace)) {
+        promise.reject(
+          CastRejection(
+            castRejectionJson(
+              "alreadyRegistered", "A channel for $namespace is already registered.", null
+            )
+          )
+        )
+        return@runOnMain
+      }
+      val callback = Cast.MessageReceivedCallback { _, ns, message ->
+        onChannelMessage?.invoke(ns, message)
+      }
+      try {
+        session.setMessageReceivedCallbacks(namespace, callback)
+      } catch (e: Exception) {
+        // setMessageReceivedCallbacks throws IOException / IllegalStateException.
+        promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+        return@runOnMain
+      }
+      channels[namespace] = callback
+      // Register-once status (v4 parity, A2): the Android SDK has no
+      // per-channel connect/writable callbacks, so {true, true} is emitted
+      // exactly once at registration and never updated — emitted BEFORE
+      // resolving so an awaiting façade reads a populated value.
+      onChannelStatus?.invoke(namespace, true, true)
+      promise.resolve(Unit)
+    }
+    return promise
+  }
+
+  override fun removeChannel(namespace: String): Promise<Unit> {
+    val promise = Promise<Unit>()
+    runOnMain {
+      if (channels.remove(namespace) != null) {
+        // Best-effort: the session may already be gone (its callbacks died
+        // with it); unregistering from a live one keeps GCK in sync.
+        try {
+          sharedCastContextOrNull()?.sessionManager?.currentCastSession
+            ?.removeMessageReceivedCallbacks(namespace)
+        } catch (_: Exception) {}
+      }
+      promise.resolve(Unit) // idempotent — not-registered resolves
+    }
+    return promise
+  }
+
+  override fun sendMessage(namespace: String, message: String): Promise<Unit> {
+    val promise = Promise<Unit>()
+    runOnMain {
+      val session = sharedCastContextOrNull()?.sessionManager?.currentCastSession
+      if (session == null) {
+        promise.reject(
+          CastRejection(castRejectionJson("noSession", "No active Cast session.", null))
+        )
+        return@runOnMain
+      }
+      if (!channels.containsKey(namespace)) {
+        promise.reject(
+          CastRejection(
+            castRejectionJson(
+              "invalidRequest", "No channel registered for $namespace — call addChannel first.",
+              null
+            )
+          )
+        )
+        return@runOnMain
+      }
+      val pending =
+        try {
+          session.sendMessage(namespace, message)
+        } catch (e: Exception) {
+          promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+          return@runOnMain
+        }
+      // A2-minor: await the PendingResult — never fire-and-forget a send.
+      pendingChannelResults.add(pending)
+      pending.setResultCallback { result ->
+        pendingChannelResults.remove(pending)
+        val status = result.status
+        if (status.isSuccess) {
+          promise.resolve(Unit)
+        } else {
+          promise.reject(
+            CastRejection(
+              castRejectionJson(
+                castErrorCodeFromGckStatusCode(status.statusCode),
+                status.statusMessage,
+                status.statusCode
+              )
+            )
+          )
+        }
       }
     }
     return promise
@@ -489,6 +621,22 @@ class HybridCastTransport : HybridCastTransportSpec() {
   }
 
   /**
+   * Drop every registered custom channel (A1). Called on session end/suspend
+   * (with the callback's still-valid session handle, so the GCK-side
+   * unregistration succeeds) and on dispose. The app re-adds channels on the
+   * next session, per the guide.
+   */
+  private fun clearChannels(session: CastSession?) {
+    if (channels.isEmpty()) return
+    channels.keys.forEach { namespace ->
+      try {
+        session?.removeMessageReceivedCallbacks(namespace)
+      } catch (_: Exception) {}
+    }
+    channels.clear()
+  }
+
+  /**
    * Emits [type] carrying a fresh full [SessionInfo] read from the *current* session (Invariant 1
    * — re-resolved, not the closed-over handle from `attachCastListener`). A teardown race that
    * nulls the session emits a null `sessionInfo`, consistent with how `ENDED` already emits null.
@@ -558,6 +706,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
       override fun onSessionEnded(session: CastSession, error: Int) {
         detachMediaCallback()
         detachCastListener()
+        clearChannels(session)
         emit(
           SessionEventType.ENDED,
           error = if (error != 0) castErrorFromStatusCode(error, null) else null
@@ -575,6 +724,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
       override fun onSessionSuspended(session: CastSession, reason: Int) {
         detachMediaCallback()
         detachCastListener()
+        clearChannels(session)
         emit(SessionEventType.SUSPENDED, reason = suspendReason(reason))
       }
     }

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -311,7 +311,9 @@ class HybridCastTransport : HybridCastTransportSpec() {
 
   // MARK: - custom channels (Phase 5.2 — registry owned here, Invariant 1 for the session)
 
-  override fun addChannel(namespace: String): Promise<Unit> {
+  // The parameter is named `channelNamespace` (matching the generated spec,
+  // where `namespace` is a C++ keyword); `namespace` stays the local term.
+  override fun addChannel(channelNamespace: String): Promise<Unit> {
     val promise = Promise<Unit>()
     runOnMain {
       val session = sharedCastContextOrNull()?.sessionManager?.currentCastSession
@@ -321,11 +323,11 @@ class HybridCastTransport : HybridCastTransportSpec() {
         )
         return@runOnMain
       }
-      if (channels.containsKey(namespace)) {
+      if (channels.containsKey(channelNamespace)) {
         promise.reject(
           CastRejection(
             castRejectionJson(
-              "alreadyRegistered", "A channel for $namespace is already registered.", null
+              "alreadyRegistered", "A channel for $channelNamespace is already registered.", null
             )
           )
         )
@@ -335,32 +337,32 @@ class HybridCastTransport : HybridCastTransportSpec() {
         onChannelMessage?.invoke(ns, message)
       }
       try {
-        session.setMessageReceivedCallbacks(namespace, callback)
+        session.setMessageReceivedCallbacks(channelNamespace, callback)
       } catch (e: Exception) {
         // setMessageReceivedCallbacks throws IOException / IllegalStateException.
         promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
         return@runOnMain
       }
-      channels[namespace] = callback
+      channels[channelNamespace] = callback
       // Register-once status (v4 parity, A2): the Android SDK has no
       // per-channel connect/writable callbacks, so {true, true} is emitted
       // exactly once at registration and never updated — emitted BEFORE
       // resolving so an awaiting façade reads a populated value.
-      onChannelStatus?.invoke(namespace, true, true)
+      onChannelStatus?.invoke(channelNamespace, true, true)
       promise.resolve(Unit)
     }
     return promise
   }
 
-  override fun removeChannel(namespace: String): Promise<Unit> {
+  override fun removeChannel(channelNamespace: String): Promise<Unit> {
     val promise = Promise<Unit>()
     runOnMain {
-      if (channels.remove(namespace) != null) {
+      if (channels.remove(channelNamespace) != null) {
         // Best-effort: the session may already be gone (its callbacks died
         // with it); unregistering from a live one keeps GCK in sync.
         try {
           sharedCastContextOrNull()?.sessionManager?.currentCastSession
-            ?.removeMessageReceivedCallbacks(namespace)
+            ?.removeMessageReceivedCallbacks(channelNamespace)
         } catch (_: Exception) {}
       }
       promise.resolve(Unit) // idempotent — not-registered resolves
@@ -368,7 +370,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
     return promise
   }
 
-  override fun sendMessage(namespace: String, message: String): Promise<Unit> {
+  override fun sendMessage(channelNamespace: String, message: String): Promise<Unit> {
     val promise = Promise<Unit>()
     runOnMain {
       val session = sharedCastContextOrNull()?.sessionManager?.currentCastSession
@@ -378,11 +380,12 @@ class HybridCastTransport : HybridCastTransportSpec() {
         )
         return@runOnMain
       }
-      if (!channels.containsKey(namespace)) {
+      if (!channels.containsKey(channelNamespace)) {
         promise.reject(
           CastRejection(
             castRejectionJson(
-              "invalidRequest", "No channel registered for $namespace — call addChannel first.",
+              "invalidRequest",
+              "No channel registered for $channelNamespace — call addChannel first.",
               null
             )
           )
@@ -391,7 +394,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
       }
       val pending =
         try {
-          session.sendMessage(namespace, message)
+          session.sendMessage(channelNamespace, message)
         } catch (e: Exception) {
           promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
           return@runOnMain

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -61,7 +61,8 @@ class HybridCastTransport : HybridCastTransportSpec() {
 
   // Registered custom channels by namespace (Phase 5.2). Cleared explicitly on
   // session end/suspend and on dispose (A1) so a dead session's callbacks never
-  // leak into the next one. Main thread only.
+  // leak into the next one (a replace is covered too: GCK always ends the old
+  // session before starting its replacement). Main thread only.
   private val channels = mutableMapOf<String, Cast.MessageReceivedCallback>()
 
   // In-flight sendMessage results, so dispose can cancel them (mirrors

--- a/android/src/main/java/com/margelo/nitro/googlecast/converters/CastErrorBuilders.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/converters/CastErrorBuilders.kt
@@ -18,6 +18,7 @@ internal fun castErrorCode(value: String): CastErrorCode =
     "authentication" -> CastErrorCode.AUTHENTICATION
     "notAllowed" -> CastErrorCode.NOTALLOWED
     "appNotFound" -> CastErrorCode.APPNOTFOUND
+    "alreadyRegistered" -> CastErrorCode.ALREADYREGISTERED
     else -> CastErrorCode.FAILED
   }
 

--- a/docs/guides/custom-channels.md
+++ b/docs/guides/custom-channels.md
@@ -4,7 +4,7 @@ title: Custom Channels
 sidebar_label: Custom Channels
 ---
 
-If you've built a [custom web receiver](https://developers.google.com/cast/docs/web_receiver/basic) or an [Android TV receiver](https://developers.google.com/cast/docs/android_tv_receiver) and want to send custom messages between your Cast sender (the mobile app you're building with this library) and the Cast receiver (on Chromecast or Android TV), you need to establist a custom channel.
+If you've built a [custom web receiver](https://developers.google.com/cast/docs/web_receiver/basic) or an [Android TV receiver](https://developers.google.com/cast/docs/android_tv_receiver) and want to send custom messages between your Cast sender (the mobile app you're building with this library) and the Cast receiver (on Chromecast or Android TV), you need to establish a custom channel.
 
 > Don't forget to set your custom receiver app ID as described in the [Setup](../getting-started/setup).
 
@@ -13,7 +13,7 @@ Each custom channel is defined by a unique namespace and must start with the pre
 A [CastChannel](../api/classes/castchannel) can be created on a [CastSession](../api/classes/castsession) by calling:
 
 ```ts
-const channel = castSession.addChannel('urn:x-cast:...')
+const channel = await castSession.addChannel('urn:x-cast:...')
 ```
 
 Or, if you're using hooks:

--- a/docs/guides/custom-channels.md
+++ b/docs/guides/custom-channels.md
@@ -58,6 +58,9 @@ channel.onMessage(message => { ... })
 channel.offMessage()
 ```
 
+> The message is always delivered as the **raw string** received from the
+> receiver — if your receiver sends JSON, parse it with `JSON.parse(message)`.
+
 When you no longer need the channel, you can remove it:
 
 ```ts

--- a/docs/guides/migrating-v4-to-v5.md
+++ b/docs/guides/migrating-v4-to-v5.md
@@ -115,7 +115,9 @@ with these changes:
   asynchronously; a `console.warn` flags a receiver with no listener for the
   namespace, as in v4). Android's SDK has no per-channel status callbacks: it
   reports `{connected: true, writable: true}` once at registration and never
-  updates — exactly v4's hardcoded values.
+  updates — exactly v4's hardcoded values. As in v4, the getters are
+  point-in-time reads: rendering `channel.connected` in a component does not
+  re-render when the status changes.
 - **Stale channels reject instead of crashing.** Like `CastSession`, a
   `CastChannel` retained across a disconnect rejects `noSession` on
   `sendMessage` / `remove` (channels are auto-removed with their session), and

--- a/docs/guides/migrating-v4-to-v5.md
+++ b/docs/guides/migrating-v4-to-v5.md
@@ -91,11 +91,39 @@ media stream use `castSession.getClient()` →
 `null` when there is no live session (consistent with `useRemoteMediaClient`),
 so guard the result (`getClient()?.play()`).
 
+## Custom channels
+
+`CastSession.addChannel` / `CastChannel` / `useCastChannel` keep their v4 shape,
+with these changes:
+
+- **Messages are strings.** `onMessage` always delivers the raw string received
+  from the receiver — call `JSON.parse` yourself if your receiver sends JSON
+  (v4's listener type suggested parsed objects, but it delivered strings too).
+  `sendMessage` still accepts an object (JSON.stringified for you) or a string,
+  and now settles with a typed `CastError` instead of silently failing.
+- **`addChannel` rejects on a duplicate namespace.** Channels are register-once
+  per namespace (true in v4 as well, where a second registration silently broke
+  the first); v5 makes it explicit with `CastError` code `alreadyRegistered`.
+  Remove the existing channel first, or lift the channel to a common parent —
+  see the [Custom Channels guide](../custom-channels).
+- **Single message listener (unchanged, now documented).** `channel.onMessage`
+  replaces any previous listener, and `useCastChannel`'s `onMessage` parameter
+  owns that one listener — passing `onMessage` to the hook *and* calling
+  `channel.onMessage` elsewhere clobbers whichever came first.
+- **`connected` / `writable` reflect the platform.** iOS reports live values —
+  often `connected: false` immediately after `addChannel` (the channel connects
+  asynchronously; a `console.warn` flags a receiver with no listener for the
+  namespace, as in v4). Android's SDK has no per-channel status callbacks: it
+  reports `{connected: true, writable: true}` once at registration and never
+  updates — exactly v4's hardcoded values.
+- **Stale channels reject instead of crashing.** Like `CastSession`, a
+  `CastChannel` retained across a disconnect rejects `noSession` on
+  `sendMessage` / `remove` (channels are auto-removed with their session), and
+  its retained listener can never receive a later session's messages.
+
 ## Deferred to later phases
 
 - `CastContext.showCastDialog()` / `showExpandedControls()` /
   `showIntroductoryOverlay()` / `showPlayServicesErrorDialog()` — **Phase 6**
   (they depend on the `CastButton` / cast activity).
-- Custom channels (`CastSession.addChannel` / `CastChannel`) — **Phase 5**
-  (slice 5.2).
 - Web / Chrome sender support — **Phase 8**.

--- a/example/ios/CastExample.xcodeproj/project.pbxproj
+++ b/example/ios/CastExample.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		89B8C26648F904B42A2948FC /* MediaQueueDataConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B925CDDC0A51A5FCC1282EE /* MediaQueueDataConverterTests.swift */; };
 		8EED9A3542CD6051A93B3F20 /* videoInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = 09C61447F6A35CD6496D7D33 /* videoInfo.json */; };
 		8F17AB62FE01E357F435B5C1 /* mediaLoadRequest.json in Resources */ = {isa = PBXBuildFile; fileRef = 2636BABBD6C616B444D45799 /* mediaLoadRequest.json */; };
+		A7C21E5D4B3F60918D2A4C72 /* CastMessageChannelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C21E5D4B3F60918D2A4C71 /* CastMessageChannelTests.swift */; };
 		A9E74E88AE270C87563785E9 /* ConverterAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AE1FB39451C5BD98524B0E /* ConverterAssertions.swift */; };
 		AA90DB0478E72CE1E85F6BA5 /* mediaSeekOptions.json in Resources */ = {isa = PBXBuildFile; fileRef = 9DA9A7DE70569F6FEDC83EE4 /* mediaSeekOptions.json */; };
 		AD6C41D2A84F59D396DD1ADE /* libPods-NitroGoogleCastTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 734165D8F6B0CBDB199B2153 /* libPods-NitroGoogleCastTests.a */; };
@@ -95,6 +96,7 @@
 		A304778A69B66DF7C7B92C51 /* VideoInfoConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoInfoConverterTests.swift; sourceTree = "<group>"; };
 		A49AEB84FBE0B676E396FA8E /* MediaSeekOptionsConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaSeekOptionsConverterTests.swift; sourceTree = "<group>"; };
 		A78BC92FD79D4698F93D9438 /* TextTrackStyleConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextTrackStyleConverterTests.swift; sourceTree = "<group>"; };
+		A7C21E5D4B3F60918D2A4C71 /* CastMessageChannelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CastMessageChannelTests.swift; sourceTree = "<group>"; };
 		AEE5126EC00A1CF0854FEC2C /* MediaInfoConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaInfoConverterTests.swift; sourceTree = "<group>"; };
 		AF59CECC66765DA0E4BBEAE4 /* NitroGoogleCastTests-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NitroGoogleCastTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B26E6F8FA09FA976940564B8 /* mediaLiveSeekableRange.json */ = {isa = PBXFileReference; includeInIndex = 1; name = mediaLiveSeekableRange.json; path = ../../fixtures/converters/mediaLiveSeekableRange.json; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				0EAE69B317C350F01C826A60 /* MediaStatusConverterTests.swift */,
 				2ECD13393927F54CD7574E81 /* StateEnumConverterTests.swift */,
 				C66E907FAE7BB1E54C860CA8 /* DeviceStatusListenerSelectorTests.swift */,
+				A7C21E5D4B3F60918D2A4C71 /* CastMessageChannelTests.swift */,
 			);
 			name = NitroGoogleCastTests;
 			path = NitroGoogleCastTests;
@@ -487,6 +490,7 @@
 				CE9BA8E4E6CB702EA00ACDC4 /* MediaStatusConverterTests.swift in Sources */,
 				22EFC52CA9BDBE7206B9BBBB /* StateEnumConverterTests.swift in Sources */,
 				3644FCF70720785683137ADB /* DeviceStatusListenerSelectorTests.swift in Sources */,
+				A7C21E5D4B3F60918D2A4C72 /* CastMessageChannelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/NitroGoogleCastTests/CastMessageChannelTests.swift
+++ b/example/ios/NitroGoogleCastTests/CastMessageChannelTests.swift
@@ -1,0 +1,30 @@
+import GoogleCast
+import XCTest
+
+@testable import NitroGoogleCast
+
+final class CastMessageChannelTests: XCTestCase {
+  func testForwardsTextMessages() {
+    var received: [String] = []
+    let channel = CastMessageChannel(
+      namespace: "urn:x-cast:test",
+      onMessage: { received.append($0) },
+      onStatus: { _, _ in })
+    channel.didReceiveTextMessage("hello")
+    XCTAssertEqual(received, ["hello"])
+  }
+
+  func testEmitsStatusOnConnectDisconnectAndWritableChange() {
+    var emits = 0
+    let channel = CastMessageChannel(
+      namespace: "urn:x-cast:test",
+      onMessage: { _ in },
+      onStatus: { _, _ in emits += 1 })
+    channel.didConnect()
+    channel.didDisconnect()
+    channel.didChangeWritableState(true)
+    // The assertion is the *forwarding*; off-session GCK reports
+    // not-connected/not-writable, so values aren't asserted here.
+    XCTAssertEqual(emits, 3)
+  }
+}

--- a/ios/NitroGoogleCast/CastMessageChannel.swift
+++ b/ios/NitroGoogleCast/CastMessageChannel.swift
@@ -1,0 +1,47 @@
+import Foundation
+import GoogleCast
+
+/// A registered custom channel: `GCKCastChannel` subclass forwarding inbound
+/// text messages and connection-status changes to closures (Phase 5.2).
+///
+/// Unlike the `GCKSessionManagerListener` adapters, these are base-class
+/// *overrides* (not optional protocol selectors), so a wrong signature fails to
+/// compile — no silent-miss hazard. The transport owns the single strong
+/// reference per namespace and clears its registry on session end/suspend (A1).
+final class CastMessageChannel: GCKCastChannel {
+  private let onMessage: (String) -> Void
+  /// (connected, writable) — emitted on every connect/disconnect/writable change.
+  private let onStatus: (Bool, Bool) -> Void
+
+  init(
+    namespace: String,
+    onMessage: @escaping (String) -> Void,
+    onStatus: @escaping (Bool, Bool) -> Void
+  ) {
+    self.onMessage = onMessage
+    self.onStatus = onStatus
+    super.init(namespace: namespace)
+  }
+
+  override func didReceiveTextMessage(_ message: String) {
+    onMessage(message)
+  }
+
+  override func didConnect() {
+    emitStatus()
+  }
+
+  override func didDisconnect() {
+    emitStatus()
+  }
+
+  override func didChangeWritableState(_ isWritable: Bool) {
+    emitStatus()
+  }
+
+  /// Read the live GCK properties rather than trusting callback arguments —
+  /// one path for all three status events.
+  private func emitStatus() {
+    onStatus(isConnected, isWritable)
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -35,8 +35,9 @@ final class HybridCastTransport: HybridCastTransportSpec {
   private var onChannelStatus: ((String, Bool, Bool) -> Void)?
   // Registered custom channels by namespace (Phase 5.2). The transport owns the
   // single strong reference per channel; cleared explicitly on session
-  // end/suspend/replace and on dispose (A1), so a dead session's channels can
-  // never leak into the next one. Main thread only.
+  // end/suspend and on dispose (A1), so a dead session's channels can never
+  // leak into the next one (a replace is covered too: GCK always ends the old
+  // session before starting its replacement). Main thread only.
   private var channels: [String: CastMessageChannel] = [:]
 
   private var castStateObserver: NSObjectProtocol?

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -31,6 +31,13 @@ final class HybridCastTransport: HybridCastTransportSpec {
   private var onDevices: (([Device]) -> Void)?
   private var onLifecycle: ((SessionLifecycleEvent) -> Void)?
   private var onMediaStatus: ((MediaStatus) -> Void)?
+  private var onChannelMessage: ((String, String) -> Void)?
+  private var onChannelStatus: ((String, Bool, Bool) -> Void)?
+  // Registered custom channels by namespace (Phase 5.2). The transport owns the
+  // single strong reference per channel; cleared explicitly on session
+  // end/suspend/replace and on dispose (A1), so a dead session's channels can
+  // never leak into the next one. Main thread only.
+  private var channels: [String: CastMessageChannel] = [:]
 
   private var castStateObserver: NSObjectProtocol?
   private var discoveryListener: CastDiscoveryListener?
@@ -72,12 +79,17 @@ final class HybridCastTransport: HybridCastTransportSpec {
     onState: @escaping (_ castState: CastState) -> Void,
     onDevices: @escaping (_ devices: [Device]) -> Void,
     onLifecycle: @escaping (_ event: SessionLifecycleEvent) -> Void,
-    onMediaStatus: @escaping (_ status: MediaStatus) -> Void
+    onMediaStatus: @escaping (_ status: MediaStatus) -> Void,
+    onChannelMessage: @escaping (_ channelNamespace: String, _ message: String) -> Void,
+    onChannelStatus: @escaping (_ channelNamespace: String, _ connected: Bool, _ writable: Bool) ->
+      Void
   ) throws -> Promise<InitialSnapshot> {
     self.onState = onState
     self.onDevices = onDevices
     self.onLifecycle = onLifecycle
     self.onMediaStatus = onMediaStatus
+    self.onChannelMessage = onChannelMessage
+    self.onChannelStatus = onChannelStatus
 
     let promise = Promise<InitialSnapshot>()
     DispatchQueue.main.async { [weak self] in
@@ -138,6 +150,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
       onSessionInactive: { [weak self] in
         self?.detachMediaListener()
         self?.detachDeviceStatusListener()
+        self?.clearChannels()
         self?.flushPendingRequests(code: "interrupted", message: "The Cast session ended.")
       })
     context.sessionManager.add(session)
@@ -169,6 +182,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
       self.detachObservers()
       self.detachMediaListener()
       self.detachDeviceStatusListener()
+      self.clearChannels()
       self.flushPendingRequests(code: "interrupted", message: "The Cast transport was disposed.")
       self.mediaStatusListener = nil
       self.deviceStatusListener = nil
@@ -176,6 +190,8 @@ final class HybridCastTransport: HybridCastTransportSpec {
       self.onDevices = nil
       self.onLifecycle = nil
       self.onMediaStatus = nil
+      self.onChannelMessage = nil
+      self.onChannelStatus = nil
     }
   }
 
@@ -229,6 +245,107 @@ final class HybridCastTransport: HybridCastTransportSpec {
 
   func setDeviceMuted(muted: Bool) throws -> Promise<Void> {
     withCastSession { $0.setDeviceMuted(muted) }
+  }
+
+  // MARK: - custom channels (Phase 5.2 — registry owned here, Invariant 1 for the session)
+
+  func addChannel(channelNamespace namespace: String) throws -> Promise<Void> {
+    let promise = Promise<Void>()
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        promise.reject(
+          withError: castRejection(
+            code: "interrupted", message: "The Cast transport was disposed.", nativeCode: nil))
+        return
+      }
+      guard let session = GCKCastContext.sharedInstance().sessionManager.currentCastSession
+      else {
+        promise.reject(
+          withError: castRejection(
+            code: "noSession", message: "There is no active Cast session.", nativeCode: nil))
+        return
+      }
+      guard self.channels[namespace] == nil else {
+        promise.reject(
+          withError: castRejection(
+            code: "alreadyRegistered",
+            message: "A channel for \(namespace) is already registered.", nativeCode: nil))
+        return
+      }
+      let channel = CastMessageChannel(
+        namespace: namespace,
+        onMessage: { [weak self] message in self?.onChannelMessage?(namespace, message) },
+        onStatus: { [weak self] connected, writable in
+          self?.onChannelStatus?(namespace, connected, writable)
+        })
+      session.add(channel)
+      self.channels[namespace] = channel
+      // Initial status BEFORE resolving, so an awaiting façade reads a
+      // populated value. This is the REAL current value (A2): `isConnected` is
+      // often still false here — the virtual connection completes async and
+      // `didConnect` streams the update when it does.
+      self.onChannelStatus?(namespace, channel.isConnected, channel.isWritable)
+      promise.resolve(withResult: ())
+    }
+    return promise
+  }
+
+  func removeChannel(channelNamespace namespace: String) throws -> Promise<Void> {
+    let promise = Promise<Void>()
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        promise.reject(
+          withError: castRejection(
+            code: "interrupted", message: "The Cast transport was disposed.", nativeCode: nil))
+        return
+      }
+      if let channel = self.channels.removeValue(forKey: namespace) {
+        // Best-effort: the session may already be gone (GCK dropped the
+        // channel with it); removing from a live one keeps GCK in sync.
+        GCKCastContext.sharedInstance().sessionManager.currentCastSession?.remove(channel)
+      }
+      promise.resolve(withResult: ())  // idempotent — not-registered resolves
+    }
+    return promise
+  }
+
+  func sendMessage(channelNamespace namespace: String, message: String) throws -> Promise<Void> {
+    let promise = Promise<Void>()
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        promise.reject(
+          withError: castRejection(
+            code: "interrupted", message: "The Cast transport was disposed.", nativeCode: nil))
+        return
+      }
+      guard let channel = self.channels[namespace] else {
+        promise.reject(
+          withError: castRejection(
+            code: "invalidRequest",
+            message: "No channel registered for \(namespace) — call addChannel first.",
+            nativeCode: nil))
+        return
+      }
+      // `-[GCKCastChannel sendTextMessage:error:]` returns BOOL + a `GCKError **`
+      // out-param (not `NSError **`, so it is NOT bridged to `throws`). The BOOL
+      // is the authority: reject on NO even if GCK left the error pointer empty.
+      var error: GCKError?
+      if channel.sendTextMessage(message, error: &error) {
+        promise.resolve(withResult: ())
+      } else if let error {
+        // Reuse the transport's GCKError → CastError code mapping (same one the
+        // request delegate uses) so send failures reject typed codes.
+        promise.reject(
+          withError: castRejection(
+            code: error.toCastErrorCode(), message: error.localizedDescription,
+            nativeCode: error.code))
+      } else {
+        promise.reject(
+          withError: castRejection(
+            code: "failed", message: "The message could not be sent.", nativeCode: nil))
+      }
+    }
+    return promise
   }
 
   // MARK: - media transport (route to GCKRemoteMediaClient — Invariant 1)
@@ -460,6 +577,17 @@ final class HybridCastTransport: HybridCastTransportSpec {
       session.remove(listener)
     }
     attachedStatusSession = nil
+  }
+
+  /// Drop every registered custom channel (A1). Called on session end/suspend
+  /// and on dispose. Removes from the live session when one still exists
+  /// (`willEnd` fires while it does); otherwise GCK already dropped the channel
+  /// with the session and we only release our strong refs.
+  private func clearChannels() {
+    guard !channels.isEmpty else { return }
+    let session = GCKCastContext.sharedInstance().sessionManager.currentCastSession
+    for channel in channels.values { session?.remove(channel) }
+    channels.removeAll()
   }
 
   /// Reject every still-pending media request. Used on session end / teardown so a

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -279,7 +279,16 @@ final class HybridCastTransport: HybridCastTransportSpec {
         onStatus: { [weak self] connected, writable in
           self?.onChannelStatus?(namespace, connected, writable)
         })
-      session.add(channel)
+      // GCK returns NO when it refuses the registration (e.g. the namespace is
+      // already registered on the session outside this registry) — recording
+      // the channel anyway would hand JS a handle that can never receive.
+      guard session.add(channel) else {
+        promise.reject(
+          withError: castRejection(
+            code: "failed",
+            message: "GCK refused to register a channel for \(namespace).", nativeCode: nil))
+        return
+      }
       self.channels[namespace] = channel
       // Initial status BEFORE resolving, so an awaiting façade reads a
       // populated value. This is the REAL current value (A2): `isConnected` is

--- a/nitrogen/generated/android/c++/JFunc_void_std__string_bool_bool.hpp
+++ b/nitrogen/generated/android/c++/JFunc_void_std__string_bool_bool.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::googlecast {
   using namespace facebook;
 
   /**
-   * Represents the Java/Kotlin callback `(namespace: String, connected: Boolean, writable: Boolean) -> Unit`.
+   * Represents the Java/Kotlin callback `(channelNamespace: String, connected: Boolean, writable: Boolean) -> Unit`.
    * This can be passed around between C++ and Java/Kotlin.
    */
   struct JFunc_void_std__string_bool_bool: public jni::JavaClass<JFunc_void_std__string_bool_bool> {
@@ -30,9 +30,9 @@ namespace margelo::nitro::googlecast {
     /**
      * Invokes the function this `JFunc_void_std__string_bool_bool` instance holds through JNI.
      */
-    void invoke(const std::string& namespace, bool connected, bool writable) const {
-      static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* namespace */, jboolean /* connected */, jboolean /* writable */)>("invoke");
-      method(self(), jni::make_jstring(namespace), connected, writable);
+    void invoke(const std::string& channelNamespace, bool connected, bool writable) const {
+      static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* channelNamespace */, jboolean /* connected */, jboolean /* writable */)>("invoke");
+      method(self(), jni::make_jstring(channelNamespace), connected, writable);
     }
   };
 
@@ -41,7 +41,7 @@ namespace margelo::nitro::googlecast {
    */
   class JFunc_void_std__string_bool_bool_cxx final: public jni::HybridClass<JFunc_void_std__string_bool_bool_cxx, JFunc_void_std__string_bool_bool> {
   public:
-    static jni::local_ref<JFunc_void_std__string_bool_bool::javaobject> fromCpp(const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& func) {
+    static jni::local_ref<JFunc_void_std__string_bool_bool::javaobject> fromCpp(const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& func) {
       return JFunc_void_std__string_bool_bool_cxx::newObjectCxxArgs(func);
     }
 
@@ -49,13 +49,13 @@ namespace margelo::nitro::googlecast {
     /**
      * Invokes the C++ `std::function<...>` this `JFunc_void_std__string_bool_bool_cxx` instance holds.
      */
-    void invoke_cxx(jni::alias_ref<jni::JString> namespace, jboolean connected, jboolean writable) {
-      _func(namespace->toStdString(), static_cast<bool>(connected), static_cast<bool>(writable));
+    void invoke_cxx(jni::alias_ref<jni::JString> channelNamespace, jboolean connected, jboolean writable) {
+      _func(channelNamespace->toStdString(), static_cast<bool>(connected), static_cast<bool>(writable));
     }
 
   public:
     [[nodiscard]]
-    inline const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& getFunction() const {
+    inline const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& getFunction() const {
       return _func;
     }
 
@@ -66,11 +66,11 @@ namespace margelo::nitro::googlecast {
     }
 
   private:
-    explicit JFunc_void_std__string_bool_bool_cxx(const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& func): _func(func) { }
+    explicit JFunc_void_std__string_bool_bool_cxx(const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& func): _func(func) { }
 
   private:
     friend HybridBase;
-    std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)> _func;
+    std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)> _func;
   };
 
 } // namespace margelo::nitro::googlecast

--- a/nitrogen/generated/android/c++/JFunc_void_std__string_std__string.hpp
+++ b/nitrogen/generated/android/c++/JFunc_void_std__string_std__string.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::googlecast {
   using namespace facebook;
 
   /**
-   * Represents the Java/Kotlin callback `(namespace: String, message: String) -> Unit`.
+   * Represents the Java/Kotlin callback `(channelNamespace: String, message: String) -> Unit`.
    * This can be passed around between C++ and Java/Kotlin.
    */
   struct JFunc_void_std__string_std__string: public jni::JavaClass<JFunc_void_std__string_std__string> {
@@ -30,9 +30,9 @@ namespace margelo::nitro::googlecast {
     /**
      * Invokes the function this `JFunc_void_std__string_std__string` instance holds through JNI.
      */
-    void invoke(const std::string& namespace, const std::string& message) const {
-      static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* namespace */, jni::alias_ref<jni::JString> /* message */)>("invoke");
-      method(self(), jni::make_jstring(namespace), jni::make_jstring(message));
+    void invoke(const std::string& channelNamespace, const std::string& message) const {
+      static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* channelNamespace */, jni::alias_ref<jni::JString> /* message */)>("invoke");
+      method(self(), jni::make_jstring(channelNamespace), jni::make_jstring(message));
     }
   };
 
@@ -41,7 +41,7 @@ namespace margelo::nitro::googlecast {
    */
   class JFunc_void_std__string_std__string_cxx final: public jni::HybridClass<JFunc_void_std__string_std__string_cxx, JFunc_void_std__string_std__string> {
   public:
-    static jni::local_ref<JFunc_void_std__string_std__string::javaobject> fromCpp(const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& func) {
+    static jni::local_ref<JFunc_void_std__string_std__string::javaobject> fromCpp(const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& func) {
       return JFunc_void_std__string_std__string_cxx::newObjectCxxArgs(func);
     }
 
@@ -49,13 +49,13 @@ namespace margelo::nitro::googlecast {
     /**
      * Invokes the C++ `std::function<...>` this `JFunc_void_std__string_std__string_cxx` instance holds.
      */
-    void invoke_cxx(jni::alias_ref<jni::JString> namespace, jni::alias_ref<jni::JString> message) {
-      _func(namespace->toStdString(), message->toStdString());
+    void invoke_cxx(jni::alias_ref<jni::JString> channelNamespace, jni::alias_ref<jni::JString> message) {
+      _func(channelNamespace->toStdString(), message->toStdString());
     }
 
   public:
     [[nodiscard]]
-    inline const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& getFunction() const {
+    inline const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& getFunction() const {
       return _func;
     }
 
@@ -66,11 +66,11 @@ namespace margelo::nitro::googlecast {
     }
 
   private:
-    explicit JFunc_void_std__string_std__string_cxx(const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& func): _func(func) { }
+    explicit JFunc_void_std__string_std__string_cxx(const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& func): _func(func) { }
 
   private:
     friend HybridBase;
-    std::function<void(const std::string& /* namespace */, const std::string& /* message */)> _func;
+    std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)> _func;
   };
 
 } // namespace margelo::nitro::googlecast

--- a/nitrogen/generated/android/c++/JHybridCastTransportSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridCastTransportSpec.cpp
@@ -244,7 +244,7 @@ namespace margelo::nitro::googlecast {
   }
 
   // Methods
-  std::shared_ptr<Promise<InitialSnapshot>> JHybridCastTransportSpec::initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) {
+  std::shared_ptr<Promise<InitialSnapshot>> JHybridCastTransportSpec::initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JFunc_void_CastState::javaobject> /* onState */, jni::alias_ref<JFunc_void_std__vector_Device_::javaobject> /* onDevices */, jni::alias_ref<JFunc_void_SessionLifecycleEvent::javaobject> /* onLifecycle */, jni::alias_ref<JFunc_void_MediaStatus::javaobject> /* onMediaStatus */, jni::alias_ref<JFunc_void_std__string_std__string::javaobject> /* onChannelMessage */, jni::alias_ref<JFunc_void_std__string_bool_bool::javaobject> /* onChannelStatus */)>("initAndSubscribe_cxx");
     auto __result = method(_javaPart, JFunc_void_CastState_cxx::fromCpp(onState), JFunc_void_std__vector_Device__cxx::fromCpp(onDevices), JFunc_void_SessionLifecycleEvent_cxx::fromCpp(onLifecycle), JFunc_void_MediaStatus_cxx::fromCpp(onMediaStatus), JFunc_void_std__string_std__string_cxx::fromCpp(onChannelMessage), JFunc_void_std__string_bool_bool_cxx::fromCpp(onChannelStatus));
     return [&]() {
@@ -320,9 +320,9 @@ namespace margelo::nitro::googlecast {
       return __promise;
     }();
   }
-  std::shared_ptr<Promise<void>> JHybridCastTransportSpec::addChannel(const std::string& namespace) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* namespace */)>("addChannel");
-    auto __result = method(_javaPart, jni::make_jstring(namespace));
+  std::shared_ptr<Promise<void>> JHybridCastTransportSpec::addChannel(const std::string& channelNamespace) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* channelNamespace */)>("addChannel");
+    auto __result = method(_javaPart, jni::make_jstring(channelNamespace));
     return [&]() {
       auto __promise = Promise<void>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
@@ -335,9 +335,9 @@ namespace margelo::nitro::googlecast {
       return __promise;
     }();
   }
-  std::shared_ptr<Promise<void>> JHybridCastTransportSpec::removeChannel(const std::string& namespace) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* namespace */)>("removeChannel");
-    auto __result = method(_javaPart, jni::make_jstring(namespace));
+  std::shared_ptr<Promise<void>> JHybridCastTransportSpec::removeChannel(const std::string& channelNamespace) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* channelNamespace */)>("removeChannel");
+    auto __result = method(_javaPart, jni::make_jstring(channelNamespace));
     return [&]() {
       auto __promise = Promise<void>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
@@ -350,9 +350,9 @@ namespace margelo::nitro::googlecast {
       return __promise;
     }();
   }
-  std::shared_ptr<Promise<void>> JHybridCastTransportSpec::sendMessage(const std::string& namespace, const std::string& message) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* namespace */, jni::alias_ref<jni::JString> /* message */)>("sendMessage");
-    auto __result = method(_javaPart, jni::make_jstring(namespace), jni::make_jstring(message));
+  std::shared_ptr<Promise<void>> JHybridCastTransportSpec::sendMessage(const std::string& channelNamespace, const std::string& message) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* channelNamespace */, jni::alias_ref<jni::JString> /* message */)>("sendMessage");
+    auto __result = method(_javaPart, jni::make_jstring(channelNamespace), jni::make_jstring(message));
     return [&]() {
       auto __promise = Promise<void>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {

--- a/nitrogen/generated/android/c++/JHybridCastTransportSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridCastTransportSpec.hpp
@@ -56,14 +56,14 @@ namespace margelo::nitro::googlecast {
 
   public:
     // Methods
-    std::shared_ptr<Promise<InitialSnapshot>> initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) override;
+    std::shared_ptr<Promise<InitialSnapshot>> initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) override;
     std::shared_ptr<Promise<void>> startSession(const std::string& deviceId) override;
     std::shared_ptr<Promise<void>> endCurrentSession(bool stopCasting) override;
     std::shared_ptr<Promise<void>> setDeviceVolume(double volume) override;
     std::shared_ptr<Promise<void>> setDeviceMuted(bool muted) override;
-    std::shared_ptr<Promise<void>> addChannel(const std::string& namespace) override;
-    std::shared_ptr<Promise<void>> removeChannel(const std::string& namespace) override;
-    std::shared_ptr<Promise<void>> sendMessage(const std::string& namespace, const std::string& message) override;
+    std::shared_ptr<Promise<void>> addChannel(const std::string& channelNamespace) override;
+    std::shared_ptr<Promise<void>> removeChannel(const std::string& channelNamespace) override;
+    std::shared_ptr<Promise<void>> sendMessage(const std::string& channelNamespace, const std::string& message) override;
     std::shared_ptr<Promise<void>> loadMedia(const MediaLoadRequest& request) override;
     std::shared_ptr<Promise<void>> play() override;
     std::shared_ptr<Promise<void>> pause() override;

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/Func_void_std__string_bool_bool.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/Func_void_std__string_bool_bool.kt
@@ -14,7 +14,7 @@ import dalvik.annotation.optimization.FastNative
 
 
 /**
- * Represents the JavaScript callback `(namespace: string, connected: boolean, writable: boolean) => void`.
+ * Represents the JavaScript callback `(channelNamespace: string, connected: boolean, writable: boolean) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),
  * or in Kotlin/Java (in which case it is a native callback).
  */
@@ -28,11 +28,11 @@ fun interface Func_void_std__string_bool_bool: (String, Boolean, Boolean) -> Uni
    */
   @DoNotStrip
   @Keep
-  override fun invoke(namespace: String, connected: Boolean, writable: Boolean): Unit
+  override fun invoke(channelNamespace: String, connected: Boolean, writable: Boolean): Unit
 }
 
 /**
- * Represents the JavaScript callback `(namespace: string, connected: boolean, writable: boolean) => void`.
+ * Represents the JavaScript callback `(channelNamespace: string, connected: boolean, writable: boolean) => void`.
  * This is implemented in C++, via a `std::function<...>`.
  * The callback might be coming from JS.
  */
@@ -56,15 +56,15 @@ class Func_void_std__string_bool_bool_cxx: Func_void_std__string_bool_bool {
 
   @DoNotStrip
   @Keep
-  override fun invoke(namespace: String, connected: Boolean, writable: Boolean): Unit
-    = invoke_cxx(namespace,connected,writable)
+  override fun invoke(channelNamespace: String, connected: Boolean, writable: Boolean): Unit
+    = invoke_cxx(channelNamespace,connected,writable)
 
   @FastNative
-  private external fun invoke_cxx(namespace: String, connected: Boolean, writable: Boolean): Unit
+  private external fun invoke_cxx(channelNamespace: String, connected: Boolean, writable: Boolean): Unit
 }
 
 /**
- * Represents the JavaScript callback `(namespace: string, connected: boolean, writable: boolean) => void`.
+ * Represents the JavaScript callback `(channelNamespace: string, connected: boolean, writable: boolean) => void`.
  * This is implemented in Java/Kotlin, via a `(String, Boolean, Boolean) -> Unit`.
  * The callback is always coming from native.
  */
@@ -74,7 +74,7 @@ class Func_void_std__string_bool_bool_cxx: Func_void_std__string_bool_bool {
 class Func_void_std__string_bool_bool_java(private val function: (String, Boolean, Boolean) -> Unit): Func_void_std__string_bool_bool {
   @DoNotStrip
   @Keep
-  override fun invoke(namespace: String, connected: Boolean, writable: Boolean): Unit {
-    return this.function(namespace, connected, writable)
+  override fun invoke(channelNamespace: String, connected: Boolean, writable: Boolean): Unit {
+    return this.function(channelNamespace, connected, writable)
   }
 }

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/Func_void_std__string_std__string.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/Func_void_std__string_std__string.kt
@@ -14,7 +14,7 @@ import dalvik.annotation.optimization.FastNative
 
 
 /**
- * Represents the JavaScript callback `(namespace: string, message: string) => void`.
+ * Represents the JavaScript callback `(channelNamespace: string, message: string) => void`.
  * This can be either implemented in C++ (in which case it might be a callback coming from JS),
  * or in Kotlin/Java (in which case it is a native callback).
  */
@@ -28,11 +28,11 @@ fun interface Func_void_std__string_std__string: (String, String) -> Unit {
    */
   @DoNotStrip
   @Keep
-  override fun invoke(namespace: String, message: String): Unit
+  override fun invoke(channelNamespace: String, message: String): Unit
 }
 
 /**
- * Represents the JavaScript callback `(namespace: string, message: string) => void`.
+ * Represents the JavaScript callback `(channelNamespace: string, message: string) => void`.
  * This is implemented in C++, via a `std::function<...>`.
  * The callback might be coming from JS.
  */
@@ -56,15 +56,15 @@ class Func_void_std__string_std__string_cxx: Func_void_std__string_std__string {
 
   @DoNotStrip
   @Keep
-  override fun invoke(namespace: String, message: String): Unit
-    = invoke_cxx(namespace,message)
+  override fun invoke(channelNamespace: String, message: String): Unit
+    = invoke_cxx(channelNamespace,message)
 
   @FastNative
-  private external fun invoke_cxx(namespace: String, message: String): Unit
+  private external fun invoke_cxx(channelNamespace: String, message: String): Unit
 }
 
 /**
- * Represents the JavaScript callback `(namespace: string, message: string) => void`.
+ * Represents the JavaScript callback `(channelNamespace: string, message: string) => void`.
  * This is implemented in Java/Kotlin, via a `(String, String) -> Unit`.
  * The callback is always coming from native.
  */
@@ -74,7 +74,7 @@ class Func_void_std__string_std__string_cxx: Func_void_std__string_std__string {
 class Func_void_std__string_std__string_java(private val function: (String, String) -> Unit): Func_void_std__string_std__string {
   @DoNotStrip
   @Keep
-  override fun invoke(namespace: String, message: String): Unit {
-    return this.function(namespace, message)
+  override fun invoke(channelNamespace: String, message: String): Unit {
+    return this.function(channelNamespace, message)
   }
 }

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/HybridCastTransportSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/HybridCastTransportSpec.kt
@@ -39,7 +39,7 @@ abstract class HybridCastTransportSpec: HybridObject() {
   abstract val isPassiveScan: Boolean
 
   // Methods
-  abstract fun initAndSubscribe(onState: (castState: CastState) -> Unit, onDevices: (devices: Array<Device>) -> Unit, onLifecycle: (event: SessionLifecycleEvent) -> Unit, onMediaStatus: (status: MediaStatus) -> Unit, onChannelMessage: (namespace: String, message: String) -> Unit, onChannelStatus: (namespace: String, connected: Boolean, writable: Boolean) -> Unit): Promise<InitialSnapshot>
+  abstract fun initAndSubscribe(onState: (castState: CastState) -> Unit, onDevices: (devices: Array<Device>) -> Unit, onLifecycle: (event: SessionLifecycleEvent) -> Unit, onMediaStatus: (status: MediaStatus) -> Unit, onChannelMessage: (channelNamespace: String, message: String) -> Unit, onChannelStatus: (channelNamespace: String, connected: Boolean, writable: Boolean) -> Unit): Promise<InitialSnapshot>
   
   @DoNotStrip
   @Keep
@@ -66,15 +66,15 @@ abstract class HybridCastTransportSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun addChannel(namespace: String): Promise<Unit>
+  abstract fun addChannel(channelNamespace: String): Promise<Unit>
   
   @DoNotStrip
   @Keep
-  abstract fun removeChannel(namespace: String): Promise<Unit>
+  abstract fun removeChannel(channelNamespace: String): Promise<Unit>
   
   @DoNotStrip
   @Keep
-  abstract fun sendMessage(namespace: String, message: String): Promise<Unit>
+  abstract fun sendMessage(channelNamespace: String, message: String): Promise<Unit>
   
   @DoNotStrip
   @Keep

--- a/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.cpp
+++ b/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.cpp
@@ -79,19 +79,19 @@ namespace margelo::nitro::googlecast::bridge::swift {
     };
   }
   
-  // pragma MARK: std::function<void(const std::string& /* namespace */, const std::string& /* message */)>
+  // pragma MARK: std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>
   Func_void_std__string_std__string create_Func_void_std__string_std__string(void* NON_NULL swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroGoogleCast::Func_void_std__string_std__string::fromUnsafe(swiftClosureWrapper);
-    return [swiftClosure = std::move(swiftClosure)](const std::string& namespace, const std::string& message) mutable -> void {
-      swiftClosure.call(namespace, message);
+    return [swiftClosure = std::move(swiftClosure)](const std::string& channelNamespace, const std::string& message) mutable -> void {
+      swiftClosure.call(channelNamespace, message);
     };
   }
   
-  // pragma MARK: std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>
+  // pragma MARK: std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>
   Func_void_std__string_bool_bool create_Func_void_std__string_bool_bool(void* NON_NULL swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroGoogleCast::Func_void_std__string_bool_bool::fromUnsafe(swiftClosureWrapper);
-    return [swiftClosure = std::move(swiftClosure)](const std::string& namespace, bool connected, bool writable) mutable -> void {
-      swiftClosure.call(namespace, connected, writable);
+    return [swiftClosure = std::move(swiftClosure)](const std::string& channelNamespace, bool connected, bool writable) mutable -> void {
+      swiftClosure.call(channelNamespace, connected, writable);
     };
   }
   

--- a/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.hpp
@@ -1114,44 +1114,44 @@ namespace margelo::nitro::googlecast::bridge::swift {
     return Func_void_MediaStatus_Wrapper(std::move(value));
   }
   
-  // pragma MARK: std::function<void(const std::string& /* namespace */, const std::string& /* message */)>
+  // pragma MARK: std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>
   /**
    * Specialized version of `std::function<void(const std::string&, const std::string&)>`.
    */
-  using Func_void_std__string_std__string = std::function<void(const std::string& /* namespace */, const std::string& /* message */)>;
+  using Func_void_std__string_std__string = std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>;
   /**
-   * Wrapper class for a `std::function<void(const std::string& / * namespace * /, const std::string& / * message * /)>`, this can be used from Swift.
+   * Wrapper class for a `std::function<void(const std::string& / * channelNamespace * /, const std::string& / * message * /)>`, this can be used from Swift.
    */
   class Func_void_std__string_std__string_Wrapper final {
   public:
-    explicit Func_void_std__string_std__string_Wrapper(std::function<void(const std::string& /* namespace */, const std::string& /* message */)>&& func): _function(std::make_unique<std::function<void(const std::string& /* namespace */, const std::string& /* message */)>>(std::move(func))) {}
-    inline void call(std::string namespace, std::string message) const noexcept {
-      _function->operator()(namespace, message);
+    explicit Func_void_std__string_std__string_Wrapper(std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>&& func): _function(std::make_unique<std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>>(std::move(func))) {}
+    inline void call(std::string channelNamespace, std::string message) const noexcept {
+      _function->operator()(channelNamespace, message);
     }
   private:
-    std::unique_ptr<std::function<void(const std::string& /* namespace */, const std::string& /* message */)>> _function;
+    std::unique_ptr<std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>> _function;
   } SWIFT_NONCOPYABLE;
   Func_void_std__string_std__string create_Func_void_std__string_std__string(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_std__string_std__string_Wrapper wrap_Func_void_std__string_std__string(Func_void_std__string_std__string value) noexcept {
     return Func_void_std__string_std__string_Wrapper(std::move(value));
   }
   
-  // pragma MARK: std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>
+  // pragma MARK: std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>
   /**
    * Specialized version of `std::function<void(const std::string&, bool, bool)>`.
    */
-  using Func_void_std__string_bool_bool = std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>;
+  using Func_void_std__string_bool_bool = std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>;
   /**
-   * Wrapper class for a `std::function<void(const std::string& / * namespace * /, bool / * connected * /, bool / * writable * /)>`, this can be used from Swift.
+   * Wrapper class for a `std::function<void(const std::string& / * channelNamespace * /, bool / * connected * /, bool / * writable * /)>`, this can be used from Swift.
    */
   class Func_void_std__string_bool_bool_Wrapper final {
   public:
-    explicit Func_void_std__string_bool_bool_Wrapper(std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>&& func): _function(std::make_unique<std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>>(std::move(func))) {}
-    inline void call(std::string namespace, bool connected, bool writable) const noexcept {
-      _function->operator()(namespace, connected, writable);
+    explicit Func_void_std__string_bool_bool_Wrapper(std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>&& func): _function(std::make_unique<std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>>(std::move(func))) {}
+    inline void call(std::string channelNamespace, bool connected, bool writable) const noexcept {
+      _function->operator()(channelNamespace, connected, writable);
     }
   private:
-    std::unique_ptr<std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>> _function;
+    std::unique_ptr<std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>> _function;
   } SWIFT_NONCOPYABLE;
   Func_void_std__string_bool_bool create_Func_void_std__string_bool_bool(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_std__string_bool_bool_Wrapper wrap_Func_void_std__string_bool_bool(Func_void_std__string_bool_bool value) noexcept {

--- a/nitrogen/generated/ios/c++/HybridCastTransportSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridCastTransportSpecSwift.hpp
@@ -207,7 +207,7 @@ namespace margelo::nitro::googlecast {
 
   public:
     // Methods
-    inline std::shared_ptr<Promise<InitialSnapshot>> initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) override {
+    inline std::shared_ptr<Promise<InitialSnapshot>> initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) override {
       auto __result = _swiftPart.initAndSubscribe(onState, onDevices, onLifecycle, onMediaStatus, onChannelMessage, onChannelStatus);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
@@ -247,24 +247,24 @@ namespace margelo::nitro::googlecast {
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline std::shared_ptr<Promise<void>> addChannel(const std::string& namespace) override {
-      auto __result = _swiftPart.addChannel(namespace);
+    inline std::shared_ptr<Promise<void>> addChannel(const std::string& channelNamespace) override {
+      auto __result = _swiftPart.addChannel(channelNamespace);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline std::shared_ptr<Promise<void>> removeChannel(const std::string& namespace) override {
-      auto __result = _swiftPart.removeChannel(namespace);
+    inline std::shared_ptr<Promise<void>> removeChannel(const std::string& channelNamespace) override {
+      auto __result = _swiftPart.removeChannel(channelNamespace);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline std::shared_ptr<Promise<void>> sendMessage(const std::string& namespace, const std::string& message) override {
-      auto __result = _swiftPart.sendMessage(namespace, message);
+    inline std::shared_ptr<Promise<void>> sendMessage(const std::string& channelNamespace, const std::string& message) override {
+      auto __result = _swiftPart.sendMessage(channelNamespace, message);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/nitrogen/generated/ios/swift/Func_void_std__string_bool_bool.swift
+++ b/nitrogen/generated/ios/swift/Func_void_std__string_bool_bool.swift
@@ -8,21 +8,21 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ namespace: String, _ connected: Bool, _ writable: Bool) -> Void` as a class.
+ * Wraps a Swift `(_ channelNamespace: String, _ connected: Bool, _ writable: Bool) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__string_bool_bool {
   public typealias bridge = margelo.nitro.googlecast.bridge.swift
 
-  private let closure: (_ namespace: String, _ connected: Bool, _ writable: Bool) -> Void
+  private let closure: (_ channelNamespace: String, _ connected: Bool, _ writable: Bool) -> Void
 
-  public init(_ closure: @escaping (_ namespace: String, _ connected: Bool, _ writable: Bool) -> Void) {
+  public init(_ closure: @escaping (_ channelNamespace: String, _ connected: Bool, _ writable: Bool) -> Void) {
     self.closure = closure
   }
 
   @inline(__always)
-  public func call(namespace: std.string, connected: Bool, writable: Bool) -> Void {
-    self.closure(String(namespace), connected, writable)
+  public func call(channelNamespace: std.string, connected: Bool, writable: Bool) -> Void {
+    self.closure(String(channelNamespace), connected, writable)
   }
 
   /**

--- a/nitrogen/generated/ios/swift/Func_void_std__string_std__string.swift
+++ b/nitrogen/generated/ios/swift/Func_void_std__string_std__string.swift
@@ -8,21 +8,21 @@
 import NitroModules
 
 /**
- * Wraps a Swift `(_ namespace: String, _ message: String) -> Void` as a class.
+ * Wraps a Swift `(_ channelNamespace: String, _ message: String) -> Void` as a class.
  * This class can be used from C++, e.g. to wrap the Swift closure as a `std::function`.
  */
 public final class Func_void_std__string_std__string {
   public typealias bridge = margelo.nitro.googlecast.bridge.swift
 
-  private let closure: (_ namespace: String, _ message: String) -> Void
+  private let closure: (_ channelNamespace: String, _ message: String) -> Void
 
-  public init(_ closure: @escaping (_ namespace: String, _ message: String) -> Void) {
+  public init(_ closure: @escaping (_ channelNamespace: String, _ message: String) -> Void) {
     self.closure = closure
   }
 
   @inline(__always)
-  public func call(namespace: std.string, message: std.string) -> Void {
-    self.closure(String(namespace), String(message))
+  public func call(channelNamespace: std.string, message: std.string) -> Void {
+    self.closure(String(channelNamespace), String(message))
   }
 
   /**

--- a/nitrogen/generated/ios/swift/HybridCastTransportSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridCastTransportSpec.swift
@@ -15,14 +15,14 @@ public protocol HybridCastTransportSpec_protocol: HybridObject {
   var isPassiveScan: Bool { get }
 
   // Methods
-  func initAndSubscribe(onState: @escaping (_ castState: CastState) -> Void, onDevices: @escaping (_ devices: [Device]) -> Void, onLifecycle: @escaping (_ event: SessionLifecycleEvent) -> Void, onMediaStatus: @escaping (_ status: MediaStatus) -> Void, onChannelMessage: @escaping (_ namespace: String, _ message: String) -> Void, onChannelStatus: @escaping (_ namespace: String, _ connected: Bool, _ writable: Bool) -> Void) throws -> Promise<InitialSnapshot>
+  func initAndSubscribe(onState: @escaping (_ castState: CastState) -> Void, onDevices: @escaping (_ devices: [Device]) -> Void, onLifecycle: @escaping (_ event: SessionLifecycleEvent) -> Void, onMediaStatus: @escaping (_ status: MediaStatus) -> Void, onChannelMessage: @escaping (_ channelNamespace: String, _ message: String) -> Void, onChannelStatus: @escaping (_ channelNamespace: String, _ connected: Bool, _ writable: Bool) -> Void) throws -> Promise<InitialSnapshot>
   func startSession(deviceId: String) throws -> Promise<Void>
   func endCurrentSession(stopCasting: Bool) throws -> Promise<Void>
   func setDeviceVolume(volume: Double) throws -> Promise<Void>
   func setDeviceMuted(muted: Bool) throws -> Promise<Void>
-  func addChannel(namespace: String) throws -> Promise<Void>
-  func removeChannel(namespace: String) throws -> Promise<Void>
-  func sendMessage(namespace: String, message: String) throws -> Promise<Void>
+  func addChannel(channelNamespace: String) throws -> Promise<Void>
+  func removeChannel(channelNamespace: String) throws -> Promise<Void>
+  func sendMessage(channelNamespace: String, message: String) throws -> Promise<Void>
   func loadMedia(request: MediaLoadRequest) throws -> Promise<Void>
   func play() throws -> Promise<Void>
   func pause() throws -> Promise<Void>

--- a/nitrogen/generated/ios/swift/HybridCastTransportSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridCastTransportSpec_cxx.swift
@@ -174,13 +174,13 @@ open class HybridCastTransportSpec_cxx {
         }
       }(), onChannelMessage: { () -> (String, String) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__string_std__string(onChannelMessage)
-        return { (__namespace: String, __message: String) -> Void in
-          __wrappedFunction.call(std.string(__namespace), std.string(__message))
+        return { (__channelNamespace: String, __message: String) -> Void in
+          __wrappedFunction.call(std.string(__channelNamespace), std.string(__message))
         }
       }(), onChannelStatus: { () -> (String, Bool, Bool) -> Void in
         let __wrappedFunction = bridge.wrap_Func_void_std__string_bool_bool(onChannelStatus)
-        return { (__namespace: String, __connected: Bool, __writable: Bool) -> Void in
-          __wrappedFunction.call(std.string(__namespace), __connected, __writable)
+        return { (__channelNamespace: String, __connected: Bool, __writable: Bool) -> Void in
+          __wrappedFunction.call(std.string(__channelNamespace), __connected, __writable)
         }
       }())
       let __resultCpp = { () -> bridge.std__shared_ptr_Promise_InitialSnapshot__ in
@@ -275,9 +275,9 @@ open class HybridCastTransportSpec_cxx {
   }
   
   @inline(__always)
-  public final func addChannel(namespace: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
+  public final func addChannel(channelNamespace: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      let __result = try self.__implementation.addChannel(namespace: String(namespace))
+      let __result = try self.__implementation.addChannel(channelNamespace: String(channelNamespace))
       let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
         let __promise = bridge.create_std__shared_ptr_Promise_void__()
         let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
@@ -294,9 +294,9 @@ open class HybridCastTransportSpec_cxx {
   }
   
   @inline(__always)
-  public final func removeChannel(namespace: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
+  public final func removeChannel(channelNamespace: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      let __result = try self.__implementation.removeChannel(namespace: String(namespace))
+      let __result = try self.__implementation.removeChannel(channelNamespace: String(channelNamespace))
       let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
         let __promise = bridge.create_std__shared_ptr_Promise_void__()
         let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
@@ -313,9 +313,9 @@ open class HybridCastTransportSpec_cxx {
   }
   
   @inline(__always)
-  public final func sendMessage(namespace: std.string, message: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
+  public final func sendMessage(channelNamespace: std.string, message: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      let __result = try self.__implementation.sendMessage(namespace: String(namespace), message: String(message))
+      let __result = try self.__implementation.sendMessage(channelNamespace: String(channelNamespace), message: String(message))
       let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
         let __promise = bridge.create_std__shared_ptr_Promise_void__()
         let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)

--- a/nitrogen/generated/shared/c++/HybridCastTransportSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridCastTransportSpec.hpp
@@ -82,14 +82,14 @@ namespace margelo::nitro::googlecast {
 
     public:
       // Methods
-      virtual std::shared_ptr<Promise<InitialSnapshot>> initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* namespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* namespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) = 0;
+      virtual std::shared_ptr<Promise<InitialSnapshot>> initAndSubscribe(const std::function<void(CastState /* castState */)>& onState, const std::function<void(const std::vector<Device>& /* devices */)>& onDevices, const std::function<void(const SessionLifecycleEvent& /* event */)>& onLifecycle, const std::function<void(const MediaStatus& /* status */)>& onMediaStatus, const std::function<void(const std::string& /* channelNamespace */, const std::string& /* message */)>& onChannelMessage, const std::function<void(const std::string& /* channelNamespace */, bool /* connected */, bool /* writable */)>& onChannelStatus) = 0;
       virtual std::shared_ptr<Promise<void>> startSession(const std::string& deviceId) = 0;
       virtual std::shared_ptr<Promise<void>> endCurrentSession(bool stopCasting) = 0;
       virtual std::shared_ptr<Promise<void>> setDeviceVolume(double volume) = 0;
       virtual std::shared_ptr<Promise<void>> setDeviceMuted(bool muted) = 0;
-      virtual std::shared_ptr<Promise<void>> addChannel(const std::string& namespace) = 0;
-      virtual std::shared_ptr<Promise<void>> removeChannel(const std::string& namespace) = 0;
-      virtual std::shared_ptr<Promise<void>> sendMessage(const std::string& namespace, const std::string& message) = 0;
+      virtual std::shared_ptr<Promise<void>> addChannel(const std::string& channelNamespace) = 0;
+      virtual std::shared_ptr<Promise<void>> removeChannel(const std::string& channelNamespace) = 0;
+      virtual std::shared_ptr<Promise<void>> sendMessage(const std::string& channelNamespace, const std::string& message) = 0;
       virtual std::shared_ptr<Promise<void>> loadMedia(const MediaLoadRequest& request) = 0;
       virtual std::shared_ptr<Promise<void>> play() = 0;
       virtual std::shared_ptr<Promise<void>> pause() = 0;

--- a/src/api/CastChannel.ts
+++ b/src/api/CastChannel.ts
@@ -155,9 +155,12 @@ export class CastChannel {
    * registrable again. (Channels are also auto-removed when the session ends.)
    */
   async remove(): Promise<void> {
+    // Drop the listener even when stale: a remove racing the session teardown
+    // (the useCastChannel cleanup path) must not leave the closure retained on
+    // the message bus until a future message for the namespace evicts it.
+    this.offMessage()
     this.assertActive()
     this.removed = true // this handle is dead from here on (isActive → false)
-    this.offMessage()
     // Free the namespace SYNCHRONOUSLY, before the bridge call (T1): an
     // immediate re-add (e.g. a `useCastChannel` remount) must pass the
     // register-once check without awaiting the removal. Ordering stays safe on

--- a/src/api/CastChannel.ts
+++ b/src/api/CastChannel.ts
@@ -39,6 +39,12 @@ export class CastChannel {
   private readonly transport: CastTransportApi
   private readonly generation: number
   private offMessageFn: (() => void) | null = null
+  /**
+   * Set by {@link remove}. The generation alone can't catch removal (the
+   * session lives on), and without this a removed handle could send over — or
+   * subscribe to — a *new* channel later registered on the same namespace.
+   */
+  private removed = false
 
   /** @internal Created by {@link CastSession.addChannel} — do not construct directly. */
   constructor(
@@ -53,9 +59,14 @@ export class CastChannel {
     this.generation = generation
   }
 
-  /** Whether this channel still belongs to the current live session. */
+  /**
+   * Whether this channel still belongs to the current live session and has
+   * not been {@link remove}d.
+   */
   get isActive(): boolean {
-    return this.store.getCurrentGeneration() === this.generation
+    return (
+      !this.removed && this.store.getCurrentGeneration() === this.generation
+    )
   }
 
   /**
@@ -145,6 +156,7 @@ export class CastChannel {
    */
   async remove(): Promise<void> {
     this.assertActive()
+    this.removed = true // this handle is dead from here on (isActive → false)
     this.offMessage()
     // Free the namespace SYNCHRONOUSLY, before the bridge call (T1): an
     // immediate re-add (e.g. a `useCastChannel` remount) must pass the

--- a/src/api/CastChannel.ts
+++ b/src/api/CastChannel.ts
@@ -63,6 +63,9 @@ export class CastChannel {
    * channel (or its session) is gone. iOS reports live values — often `false`
    * right after {@link CastSession.addChannel} (the connection completes
    * asynchronously); Android always reports `true` (register-once, v4 parity).
+   *
+   * A point-in-time read of the store cache, not a reactive value: a component
+   * rendering it does not re-render when the status changes (v4 parity).
    */
   get connected(): boolean | undefined {
     return this.status()?.connected

--- a/src/api/CastChannel.ts
+++ b/src/api/CastChannel.ts
@@ -1,0 +1,156 @@
+import type { CastError, CastTransportApi } from '../transport/types'
+import type { CastStore } from '../state/CastStore'
+import {
+  CHANNEL_SLICE_KEY,
+  type ChannelState,
+  type ChannelStatus,
+} from '../state/channel.slice'
+
+/** Custom channel namespaces must start with this prefix (v4 parity). */
+export const CAST_NAMESPACE_PREFIX = 'urn:x-cast:'
+/** GCK's own media namespace — reserved, cannot be registered (v4 parity). */
+export const RESERVED_MEDIA_NAMESPACE = 'urn:x-cast:com.google.cast.media'
+
+/**
+ * A channel for sending custom messages between this sender and the Cast
+ * receiver, created via {@link CastSession.addChannel} (or the
+ * {@link useCastChannel} hook). Use when you've built a custom receiver and
+ * want to communicate with it.
+ *
+ * Like {@link CastSession}, a channel is **generation-bound** (Invariant 3): it
+ * belongs to the session that was live when it was added. Channels are
+ * auto-removed natively when the session ends, so once that session is gone
+ * this handle is stale — `sendMessage`/`remove` reject `noSession` before
+ * crossing the bridge, `connected`/`writable` read `undefined`, and a retained
+ * message listener can never receive a later session's messages (even if the
+ * same namespace is re-registered).
+ *
+ * `onMessage` holds a **single listener, replace-on-set** (v4 semantics): a
+ * channel is a pipe, not a broadcast. Messages are always delivered as the raw
+ * string received — call `JSON.parse` yourself if your receiver sends JSON.
+ *
+ * @see [Custom Channels](../../guides/custom-channels)
+ */
+export class CastChannel {
+  /** The channel's custom namespace (starts with `urn:x-cast:`). */
+  readonly namespace: string
+
+  private readonly store: CastStore
+  private readonly transport: CastTransportApi
+  private readonly generation: number
+  private offMessageFn: (() => void) | null = null
+
+  /** @internal Created by {@link CastSession.addChannel} — do not construct directly. */
+  constructor(
+    store: CastStore,
+    transport: CastTransportApi,
+    namespace: string,
+    generation: number
+  ) {
+    this.store = store
+    this.transport = transport
+    this.namespace = namespace
+    this.generation = generation
+  }
+
+  /** Whether this channel still belongs to the current live session. */
+  get isActive(): boolean {
+    return this.store.getCurrentGeneration() === this.generation
+  }
+
+  /**
+   * Whether this channel is currently connected, or `undefined` when the
+   * channel (or its session) is gone. iOS reports live values — often `false`
+   * right after {@link CastSession.addChannel} (the connection completes
+   * asynchronously); Android always reports `true` (register-once, v4 parity).
+   */
+  get connected(): boolean | undefined {
+    return this.status()?.connected
+  }
+
+  /** Whether this channel is currently writable (same platform note as `connected`). */
+  get writable(): boolean | undefined {
+    return this.status()?.writable
+  }
+
+  private status(): ChannelStatus | undefined {
+    if (!this.isActive) return undefined
+    return this.store.getSliceState<ChannelState>(CHANNEL_SLICE_KEY).statuses[
+      this.namespace
+    ]
+  }
+
+  private assertActive(): void {
+    if (!this.isActive) {
+      const error: CastError = {
+        code: 'noSession',
+        message: 'This Cast channel’s session has ended.',
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Send a message to the connected Cast receiver on this channel. Objects are
+   * `JSON.stringify`ed (v4 parity); strings pass through unchanged. Note that
+   * by default a custom web receiver parses messages as JSON — send objects
+   * unless you've configured the namespace as `STRING`.
+   *
+   * Settles when the platform accepts/rejects the send (v4 fire-and-forgot on
+   * Android); rejects a typed {@link CastError} (`noSession` once stale).
+   */
+  async sendMessage(message: object | string): Promise<void> {
+    this.assertActive()
+    return this.transport.sendMessage(
+      this.namespace,
+      typeof message === 'string' ? message : JSON.stringify(message)
+    )
+  }
+
+  /**
+   * Register the message listener, **replacing** any previous one (v4 parity —
+   * a channel holds at most one listener; see the listener-ownership note in
+   * the guide). The subscription is liveness-scoped: once this channel is
+   * stale it stops delivering and drops itself.
+   */
+  onMessage(listener: (message: string) => void): void {
+    this.offMessage()
+    if (!this.isActive) return
+    this.offMessageFn = this.store.onChannelMessage(
+      this.namespace,
+      (message) => {
+        // Stale (session changed): drop the subscription instead of delivering
+        // a later session's message for a re-registered namespace.
+        if (!this.isActive) {
+          this.offMessage()
+          return
+        }
+        listener(message)
+      }
+    )
+  }
+
+  /** Unregister the message listener. */
+  offMessage(): void {
+    this.offMessageFn?.()
+    this.offMessageFn = null
+  }
+
+  /**
+   * Remove the channel when it's no longer needed; the namespace becomes
+   * registrable again. (Channels are also auto-removed when the session ends.)
+   */
+  async remove(): Promise<void> {
+    this.assertActive()
+    this.offMessage()
+    // Free the namespace SYNCHRONOUSLY, before the bridge call (T1): an
+    // immediate re-add (e.g. a `useCastChannel` remount) must pass the
+    // register-once check without awaiting the removal. Ordering stays safe on
+    // both sides — the native main-thread queue processes this removeChannel
+    // before any subsequently-issued addChannel. (`removeChannel` is idempotent
+    // and effectively infallible, so the optimistic free cannot strand state;
+    // a teardown clears the slice wholesale anyway.)
+    this.store.dispatch({ kind: 'channelRemoved', namespace: this.namespace })
+    await this.transport.removeChannel(this.namespace)
+  }
+}

--- a/src/api/CastSession.ts
+++ b/src/api/CastSession.ts
@@ -242,6 +242,22 @@ export class CastSession {
 
     await this.transport.addChannel(namespace)
 
+    if (!this.isActive) {
+      // The session was replaced while the native registration was in flight.
+      // Native re-resolves the current session per call (Invariant 1), so the
+      // channel got registered on the NEW session — while the façade we'd
+      // return is bound to this stale generation and could never remove it
+      // (`remove()` rejects `noSession`), poisoning the namespace for the
+      // whole live session. Undo both sides, then reject.
+      this.store.dispatch({ kind: 'channelRemoved', namespace })
+      void this.transport.removeChannel(namespace).catch(() => {})
+      const error: CastError = {
+        code: 'noSession',
+        message: 'This Cast session has ended.',
+      }
+      throw error
+    }
+
     const channel = new CastChannel(
       this.store,
       this.transport,

--- a/src/api/CastSession.ts
+++ b/src/api/CastSession.ts
@@ -11,6 +11,12 @@ import type { StandbyState } from '../types/StandbyState'
 import type { ActiveInputState } from '../types/ActiveInputState'
 import type { EventSubscription } from './subscribeSelector'
 import { RemoteMediaClient } from './RemoteMediaClient'
+import {
+  CastChannel,
+  CAST_NAMESPACE_PREFIX,
+  RESERVED_MEDIA_NAMESPACE,
+} from './CastChannel'
+import { CHANNEL_SLICE_KEY, type ChannelState } from '../state/channel.slice'
 
 /** Fallback detail — unreachable after `assertActive` (a live session is seeded). */
 const DEFAULT_DETAIL: SessionDetail = {
@@ -183,6 +189,74 @@ export class CastSession {
   getClient(): RemoteMediaClient | null {
     this.assertActive()
     return RemoteMediaClient.current(this.store, this.transport)
+  }
+
+  // --- custom channels (Phase 5.2) ---
+
+  /**
+   * Add a custom channel for `namespace` to this session and return its
+   * {@link CastChannel}. The namespace must start with `urn:x-cast:` and is
+   * register-once: adding a namespace that is already registered rejects
+   * `alreadyRegistered` — remove the existing channel first (or lift the
+   * channel to a common parent; see the guide).
+   *
+   * Resolves once native has registered the channel and reported its initial
+   * status, so `channel.connected` is populated — but not necessarily `true`:
+   * on iOS the connection completes asynchronously, and a receiver with no
+   * listener for the namespace never connects (a `console.warn` flags this,
+   * as in v4).
+   *
+   * @param namespace custom channel identifier starting with `urn:x-cast:`.
+   * @param onMessage optional message listener (equivalent to `channel.onMessage`).
+   */
+  async addChannel(
+    namespace: string,
+    onMessage?: (message: string) => void
+  ): Promise<CastChannel> {
+    this.assertActive()
+    if (!namespace.startsWith(CAST_NAMESPACE_PREFIX)) {
+      const error: CastError = {
+        code: 'invalidParameter',
+        message: `Custom channel namespaces must start with "${CAST_NAMESPACE_PREFIX}" (got "${namespace}").`,
+      }
+      throw error
+    }
+    if (namespace === RESERVED_MEDIA_NAMESPACE) {
+      const error: CastError = {
+        code: 'invalidParameter',
+        message: `The namespace "${RESERVED_MEDIA_NAMESPACE}" is reserved. Please use a different name.`,
+      }
+      throw error
+    }
+    const registered =
+      this.store.getSliceState<ChannelState>(CHANNEL_SLICE_KEY).statuses[
+        namespace
+      ]
+    if (registered) {
+      const error: CastError = {
+        code: 'alreadyRegistered',
+        message: `A channel for "${namespace}" is already registered (channels are register-once per namespace). Remove the existing channel first.`,
+      }
+      throw error
+    }
+
+    await this.transport.addChannel(namespace)
+
+    const channel = new CastChannel(
+      this.store,
+      this.transport,
+      namespace,
+      this.generation
+    )
+    if (onMessage) channel.onMessage(onMessage)
+    if (!channel.connected) {
+      // v4-parity hint (A2): the most common cause is a receiver that never
+      // registered a listener for this namespace.
+      console.warn(
+        `Channel ${namespace} is not connected. Make sure a session is established and you've set a listener in your custom receiver: https://developers.google.com/cast/docs/web_receiver/core_features#custom_messages`
+      )
+    }
+    return channel
   }
 
   // --- detail change listeners (via the store's typed bus; never replayed) ---

--- a/src/api/__tests__/channels.test.ts
+++ b/src/api/__tests__/channels.test.ts
@@ -1,0 +1,207 @@
+import { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import type { Device, SessionInfo } from '../../transport/types'
+import { CastStore } from '../../state/CastStore'
+import { SessionManager } from '../SessionManager'
+
+// CastSession → RemoteMediaClient transitively pulls the native singleton;
+// swap it for a fake-backed one (same pattern as facades.test.ts).
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+const NS = 'urn:x-cast:com.example.a'
+const NS_B = 'urn:x-cast:com.example.b'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+
+async function setup() {
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  await store.ready
+  transport.emitLifecycle({ type: 'started', session: session('s1') })
+  const sessionManager = new SessionManager(store, transport)
+  const castSession = sessionManager.getCurrentCastSession()!
+  return { transport, store, sessionManager, castSession }
+}
+
+describe('CastSession.addChannel — validation', () => {
+  it('rejects a namespace without the urn:x-cast: prefix', async () => {
+    const { castSession, transport } = await setup()
+    await expect(castSession.addChannel('com.example.a')).rejects.toMatchObject(
+      { code: 'invalidParameter' }
+    )
+    expect(transport.addChannelCalls).toEqual([])
+  })
+
+  it('rejects the reserved media namespace', async () => {
+    const { castSession } = await setup()
+    await expect(
+      castSession.addChannel('urn:x-cast:com.google.cast.media')
+    ).rejects.toMatchObject({ code: 'invalidParameter' })
+  })
+
+  it('rejects a duplicate namespace with alreadyRegistered (T1)', async () => {
+    const { castSession, transport } = await setup()
+    await castSession.addChannel(NS)
+    await expect(castSession.addChannel(NS)).rejects.toMatchObject({
+      code: 'alreadyRegistered',
+    })
+    expect(transport.addChannelCalls).toEqual([NS]) // second never hit the bridge
+  })
+
+  it('rejects noSession when the session is stale', async () => {
+    const { castSession, transport } = await setup()
+    transport.emitLifecycle({ type: 'ended' })
+    await expect(castSession.addChannel(NS)).rejects.toMatchObject({
+      code: 'noSession',
+    })
+  })
+})
+
+describe('CastSession.addChannel — creation (A2)', () => {
+  it('resolves a channel with populated connected/writable', async () => {
+    const { castSession } = await setup()
+    const channel = await castSession.addChannel(NS)
+    expect(channel.namespace).toBe(NS)
+    expect(channel.connected).toBe(true)
+    expect(channel.writable).toBe(true)
+  })
+
+  it('warns when the initial status is not connected (iOS shape)', async () => {
+    const { castSession, transport } = await setup()
+    transport.addChannelBehavior = async (ns) => {
+      transport.emitChannelStatus(ns, false, false)
+    }
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const channel = await castSession.addChannel(NS)
+    expect(channel.connected).toBe(false)
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain(NS)
+    warn.mockRestore()
+  })
+
+  it('does not warn when connected', async () => {
+    const { castSession } = await setup()
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    await castSession.addChannel(NS)
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('CastChannel — messages', () => {
+  it('routes inbound messages by namespace to the single listener', async () => {
+    const { castSession, transport } = await setup()
+    const onA = jest.fn()
+    const channelA = await castSession.addChannel(NS, onA)
+    await castSession.addChannel(NS_B, jest.fn())
+    transport.emitChannelMessage(NS, '{"hello":"world"}')
+    expect(onA).toHaveBeenCalledWith('{"hello":"world"}')
+    transport.emitChannelMessage(NS_B, 'other')
+    expect(onA).toHaveBeenCalledTimes(1)
+    void channelA
+  })
+
+  it('onMessage replaces the previous listener; offMessage clears it', async () => {
+    const { castSession, transport } = await setup()
+    const first = jest.fn()
+    const second = jest.fn()
+    const channel = await castSession.addChannel(NS, first)
+    channel.onMessage(second)
+    transport.emitChannelMessage(NS, 'm1')
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledWith('m1')
+    channel.offMessage()
+    transport.emitChannelMessage(NS, 'm2')
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('sendMessage stringifies objects and passes strings through (v4)', async () => {
+    const { castSession, transport } = await setup()
+    const channel = await castSession.addChannel(NS)
+    await channel.sendMessage({ hello: 'world' })
+    await channel.sendMessage('raw')
+    expect(transport.sendMessageCalls).toEqual([
+      { namespace: NS, message: '{"hello":"world"}' },
+      { namespace: NS, message: 'raw' },
+    ])
+  })
+})
+
+describe('CastChannel — lifecycle (Invariant 3)', () => {
+  it('sendMessage/remove reject noSession on a stale channel, before the bridge', async () => {
+    const { castSession, transport } = await setup()
+    const channel = await castSession.addChannel(NS)
+    transport.emitLifecycle({ type: 'ended' })
+    await expect(channel.sendMessage('x')).rejects.toMatchObject({
+      code: 'noSession',
+    })
+    await expect(channel.remove()).rejects.toMatchObject({ code: 'noSession' })
+    expect(transport.sendMessageCalls).toEqual([])
+    expect(transport.removeChannelCalls).toEqual([])
+  })
+
+  it('connected/writable read undefined once stale (slice cleared / gated)', async () => {
+    const { castSession, transport } = await setup()
+    const channel = await castSession.addChannel(NS)
+    transport.emitLifecycle({ type: 'ended' })
+    expect(channel.connected).toBeUndefined()
+    expect(channel.writable).toBeUndefined()
+  })
+
+  it('a stale channel never delivers a later session’s messages, even for the same namespace', async () => {
+    const { castSession, transport, sessionManager } = await setup()
+    const staleListener = jest.fn()
+    await castSession.addChannel(NS, staleListener)
+    transport.emitLifecycle({ type: 'ended' })
+    transport.emitLifecycle({ type: 'started', session: session('s2') })
+    // The new session re-registers the same namespace.
+    const fresh = sessionManager.getCurrentCastSession()!
+    const freshListener = jest.fn()
+    await fresh.addChannel(NS, freshListener)
+    transport.emitChannelMessage(NS, 'for-s2')
+    expect(staleListener).not.toHaveBeenCalled()
+    expect(freshListener).toHaveBeenCalledWith('for-s2')
+  })
+
+  it('remove() unregisters, frees the namespace, and drops the listener', async () => {
+    const { castSession, transport, store } = await setup()
+    const listener = jest.fn()
+    const channel = await castSession.addChannel(NS, listener)
+    await channel.remove()
+    expect(transport.removeChannelCalls).toEqual([NS])
+    transport.emitChannelMessage(NS, 'after-remove')
+    expect(listener).not.toHaveBeenCalled()
+    // channelRemoved freed the namespace → re-add succeeds (T1 bookkeeping).
+    await expect(castSession.addChannel(NS)).resolves.toBeDefined()
+    void store
+  })
+
+  it('teardown clears the slice so the namespace is re-addable in a new session', async () => {
+    const { castSession, transport, sessionManager } = await setup()
+    await castSession.addChannel(NS)
+    transport.emitLifecycle({ type: 'ended' })
+    transport.emitLifecycle({ type: 'started', session: session('s2') })
+    const fresh = sessionManager.getCurrentCastSession()!
+    await expect(fresh.addChannel(NS)).resolves.toBeDefined()
+  })
+})

--- a/src/api/__tests__/channels.test.ts
+++ b/src/api/__tests__/channels.test.ts
@@ -204,4 +204,28 @@ describe('CastChannel — lifecycle (Invariant 3)', () => {
     const fresh = sessionManager.getCurrentCastSession()!
     await expect(fresh.addChannel(NS)).resolves.toBeDefined()
   })
+
+  it('addChannel racing a session REPLACE undoes the registration and rejects noSession', async () => {
+    const { castSession, transport, sessionManager } = await setup()
+    transport.addChannelBehavior = async (ns) => {
+      // The session is replaced while the native registration is in flight;
+      // native (Invariant 1) registers on the NEW session and emits its
+      // initial status there — the slice (live for s2) records the entry.
+      transport.emitLifecycle({ type: 'ended' })
+      transport.emitLifecycle({ type: 'started', session: session('s2') })
+      transport.emitChannelStatus(ns, true, true)
+    }
+    await expect(castSession.addChannel(NS)).rejects.toMatchObject({
+      code: 'noSession',
+    })
+    // The undo freed BOTH sides — otherwise the live session's namespace
+    // would be poisoned (its own addChannel would reject alreadyRegistered
+    // forever, and the stale façade could never remove it).
+    expect(transport.removeChannelCalls).toEqual([NS])
+    transport.addChannelBehavior = async (ns) => {
+      transport.emitChannelStatus(ns, true, true)
+    }
+    const fresh = sessionManager.getCurrentCastSession()!
+    await expect(fresh.addChannel(NS)).resolves.toBeDefined()
+  })
 })

--- a/src/api/__tests__/channels.test.ts
+++ b/src/api/__tests__/channels.test.ts
@@ -196,6 +196,27 @@ describe('CastChannel — lifecycle (Invariant 3)', () => {
     void store
   })
 
+  it('a removed handle is dead even though the session lives: it cannot send over or receive from a re-added channel', async () => {
+    const { castSession, transport } = await setup()
+    const staleListener = jest.fn()
+    const old = await castSession.addChannel(NS, staleListener)
+    await old.remove()
+    // Same session, same namespace, new channel.
+    const freshListener = jest.fn()
+    await castSession.addChannel(NS, freshListener)
+
+    await expect(old.sendMessage('x')).rejects.toMatchObject({
+      code: 'noSession',
+    })
+    expect(transport.sendMessageCalls).toEqual([])
+    old.onMessage(staleListener) // no-ops on a removed handle
+    transport.emitChannelMessage(NS, 'for-fresh')
+    expect(staleListener).not.toHaveBeenCalled()
+    expect(freshListener).toHaveBeenCalledWith('for-fresh')
+    expect(old.isActive).toBe(false)
+    expect(old.connected).toBeUndefined()
+  })
+
   it('teardown clears the slice so the namespace is re-addable in a new session', async () => {
     const { castSession, transport, sessionManager } = await setup()
     await castSession.addChannel(NS)

--- a/src/api/__tests__/channels.test.ts
+++ b/src/api/__tests__/channels.test.ts
@@ -196,6 +196,23 @@ describe('CastChannel — lifecycle (Invariant 3)', () => {
     void store
   })
 
+  it('remove() on a stale handle rejects but still drops the bus listener (no leak across sessions)', async () => {
+    const { castSession, transport, store } = await setup()
+    const listener = jest.fn()
+    const channel = await castSession.addChannel(NS, listener)
+    transport.emitLifecycle({ type: 'ended' })
+    await expect(channel.remove()).rejects.toMatchObject({ code: 'noSession' })
+    // White-box on purpose: the wrapper would no-op via the liveness guard
+    // anyway — the finding is the *retention* of the closure on the bus, which
+    // only a handler-count check can observe.
+    const bus = (
+      store as unknown as {
+        channelMessageBus: { handlers: Map<string, Set<unknown>> }
+      }
+    ).channelMessageBus
+    expect(bus.handlers.get(NS)?.size ?? 0).toBe(0)
+  })
+
   it('a removed handle is dead even though the session lives: it cannot send over or receive from a re-added channel', async () => {
     const { castSession, transport } = await setup()
     const staleListener = jest.fn()

--- a/src/api/__tests__/useCastChannel.test.tsx
+++ b/src/api/__tests__/useCastChannel.test.tsx
@@ -4,6 +4,7 @@ import type { Device, SessionInfo } from '../../transport/types'
 import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
 import { castTransport } from '../../state/castStore.singleton'
 import type { CastChannel } from '../CastChannel'
+import { CastSession } from '../CastSession'
 import { useCastChannel } from '../useCastChannel'
 
 jest.mock('../../state/castStore.singleton', () => {
@@ -105,6 +106,35 @@ describe('useCastChannel', () => {
     })
     expect(onMessage).toHaveBeenCalledWith('hi')
     act(() => renderer.unmount())
+  })
+
+  it('installs the listener at addChannel time and forwards to the LATEST onMessage', async () => {
+    // The forwarder is passed INTO addChannel (wired before the channel is
+    // exposed), so an initial receiver message can't be dropped in the gap a
+    // separate post-render wiring effect would leave.
+    const spy = jest.spyOn(CastSession.prototype, 'addChannel')
+    const first = jest.fn()
+    const renderer = createProbe(<Probe namespace={NS} onMessage={first} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    expect(spy).toHaveBeenCalledWith(NS, expect.any(Function))
+
+    // Handler identity change: no re-registration, forwarder reads the ref.
+    const second = jest.fn()
+    act(() => {
+      renderer.update(<Probe namespace={NS} onMessage={second} />)
+    })
+    await flush()
+    expect(transport.addChannelCalls).toEqual([NS]) // still one registration
+    act(() => {
+      transport.emitChannelMessage(NS, 'm')
+    })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledWith('m')
+    act(() => renderer.unmount())
+    spy.mockRestore()
   })
 
   it('removes the channel on unmount', async () => {

--- a/src/api/__tests__/useCastChannel.test.tsx
+++ b/src/api/__tests__/useCastChannel.test.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import type { Device, SessionInfo } from '../../transport/types'
+import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import { castTransport } from '../../state/castStore.singleton'
+import type { CastChannel } from '../CastChannel'
+import { useCastChannel } from '../useCastChannel'
+
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+const transport = castTransport as unknown as FakeCastTransport
+const NS = 'urn:x-cast:com.example.a'
+const NS_B = 'urn:x-cast:com.example.b'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+
+let latest: CastChannel | null = null
+function Probe({
+  namespace,
+  onMessage,
+}: {
+  namespace: string
+  onMessage?: (message: string) => void
+}) {
+  latest = useCastChannel(namespace, onMessage)
+  return null
+}
+
+/** Flush effects + the addChannel/remove promise chains. */
+async function flush() {
+  await act(async () => {})
+}
+
+beforeEach(async () => {
+  latest = null
+  transport.addChannelCalls.length = 0
+  transport.removeChannelCalls.length = 0
+  await flush()
+})
+
+afterEach(() => {
+  act(() => {
+    transport.emitLifecycle({ type: 'ended' })
+  })
+})
+
+describe('useCastChannel', () => {
+  it('is null with no session and adds the channel once one is live', async () => {
+    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    await flush()
+    expect(latest).toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    expect(transport.addChannelCalls).toEqual([NS])
+    expect(latest).not.toBeNull()
+    expect(latest!.namespace).toBe(NS)
+    expect(latest!.connected).toBe(true)
+    renderer.unmount()
+  })
+
+  it('wires onMessage through the hook', async () => {
+    const onMessage = jest.fn()
+    const renderer = TestRenderer.create(
+      <Probe namespace={NS} onMessage={onMessage} />
+    )
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    act(() => {
+      transport.emitChannelMessage(NS, 'hi')
+    })
+    expect(onMessage).toHaveBeenCalledWith('hi')
+    renderer.unmount()
+  })
+
+  it('removes the channel on unmount', async () => {
+    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    renderer.unmount()
+    await act(async () => {})
+    expect(transport.removeChannelCalls).toEqual([NS])
+  })
+
+  it('a remount on the same namespace does not self-collide (T1)', async () => {
+    const first = TestRenderer.create(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    first.unmount()
+    // Immediately remount — remove() frees the namespace synchronously (T1),
+    // so the re-add must not reject `alreadyRegistered` against its predecessor.
+    const second = TestRenderer.create(<Probe namespace={NS} />)
+    await flush()
+    await flush()
+    expect(latest).not.toBeNull()
+    expect(transport.addChannelCalls).toEqual([NS, NS])
+    expect(transport.removeChannelCalls).toEqual([NS])
+    second.unmount()
+  })
+
+  it('switches channels when the namespace changes', async () => {
+    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    act(() => {
+      renderer.update(<Probe namespace={NS_B} />)
+    })
+    await flush()
+    await flush()
+    expect(transport.removeChannelCalls).toEqual([NS])
+    expect(transport.addChannelCalls).toEqual([NS, NS_B])
+    expect(latest!.namespace).toBe(NS_B)
+    renderer.unmount()
+  })
+
+  it('drops to null when the session ends', async () => {
+    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    expect(latest).not.toBeNull()
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+    await flush()
+    expect(latest).toBeNull()
+    renderer.unmount()
+  })
+})

--- a/src/api/__tests__/useCastChannel.test.tsx
+++ b/src/api/__tests__/useCastChannel.test.tsx
@@ -52,6 +52,17 @@ async function flush() {
   await act(async () => {})
 }
 
+/** Mount inside act() so the initial render/effects are properly flushed. */
+function createProbe(
+  element: React.ReactElement
+): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(element)
+  })
+  return renderer
+}
+
 beforeEach(async () => {
   latest = null
   transport.addChannelCalls.length = 0
@@ -67,7 +78,7 @@ afterEach(() => {
 
 describe('useCastChannel', () => {
   it('is null with no session and adds the channel once one is live', async () => {
-    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    const renderer = createProbe(<Probe namespace={NS} />)
     await flush()
     expect(latest).toBeNull()
 
@@ -79,14 +90,12 @@ describe('useCastChannel', () => {
     expect(latest).not.toBeNull()
     expect(latest!.namespace).toBe(NS)
     expect(latest!.connected).toBe(true)
-    renderer.unmount()
+    act(() => renderer.unmount())
   })
 
   it('wires onMessage through the hook', async () => {
     const onMessage = jest.fn()
-    const renderer = TestRenderer.create(
-      <Probe namespace={NS} onMessage={onMessage} />
-    )
+    const renderer = createProbe(<Probe namespace={NS} onMessage={onMessage} />)
     act(() => {
       transport.emitLifecycle({ type: 'started', session: session('s1') })
     })
@@ -95,40 +104,40 @@ describe('useCastChannel', () => {
       transport.emitChannelMessage(NS, 'hi')
     })
     expect(onMessage).toHaveBeenCalledWith('hi')
-    renderer.unmount()
+    act(() => renderer.unmount())
   })
 
   it('removes the channel on unmount', async () => {
-    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    const renderer = createProbe(<Probe namespace={NS} />)
     act(() => {
       transport.emitLifecycle({ type: 'started', session: session('s1') })
     })
     await flush()
-    renderer.unmount()
+    act(() => renderer.unmount())
     await act(async () => {})
     expect(transport.removeChannelCalls).toEqual([NS])
   })
 
   it('a remount on the same namespace does not self-collide (T1)', async () => {
-    const first = TestRenderer.create(<Probe namespace={NS} />)
+    const first = createProbe(<Probe namespace={NS} />)
     act(() => {
       transport.emitLifecycle({ type: 'started', session: session('s1') })
     })
     await flush()
-    first.unmount()
+    act(() => first.unmount())
     // Immediately remount — remove() frees the namespace synchronously (T1),
     // so the re-add must not reject `alreadyRegistered` against its predecessor.
-    const second = TestRenderer.create(<Probe namespace={NS} />)
+    const second = createProbe(<Probe namespace={NS} />)
     await flush()
     await flush()
     expect(latest).not.toBeNull()
     expect(transport.addChannelCalls).toEqual([NS, NS])
     expect(transport.removeChannelCalls).toEqual([NS])
-    second.unmount()
+    act(() => second.unmount())
   })
 
   it('switches channels when the namespace changes', async () => {
-    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    const renderer = createProbe(<Probe namespace={NS} />)
     act(() => {
       transport.emitLifecycle({ type: 'started', session: session('s1') })
     })
@@ -141,11 +150,11 @@ describe('useCastChannel', () => {
     expect(transport.removeChannelCalls).toEqual([NS])
     expect(transport.addChannelCalls).toEqual([NS, NS_B])
     expect(latest!.namespace).toBe(NS_B)
-    renderer.unmount()
+    act(() => renderer.unmount())
   })
 
   it('drops to null when the session ends', async () => {
-    const renderer = TestRenderer.create(<Probe namespace={NS} />)
+    const renderer = createProbe(<Probe namespace={NS} />)
     act(() => {
       transport.emitLifecycle({ type: 'started', session: session('s1') })
     })
@@ -156,6 +165,6 @@ describe('useCastChannel', () => {
     })
     await flush()
     expect(latest).toBeNull()
-    renderer.unmount()
+    act(() => renderer.unmount())
   })
 })

--- a/src/api/useCastChannel.ts
+++ b/src/api/useCastChannel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { castStore } from '../state/castStore.singleton'
 import { CastContext } from './CastContext'
 import type { CastChannel } from './CastChannel'
@@ -7,10 +7,13 @@ import type { CastChannel } from './CastChannel'
  * Hook that establishes a custom {@link CastChannel} on the current session.
  *
  * The channel is added when a session is live, removed on unmount and when the
- * session or `namespace` changes, and re-created on the next session. Passing
- * `onMessage` makes the hook the owner of the channel's **single** message
- * listener (replace-on-set, v4 parity) — do not also call `channel.onMessage`
- * elsewhere, or the two will clobber each other.
+ * session or `namespace` changes, and re-created on the next session. The hook
+ * owns the channel's **single** message listener (replace-on-set, v4 parity):
+ * it installs a forwarder at `addChannel` time — *before* the channel is
+ * exposed, so an initial message from the receiver is never dropped — that
+ * always invokes the latest `onMessage` (identity changes take effect without
+ * re-registering the channel). Do not also call `channel.onMessage` elsewhere,
+ * or the two will clobber each other.
  *
  * Note that a namespace can only be registered once at a time. To use a
  * channel from multiple screens, lift the hook to a common parent (or manage
@@ -43,6 +46,11 @@ export function useCastChannel(
     CastContext.getSessionManager().getCurrentCastSession()
   )
   const [channel, setChannel] = useState<CastChannel | null>(null)
+  // Latest-ref for the listener: the forwarder installed at addChannel time
+  // always calls the current `onMessage`, so a changed handler needs no
+  // re-registration and an initial message can't slip through unheard.
+  const onMessageRef = useRef(onMessage)
+  onMessageRef.current = onMessage
 
   useEffect(() => {
     if (!castSession) {
@@ -52,7 +60,7 @@ export function useCastChannel(
     let active = true
     let created: CastChannel | null = null
     castSession
-      .addChannel(namespace)
+      .addChannel(namespace, (message) => onMessageRef.current?.(message))
       .then((c) => {
         if (active) {
           created = c
@@ -77,12 +85,6 @@ export function useCastChannel(
       void created?.remove().catch(() => {})
     }
   }, [castSession, namespace])
-
-  useEffect(() => {
-    if (!channel || !onMessage) return
-    channel.onMessage(onMessage)
-    return () => channel.offMessage()
-  }, [channel, onMessage])
 
   return channel
 }

--- a/src/api/useCastChannel.ts
+++ b/src/api/useCastChannel.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import { castStore } from '../state/castStore.singleton'
+import { CastContext } from './CastContext'
+import type { CastChannel } from './CastChannel'
+
+/**
+ * Hook that establishes a custom {@link CastChannel} on the current session.
+ *
+ * The channel is added when a session is live, removed on unmount and when the
+ * session or `namespace` changes, and re-created on the next session. Passing
+ * `onMessage` makes the hook the owner of the channel's **single** message
+ * listener (replace-on-set, v4 parity) — do not also call `channel.onMessage`
+ * elsewhere, or the two will clobber each other.
+ *
+ * Note that a namespace can only be registered once at a time. To use a
+ * channel from multiple screens, lift the hook to a common parent (or manage
+ * the channel in a global store) — see the Custom Channels guide.
+ *
+ * @param namespace custom namespace starting with `urn:x-cast:`.
+ * @param onMessage listener invoked with each raw message string received.
+ * @returns the channel, or `null` while there is no session (or during setup).
+ *
+ * @example
+ * ```js
+ * import { useCastChannel } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const channel = useCastChannel(
+ *     'urn:x-cast:com.example.custom',
+ *     useCallback((message) => console.log('received', message), [])
+ *   )
+ *   // later: channel?.sendMessage({ hello: 'world' })
+ * }
+ * ```
+ */
+export function useCastChannel(
+  namespace: string,
+  onMessage?: (message: string) => void
+): CastChannel | null {
+  // Memoized per generation by SessionManager → ref-stable across re-renders,
+  // changes exactly when the session changes.
+  const castSession = useSyncExternalStore(castStore.subscribe, () =>
+    CastContext.getSessionManager().getCurrentCastSession()
+  )
+  const [channel, setChannel] = useState<CastChannel | null>(null)
+
+  useEffect(() => {
+    if (!castSession) {
+      setChannel(null)
+      return
+    }
+    let active = true
+    let created: CastChannel | null = null
+    castSession
+      .addChannel(namespace)
+      .then((c) => {
+        if (active) {
+          created = c
+          setChannel(c)
+        } else {
+          // Unmounted while adding — undo immediately.
+          void c.remove().catch(() => {})
+        }
+      })
+      .catch(() => {
+        // Session ended mid-add, or the namespace is registered elsewhere
+        // (register-once — see the guide's lift-to-parent note).
+        if (active) setChannel(null)
+      })
+    return () => {
+      active = false
+      setChannel(null)
+      // `remove()` frees the namespace synchronously (T1), so a remount /
+      // namespace change can re-add immediately without self-colliding. It
+      // rejects noSession once the session already ended (native auto-removed
+      // the channel with it) — safe to swallow.
+      void created?.remove().catch(() => {})
+    }
+  }, [castSession, namespace])
+
+  useEffect(() => {
+    if (!channel || !onMessage) return
+    channel.onMessage(onMessage)
+    return () => channel.offMessage()
+  }, [channel, onMessage])
+
+  return channel
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,12 @@ export { CastContext }
 export { DiscoveryManager } from './api/DiscoveryManager'
 export { SessionManager } from './api/SessionManager'
 export { CastSession } from './api/CastSession'
+export { CastChannel } from './api/CastChannel'
 export { RemoteMediaClient } from './api/RemoteMediaClient'
 export { useRemoteMediaClient } from './api/useRemoteMediaClient'
 export { useMediaStatus } from './api/useMediaStatus'
 export { useStreamPosition } from './api/useStreamPosition'
+export { useCastChannel } from './api/useCastChannel'
 export type { SessionEventHandler } from './api/SessionManager'
 export type { EventSubscription } from './api/subscribeSelector'
 

--- a/src/specs/CastTransport.nitro.ts
+++ b/src/specs/CastTransport.nitro.ts
@@ -38,9 +38,11 @@ export interface CastTransport
     onDevices: (devices: Device[]) => void,
     onLifecycle: (event: SessionLifecycleEvent) => void,
     onMediaStatus: (status: MediaStatus) => void,
-    onChannelMessage: (namespace: string, message: string) => void,
+    // `channelNamespace` (not `namespace`): nitrogen emits parameter names
+    // verbatim into the generated C++, where `namespace` is a reserved keyword.
+    onChannelMessage: (channelNamespace: string, message: string) => void,
     onChannelStatus: (
-      namespace: string,
+      channelNamespace: string,
       connected: boolean,
       writable: boolean
     ) => void
@@ -60,9 +62,9 @@ export interface CastTransport
   // Custom channel surface (Phase 5.2) — string-only bridge; mirrors
   // `CastTransportApi` (drift guard in `__fakes__/FakeCastTransport.ts`).
   // Inbound messages/status stream via `onChannelMessage` / `onChannelStatus`.
-  addChannel(namespace: string): Promise<void>
-  removeChannel(namespace: string): Promise<void>
-  sendMessage(namespace: string, message: string): Promise<void>
+  addChannel(channelNamespace: string): Promise<void>
+  removeChannel(channelNamespace: string): Promise<void>
+  sendMessage(channelNamespace: string, message: string): Promise<void>
 
   // RemoteMediaClient mutation surface (Phase 4) — mirrors `CastTransportApi`;
   // the drift guard in `__fakes__/FakeCastTransport.ts` fails the build if these

--- a/src/state/CastStore.ts
+++ b/src/state/CastStore.ts
@@ -21,6 +21,7 @@ import {
   sessionSlice,
 } from './session.slice'
 import { mediaSlice } from './media.slice'
+import { KeyedBus } from './keyedBus'
 
 export type { StoreSession }
 
@@ -82,9 +83,9 @@ export class CastStore {
   private readonly slices: RegisteredSlice[] = []
   private readonly states = new Map<string, unknown>()
   private readonly subscribers = new Set<() => void>()
-  private readonly busHandlers = new Map<
+  private readonly lifecycleBus = new KeyedBus<
     SessionEventType,
-    Set<(event: SessionLifecycleEvent) => void>
+    SessionLifecycleEvent
   >()
 
   private snapshot: CastSnapshot
@@ -146,15 +147,7 @@ export class CastStore {
     handler: (event: SessionLifecycleEvent) => void
   ): () => void {
     if (this.disposed) return () => {}
-    let handlers = this.busHandlers.get(type)
-    if (!handlers) {
-      handlers = new Set()
-      this.busHandlers.set(type, handlers)
-    }
-    handlers.add(handler)
-    return () => {
-      handlers!.delete(handler)
-    }
+    return this.lifecycleBus.subscribe(type, handler)
   }
 
   // --- mutation entry (P4/P5 feed their native events here too) ---
@@ -187,7 +180,7 @@ export class CastStore {
       // teardown is best-effort; never throw out of dispose
     }
     this.subscribers.clear()
-    this.busHandlers.clear()
+    this.lifecycleBus.clear()
   }
 
   /** Register an extra slice. Only valid before init has streamed any events. */
@@ -236,9 +229,7 @@ export class CastStore {
   }
 
   private emit(event: SessionLifecycleEvent): void {
-    const handlers = this.busHandlers.get(event.type)
-    if (!handlers) return
-    for (const handler of [...handlers]) handler(event)
+    this.lifecycleBus.emit(event.type, event)
   }
 
   private seedAll(snapshot: InitialSnapshot): void {

--- a/src/state/CastStore.ts
+++ b/src/state/CastStore.ts
@@ -21,6 +21,7 @@ import {
   sessionSlice,
 } from './session.slice'
 import { mediaSlice } from './media.slice'
+import { channelSlice } from './channel.slice'
 import { KeyedBus } from './keyedBus'
 
 export type { StoreSession }
@@ -87,6 +88,10 @@ export class CastStore {
     SessionEventType,
     SessionLifecycleEvent
   >()
+  // P5.2 — inbound custom-channel messages. Deliberately a separate bus and a
+  // dedicated path: messages are transient (never replayed, never state), so
+  // they must not run the slice dispatch loop or touch the snapshot.
+  private readonly channelMessageBus = new KeyedBus<string, string>()
 
   private snapshot: CastSnapshot
   private initialized = false
@@ -104,6 +109,7 @@ export class CastStore {
     this.push(discoverySlice)
     this.push(sessionSlice)
     this.push(mediaSlice)
+    this.push(channelSlice)
     for (const slice of options.slices ?? []) this.push(slice)
 
     // Seed safe defaults so getSnapshot() works before init resolves.
@@ -150,6 +156,19 @@ export class CastStore {
     return this.lifecycleBus.subscribe(type, handler)
   }
 
+  /**
+   * Subscribe to inbound messages for one custom-channel namespace (P5.2).
+   * Messages are transient: never replayed to a late subscriber, never in
+   * `getSnapshot`. The `CastChannel` façade is the intended consumer.
+   */
+  onChannelMessage(
+    namespace: string,
+    handler: (message: string) => void
+  ): () => void {
+    if (this.disposed) return () => {}
+    return this.channelMessageBus.subscribe(namespace, handler)
+  }
+
   // --- mutation entry (P4/P5 feed their native events here too) ---
 
   /** Apply a store event, updating slices and notifying state subscribers. */
@@ -181,6 +200,7 @@ export class CastStore {
     }
     this.subscribers.clear()
     this.lifecycleBus.clear()
+    this.channelMessageBus.clear()
   }
 
   /** Register an extra slice. Only valid before init has streamed any events. */
@@ -208,8 +228,14 @@ export class CastStore {
         (devices) => this.dispatch({ kind: 'devices', devices }),
         (event) => this.dispatchLifecycle(event),
         (status) => this.dispatch({ kind: 'mediaStatus', status }),
-        () => {}, // onChannelMessage — wired to the channel message bus in 5.2b
-        () => {} // onChannelStatus — dispatched as `channelStatus` in 5.2b
+        (namespace, message) => this.channelMessageBus.emit(namespace, message),
+        (namespace, connected, writable) =>
+          this.dispatch({
+            kind: 'channelStatus',
+            namespace,
+            connected,
+            writable,
+          })
       )
       this.seedAll(snapshot)
     } catch {

--- a/src/state/__tests__/CastStore.test.ts
+++ b/src/state/__tests__/CastStore.test.ts
@@ -2,6 +2,7 @@ import { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
 import type { Device, SessionInfo } from '../../transport/types'
 import type { Slice } from '../slice'
 import { CastStore } from '../CastStore'
+import { CHANNEL_SLICE_KEY, type ChannelState } from '../channel.slice'
 
 function device(id: string): Device {
   return {
@@ -352,6 +353,75 @@ describe('CastStore — slice registry', () => {
     expect(() =>
       store.registerSlice({ key: 'late', seed: () => 0, reduce: (s) => s })
     ).toThrow(/before init/)
+  })
+})
+
+describe('channel message bus (P5.2 — transient, never replayed)', () => {
+  const NS = 'urn:x-cast:com.example.a'
+  const NS_B = 'urn:x-cast:com.example.b'
+
+  it('routes onChannelMessage by namespace', async () => {
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    const a = jest.fn()
+    const b = jest.fn()
+    store.onChannelMessage(NS, a)
+    store.onChannelMessage(NS_B, b)
+    transport.emitChannelMessage(NS, 'hello')
+    expect(a).toHaveBeenCalledWith('hello')
+    expect(b).not.toHaveBeenCalled()
+  })
+
+  it('never replays messages to a late subscriber', async () => {
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    transport.emitChannelMessage(NS, 'early')
+    const late = jest.fn()
+    store.onChannelMessage(NS, late)
+    expect(late).not.toHaveBeenCalled()
+    transport.emitChannelMessage(NS, 'now')
+    expect(late).toHaveBeenCalledTimes(1)
+    expect(late).toHaveBeenCalledWith('now')
+  })
+
+  it('a message is not state: no snapshot rebuild, no subscriber notify', async () => {
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    const listener = jest.fn()
+    store.subscribe(listener)
+    const before = store.getSnapshot()
+    transport.emitChannelMessage(NS, 'transient')
+    expect(store.getSnapshot()).toBe(before)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('onChannelStatus dispatches into the channel slice', async () => {
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    transport.emitLifecycle({
+      type: 'started',
+      session: { sessionId: 's1', device: device('d1') },
+    })
+    transport.emitChannelStatus(NS, true, false)
+    const state = store.getSliceState<ChannelState>(CHANNEL_SLICE_KEY)
+    expect(state.statuses[NS]).toEqual({ connected: true, writable: false })
+  })
+
+  it('dispose drops message handlers', async () => {
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    const handler = jest.fn()
+    store.onChannelMessage(NS, handler)
+    store.dispose()
+    transport.emitChannelMessage(NS, 'late')
+    expect(handler).not.toHaveBeenCalled()
+    // subscribing after dispose is a no-op unsubscribe, like on()
+    expect(typeof store.onChannelMessage(NS, jest.fn())).toBe('function')
   })
 })
 

--- a/src/state/__tests__/channel.slice.test.ts
+++ b/src/state/__tests__/channel.slice.test.ts
@@ -1,0 +1,136 @@
+import { channelSlice, type ChannelState } from '../channel.slice'
+import type {
+  Device,
+  SessionInfo,
+  SessionLifecycleEvent,
+} from '../../transport/types'
+import type { StoreEvent } from '../slice'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+const status = (
+  namespace: string,
+  connected = true,
+  writable = true
+): StoreEvent => ({ kind: 'channelStatus', namespace, connected, writable })
+const lifecycle = (event: SessionLifecycleEvent): StoreEvent => ({
+  kind: 'lifecycle',
+  event,
+})
+
+const NS = 'urn:x-cast:com.example.a'
+const NS_B = 'urn:x-cast:com.example.b'
+
+function liveState(): ChannelState {
+  return channelSlice.reduce(
+    channelSlice.seed({
+      castState: 'connected',
+      playServicesState: 'success',
+      devices: [],
+    }),
+    lifecycle({ type: 'started', session: session('s1') })
+  )
+}
+
+describe('channel.slice', () => {
+  it('seeds empty (idle without a session, live with one)', () => {
+    const idle = channelSlice.seed({
+      castState: 'notConnected',
+      playServicesState: 'success',
+      devices: [],
+    })
+    expect(idle).toEqual({ statuses: {}, live: false })
+    const live = channelSlice.seed({
+      castState: 'connected',
+      playServicesState: 'success',
+      devices: [],
+      currentSession: session('s1'),
+    })
+    expect(live).toEqual({ statuses: {}, live: true })
+  })
+
+  it('channelStatus sets/replaces the namespace entry while live', () => {
+    let state = liveState()
+    state = channelSlice.reduce(state, status(NS, false, false))
+    expect(state.statuses[NS]).toEqual({ connected: false, writable: false })
+    state = channelSlice.reduce(state, status(NS, true, true))
+    expect(state.statuses[NS]).toEqual({ connected: true, writable: true })
+  })
+
+  it('is ref-stable when the status is unchanged (Invariant 2)', () => {
+    let state = liveState()
+    state = channelSlice.reduce(state, status(NS, true, true))
+    const again = channelSlice.reduce(state, status(NS, true, true))
+    expect(again).toBe(state)
+  })
+
+  it('drops a channelStatus while no session is live', () => {
+    const idle = channelSlice.seed({
+      castState: 'notConnected',
+      playServicesState: 'success',
+      devices: [],
+    })
+    expect(channelSlice.reduce(idle, status(NS))).toBe(idle)
+  })
+
+  it('channelRemoved deletes only that namespace (ref-stable when absent)', () => {
+    let state = liveState()
+    state = channelSlice.reduce(state, status(NS))
+    state = channelSlice.reduce(state, status(NS_B))
+    const removed = channelSlice.reduce(state, {
+      kind: 'channelRemoved',
+      namespace: NS,
+    })
+    expect(removed.statuses[NS]).toBeUndefined()
+    expect(removed.statuses[NS_B]).toEqual({ connected: true, writable: true })
+    expect(
+      channelSlice.reduce(removed, { kind: 'channelRemoved', namespace: NS })
+    ).toBe(removed)
+  })
+
+  it('clears on teardown and on a new session (establish)', () => {
+    let state = liveState()
+    state = channelSlice.reduce(state, status(NS))
+    const torn = channelSlice.reduce(state, lifecycle({ type: 'ended' }))
+    expect(torn).toEqual({ statuses: {}, live: false })
+
+    let state2 = liveState()
+    state2 = channelSlice.reduce(state2, status(NS))
+    const replaced = channelSlice.reduce(
+      state2,
+      lifecycle({ type: 'started', session: session('s2') })
+    )
+    expect(replaced).toEqual({ statuses: {}, live: true })
+  })
+
+  it('is ref-stable across teardown/establish when already empty', () => {
+    const state = liveState()
+    expect(
+      channelSlice.reduce(
+        state,
+        lifecycle({ type: 'started', session: session('s2') })
+      )
+    ).toBe(state)
+    const idle = channelSlice.reduce(state, lifecycle({ type: 'ended' }))
+    expect(channelSlice.reduce(idle, lifecycle({ type: 'ended' }))).toBe(idle)
+  })
+
+  it('ignores unrelated events (same ref)', () => {
+    const state = liveState()
+    expect(
+      channelSlice.reduce(state, { kind: 'state', castState: 'connected' })
+    ).toBe(state)
+  })
+})

--- a/src/state/__tests__/keyedBus.test.ts
+++ b/src/state/__tests__/keyedBus.test.ts
@@ -1,0 +1,63 @@
+import { KeyedBus } from '../keyedBus'
+
+describe('KeyedBus', () => {
+  it('routes emits to the subscribed key only', () => {
+    const bus = new KeyedBus<string, number>()
+    const a = jest.fn()
+    const b = jest.fn()
+    bus.subscribe('a', a)
+    bus.subscribe('b', b)
+    bus.emit('a', 1)
+    expect(a).toHaveBeenCalledWith(1)
+    expect(b).not.toHaveBeenCalled()
+  })
+
+  it('supports multiple handlers per key', () => {
+    const bus = new KeyedBus<string, string>()
+    const first = jest.fn()
+    const second = jest.fn()
+    bus.subscribe('k', first)
+    bus.subscribe('k', second)
+    bus.emit('k', 'msg')
+    expect(first).toHaveBeenCalledWith('msg')
+    expect(second).toHaveBeenCalledWith('msg')
+  })
+
+  it('unsubscribe removes only that handler', () => {
+    const bus = new KeyedBus<string, number>()
+    const kept = jest.fn()
+    const removed = jest.fn()
+    const off = bus.subscribe('k', removed)
+    bus.subscribe('k', kept)
+    off()
+    bus.emit('k', 1)
+    expect(removed).not.toHaveBeenCalled()
+    expect(kept).toHaveBeenCalledTimes(1)
+  })
+
+  it('a handler unsubscribing during emit does not skip the others (copy-on-emit)', () => {
+    const bus = new KeyedBus<string, number>()
+    const calls: string[] = []
+    const off = bus.subscribe('k', () => {
+      calls.push('first')
+      off()
+    })
+    bus.subscribe('k', () => calls.push('second'))
+    bus.emit('k', 0)
+    expect(calls).toEqual(['first', 'second'])
+  })
+
+  it('emitting a key with no handlers is a no-op', () => {
+    const bus = new KeyedBus<string, number>()
+    expect(() => bus.emit('nobody', 1)).not.toThrow()
+  })
+
+  it('clear() drops every handler', () => {
+    const bus = new KeyedBus<string, number>()
+    const handler = jest.fn()
+    bus.subscribe('k', handler)
+    bus.clear()
+    bus.emit('k', 1)
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/src/state/channel.slice.ts
+++ b/src/state/channel.slice.ts
@@ -1,0 +1,105 @@
+import {
+  SESSION_ESTABLISH_TYPES,
+  SESSION_TEARDOWN_TYPES,
+} from './session.slice'
+import type { Slice } from './slice'
+
+export const CHANNEL_SLICE_KEY = 'channel'
+
+/** Connection status of one registered custom channel (see the platform note). */
+export interface ChannelStatus {
+  readonly connected: boolean
+  readonly writable: boolean
+}
+
+/**
+ * Per-namespace connection status of every registered custom channel (P5.2).
+ *
+ * Status is *state* (a component mounting mid-session must read the current
+ * `connected`/`writable`), so it lives here and replays via the slice —
+ * unlike inbound channel *messages*, which are transient and ride the store's
+ * message bus, never a slice. An entry also doubles as the register-once
+ * bookkeeping (T1): `CastSession.addChannel` rejects `alreadyRegistered` while
+ * the namespace has an entry; `CastChannel.remove()` dispatches
+ * `channelRemoved` to free it.
+ *
+ * Platform asymmetry (documented in the guide): iOS streams real dynamic
+ * values; Android emits `{connected: true, writable: true}` once at
+ * registration and never updates (its SDK has no per-channel callbacks).
+ */
+export interface ChannelState {
+  readonly statuses: Readonly<Record<string, ChannelStatus>>
+  /**
+   * Whether a live session currently exists — same derivation as the media
+   * slice's `live` (same event lists), gating status application so a
+   * `channelStatus` racing a teardown is dropped (Invariant 3).
+   */
+  readonly live: boolean
+}
+
+const EMPTY_STATUSES: Readonly<Record<string, ChannelStatus>> = Object.freeze(
+  {}
+)
+const EMPTY_IDLE: ChannelState = { statuses: EMPTY_STATUSES, live: false }
+const EMPTY_LIVE: ChannelState = { statuses: EMPTY_STATUSES, live: true }
+
+/**
+ * P5.2 slice: custom-channel connection status, bound to live-session presence.
+ * Channels never outlive their session: cleared on teardown (GCK auto-removes
+ * them natively) and on establishment (a new session starts with none; the app
+ * re-adds).
+ */
+export const channelSlice: Slice<ChannelState> = {
+  key: CHANNEL_SLICE_KEY,
+
+  seed: (snapshot) => (snapshot.currentSession ? EMPTY_LIVE : EMPTY_IDLE),
+
+  reduce: (state, event) => {
+    if (event.kind === 'channelStatus') {
+      // Drop a status arriving while no session is live — it would resurrect
+      // a channel the teardown already cleared (same gate as the media slice).
+      if (!state.live) return state
+      const prev = state.statuses[event.namespace]
+      if (
+        prev &&
+        prev.connected === event.connected &&
+        prev.writable === event.writable
+      ) {
+        return state
+      }
+      return {
+        statuses: Object.freeze({
+          ...state.statuses,
+          [event.namespace]: Object.freeze({
+            connected: event.connected,
+            writable: event.writable,
+          }),
+        }),
+        live: true,
+      }
+    }
+
+    if (event.kind === 'channelRemoved') {
+      if (!(event.namespace in state.statuses)) return state
+      const { [event.namespace]: _removed, ...rest } = state.statuses
+      return { statuses: Object.freeze(rest), live: state.live }
+    }
+
+    if (event.kind === 'lifecycle') {
+      const { type } = event.event
+      if (SESSION_ESTABLISH_TYPES.has(type)) {
+        const live = event.event.session != null
+        const empty = Object.keys(state.statuses).length === 0
+        if (empty && state.live === live) return state
+        return live ? EMPTY_LIVE : EMPTY_IDLE
+      }
+      if (SESSION_TEARDOWN_TYPES.has(type)) {
+        return Object.keys(state.statuses).length === 0 && !state.live
+          ? state
+          : EMPTY_IDLE
+      }
+    }
+
+    return state
+  },
+}

--- a/src/state/keyedBus.ts
+++ b/src/state/keyedBus.ts
@@ -1,0 +1,39 @@
+/**
+ * Generic keyed multi-handler event bus: subscribe by key, emit to that key's
+ * handlers. Handlers are copied before invocation (copy-on-emit), so a handler
+ * that unsubscribes itself — or another handler — mid-emit cannot corrupt the
+ * iteration.
+ *
+ * Backs both of the store's never-replayed event paths: the typed session
+ * lifecycle bus (`CastStore.on`) and the Phase 5 per-namespace channel message
+ * bus (`CastStore.onChannelMessage`). State replay is `getSnapshot`'s job —
+ * nothing emitted through a bus is ever replayed to a late subscriber.
+ */
+export class KeyedBus<K, V> {
+  private readonly handlers = new Map<K, Set<(value: V) => void>>()
+
+  /** Subscribe to `key`; returns the unsubscribe function. */
+  subscribe(key: K, handler: (value: V) => void): () => void {
+    let set = this.handlers.get(key)
+    if (!set) {
+      set = new Set()
+      this.handlers.set(key, set)
+    }
+    set.add(handler)
+    return () => {
+      set.delete(handler)
+    }
+  }
+
+  /** Emit `value` to every handler subscribed to `key` (copy-on-emit). */
+  emit(key: K, value: V): void {
+    const set = this.handlers.get(key)
+    if (!set) return
+    for (const handler of [...set]) handler(value)
+  }
+
+  /** Drop every handler (store dispose). */
+  clear(): void {
+    this.handlers.clear()
+  }
+}

--- a/src/state/slice.ts
+++ b/src/state/slice.ts
@@ -5,8 +5,8 @@ import type { MediaStatus } from '../types/MediaStatus'
 /**
  * Internal store event — the union of the native push sources fed through
  * {@link CastTransportApi.initAndSubscribe}. Later phases extend this union with
- * their own kinds (channel messages in P5) and feed them via their own native
- * HybridObject into `CastStore.dispatch`.
+ * their own kinds and feed them via their own native HybridObject into
+ * `CastStore.dispatch`.
  *
  * `mediaStatus` (P4) is the streamed `GCKMediaStatus` / `MediaStatus` of the
  * active session's RemoteMediaClient, pushed through the `onMediaStatus`
@@ -20,6 +20,19 @@ export type StoreEvent =
   | { readonly kind: 'devices'; readonly devices: Device[] }
   | { readonly kind: 'lifecycle'; readonly event: SessionLifecycleEvent }
   | { readonly kind: 'mediaStatus'; readonly status: MediaStatus }
+  // P5.2 custom channels. Connection status is state (slice + snapshot-replay);
+  // inbound channel *messages* are transient and deliberately NOT a StoreEvent —
+  // they ride the store's namespace-keyed message bus and are never replayed.
+  | {
+      readonly kind: 'channelStatus'
+      readonly namespace: string
+      readonly connected: boolean
+      readonly writable: boolean
+    }
+  // TS-only (dispatched by the CastChannel façade synchronously before the
+  // bridge removeChannel call, T1): deletes the namespace's slice entry so
+  // register-once bookkeeping frees the namespace for a later addChannel.
+  | { readonly kind: 'channelRemoved'; readonly namespace: string }
 
 /**
  * A registered piece of store state. Core slices (context / discovery / session)

--- a/src/transport/__tests__/nativeErrors.test.ts
+++ b/src/transport/__tests__/nativeErrors.test.ts
@@ -27,6 +27,19 @@ describe('parseCastError (critical-gap #12 translation)', () => {
     expect(parseCastError(raw)).toEqual({ code: 'cancelled', nativeCode: 3 })
   })
 
+  it('parses the P5.2 alreadyRegistered rejection (native register-once guard)', () => {
+    const raw = new Error(
+      JSON.stringify({
+        code: 'alreadyRegistered',
+        message: 'A channel for urn:x-cast:x is already registered.',
+      })
+    )
+    expect(parseCastError(raw)).toEqual({
+      code: 'alreadyRegistered',
+      message: 'A channel for urn:x-cast:x is already registered.',
+    })
+  })
+
   it('falls back to "failed" with the raw message for unknown codes', () => {
     const raw = new Error(JSON.stringify({ code: 'banana' }))
     expect(parseCastError(raw)).toEqual({

--- a/src/transport/nativeErrors.ts
+++ b/src/transport/nativeErrors.ts
@@ -27,6 +27,7 @@ const KNOWN_CODES: readonly CastErrorCode[] = [
   'authentication',
   'notAllowed',
   'appNotFound',
+  'alreadyRegistered',
 ]
 
 function isCastErrorCode(value: unknown): value is CastErrorCode {


### PR DESCRIPTION
v4-parity custom channels for the v5 Nitro rewrite: `CastSession.addChannel` / `CastChannel` / `useCastChannel`, built on the string-only bridge locked in the design (no envelope struct, no converter fixture).

**Design:** `docs/superpowers/specs/2026-07-11-castchannel-design.md` (+ eng-review amendments A1/A2/C1/T1) · **Plan:** `docs/superpowers/plans/2026-07-12-castchannel-implementation.md`

## Architecture (the two-flow split)

- **Inbound messages** ride a namespace-keyed **message bus** (new generic `KeyedBus`, also retrofitted behavior-preserving onto the lifecycle bus — C1): transient, never replayed, never in the snapshot, never through the slice dispatch loop.
- **connected/writable** is state: `channelStatus` StoreEvent → `channel.slice` (live-gated like the media slice, ref-stable), read synchronously by the façade.
- `CastChannel` is generation-bound (Invariant 3): stale handles reject `noSession` before the bridge; a retained listener can never receive a later session's messages.
- Register-once per namespace (T1): new `CastError` code `alreadyRegistered`; `remove()` frees the namespace synchronously (pre-bridge `channelRemoved` dispatch) so a `useCastChannel` remount can't self-collide.
- **Platform asymmetry (documented):** iOS streams real dynamic status via a `GCKCastChannel` subclass (initial status emitted before `addChannel` resolves — often `connected:false`, with the v4-parity `console.warn`); Android is register-once `{true,true}` (its SDK has no per-channel status callbacks). Android `sendMessage` awaits its `PendingResult<Status>` (A2-minor). Native registries cleared explicitly on end/suspend/dispose (A1).

## Structure

Barrier-first, mirroring 5.1: 2a transport surface landed on `v5` (`8a86b02`), then three parallel lanes merged here — `petrbela/p52-ts` (TS), `petrbela/p52-ios`, `petrbela/p52-android` — plus review fixes.

Notable: the iOS lane caught that `namespace` as a spec parameter name breaks nitrogen's generated C++ (reserved keyword) → renamed `channelNamespace` + regen (`f643e6e`).

## Review (three independent reviewers)

- **iOS + Android diffs** (separate reviewers): both clean on Invariant 1 / A1 / A2 / threading / settle-exhaustiveness; both independently flagged the same gap — `parseCastError`'s `KNOWN_CODES` missing `alreadyRegistered` → fixed (`4bf1ae3`).
- **Holistic:** found a real MAJOR — `addChannel` racing a session **replace** registered the channel on the new session (Invariant 1) while binding the façade to the old generation, permanently poisoning the namespace for the live session. Fixed with a post-await liveness re-check + undo, with a regression test driving the race through the fake (`a8b2271`). Non-gating minors folded or deferred to bead `v5-vlv`.

## Verification

- TS: `yarn typescript` (3-surface drift guard) + **181 jest tests** + prettier — green.
- iOS: `pod install` + `xcodebuild` (NitroGoogleCast target) — BUILD SUCCEEDED; full XCTest suite incl. new `CastMessageChannelTests` — TEST SUCCEEDED (run in-lane).
- Android: `compileDebugKotlin` + `testDebugUnitTest` (Robolectric) — BUILD SUCCESSFUL.
- Device-gated (post-merge, real Chromecast): message delivery both platforms, iOS connected/writable transitions, teardown auto-remove.

Closes beads `v5-8me.5`–`.9`. Squash-merge (repo convention; lane branches preserve granularity on origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x7of3gwAhCEwxUCoDq3HM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end custom Cast channel support for sending/receiving messages, plus connection and writability status tracking.
  * Introduced `CastSession.addChannel` and the `useCastChannel` React hook.
  * Added channel message APIs with string passthrough or JSON-serialized object sending.
* **Bug Fixes**
  * Improved channel lifecycle cleanup and duplicate-namespace handling.
  * Added typed error handling for `alreadyRegistered` and more consistent session-stale behavior.
* **Documentation**
  * Updated custom-channels and v4→v5 migration guides (awaiting `addChannel`, raw message JSON parsing).
* **Tests**
  * Added/expanded Jest coverage for channel behavior and error parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->