### PR TITLE
feat(v5): Phase 6 Slice 6.1 — CastButton + Cast UI (v5-8hq.2/.3/.4/.5/.6)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/CastButtonRegistry.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/CastButtonRegistry.kt
@@ -1,0 +1,48 @@
+package com.margelo.nitro.googlecast
+
+import android.view.View
+import androidx.mediarouter.app.MediaRouteButton
+import java.lang.ref.WeakReference
+
+/**
+ * Attach-ordered registry of mounted Cast buttons (E10). It exists **only** so
+ * `showIntroductoryOverlay` can anchor to "the" CastButton — v5 dialogs no
+ * longer need a button. [current] is the most recently attached button that is
+ * still attached to a window and `VISIBLE`, mirroring the iOS registry
+ * (last-attached wins; attached + not hidden).
+ *
+ * Weak refs only (a dropped view must never be retained here); entries are
+ * added/removed from the attach/detach window callbacks plus `onDropView`.
+ * Main-thread only — attach callbacks and the transport's UI methods both run
+ * on the main thread.
+ */
+internal object CastButtonRegistry {
+  private val buttons = mutableListOf<WeakReference<MediaRouteButton>>()
+
+  /** Called on attach-to-window. Re-registering moves [button] to the end (last-attached wins). */
+  fun register(button: MediaRouteButton) {
+    remove(button)
+    buttons.add(WeakReference(button))
+  }
+
+  /** Called on detach-from-window and `onDropView`. Idempotent. */
+  fun unregister(button: MediaRouteButton) {
+    remove(button)
+  }
+
+  /** The overlay anchor: the last-attached button still attached and visible, else `null`. */
+  val current: MediaRouteButton?
+    get() {
+      val anchor =
+        buttons.lastOrNull { ref ->
+          val button = ref.get()
+          button != null && button.isAttachedToWindow && button.visibility == View.VISIBLE
+        }
+      return anchor?.get()
+    }
+
+  /** Drops [button] and any garbage-collected entries. */
+  private fun remove(button: MediaRouteButton) {
+    buttons.removeAll { it.get() == null || it.get() === button }
+  }
+}

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastButton.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastButton.kt
@@ -1,0 +1,95 @@
+package com.margelo.nitro.googlecast
+
+import android.view.ContextThemeWrapper
+import android.view.View
+import androidx.annotation.Keep
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.uimanager.ThemedReactContext
+import com.google.android.gms.cast.framework.CastButtonFactory
+import com.google.android.gms.cast.framework.CastContext
+import com.margelo.nitro.views.RecyclableView
+
+/**
+ * Nitro HybridView backing `<CastButton />` on Android: a single
+ * [TintableMediaRouteButton] wired to the Cast framework. Constructed by the
+ * generated `HybridCastButtonManager` with the `ThemedReactContext` of the
+ * surface it mounts on.
+ *
+ * v4-faithful construction order: the `Theme_MediaRouter` remote-indicator
+ * drawable is set **before** `CastButtonFactory.setUpMediaRouteButton`
+ * (otherwise the button does not initiate with the correct visual state), and
+ * a missing/broken Cast framework degrades to an inert default button
+ * (try/catch like v4) — the view never throws across the bridge.
+ *
+ * Registers in [CastButtonRegistry] while attached to a window (E10) so
+ * `showIntroductoryOverlay` can anchor to the most recently attached visible
+ * button; unregisters on detach, [onDropView], and [prepareForRecycle].
+ */
+@Keep
+@DoNotStrip
+class HybridCastButton(reactContext: ThemedReactContext) :
+  HybridCastButtonSpec(), RecyclableView {
+
+  private val button = TintableMediaRouteButton(reactContext)
+
+  init {
+    // Resolve the enabled-state indicator drawable from the MediaRouter theme…
+    val themedContext =
+      ContextThemeWrapper(reactContext, androidx.mediarouter.R.style.Theme_MediaRouter)
+    val styleAttrs =
+      themedContext.obtainStyledAttributes(
+        null,
+        androidx.mediarouter.R.styleable.MediaRouteButton,
+        androidx.mediarouter.R.attr.mediaRouteButtonStyle,
+        0
+      )
+    val drawable =
+      styleAttrs.getDrawable(
+        androidx.mediarouter.R.styleable.MediaRouteButton_externalRouteEnabledDrawable
+      )
+    styleAttrs.recycle()
+
+    // …and set it BEFORE CastButtonFactory.setUpMediaRouteButton, else the
+    // button won't initiate with the correct visual state (v4 dance).
+    button.setRemoteIndicatorDrawable(drawable)
+
+    try {
+      CastContext.getSharedInstance(reactContext)
+      CastButtonFactory.setUpMediaRouteButton(reactContext, button)
+    } catch (_: Exception) {
+      // Cast framework unavailable (e.g. missing/outdated Play Services) —
+      // leave the default, inert button rather than crash (v4 behavior).
+    }
+
+    button.addOnAttachStateChangeListener(
+      object : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(v: View) = CastButtonRegistry.register(button)
+        override fun onViewDetachedFromWindow(v: View) = CastButtonRegistry.unregister(button)
+      }
+    )
+  }
+
+  override val view: View
+    get() = button
+
+  override var tintColor: Double? = null
+    set(value) {
+      field = value
+      // Processed AARRGGBB color from RN's `processColor`. It may arrive as a
+      // signed or an unsigned 32-bit value; `toLong().toInt()` maps both onto
+      // the same Android color int (a plain `toInt()` would clamp unsigned
+      // values above Int.MAX_VALUE). Null clears back to the default (E11).
+      button.applyTint(value?.toLong()?.toInt())
+    }
+
+  override fun onDropView() {
+    CastButtonRegistry.unregister(button)
+    super.onDropView()
+  }
+
+  override fun prepareForRecycle() {
+    // Reset to default props for the next mount (the setter clears the tint).
+    tintColor = null
+    CastButtonRegistry.unregister(button)
+  }
+}

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -493,7 +493,10 @@ class HybridCastTransport : HybridCastTransportSpec() {
     val promise = Promise<Boolean>()
     runOnMain {
       val activity = currentActivityOrNull()
-      if (activity == null) {
+      // Gate on the framework too: GCK's ExpandedControllerActivity resolves
+      // CastContext in its own onCreate, so launching without a working Cast
+      // framework would crash the *launched* activity after we resolved.
+      if (activity == null || sharedCastContextOrNull() == null) {
         promise.resolve(false)
         return@runOnMain
       }

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -450,12 +450,27 @@ class HybridCastTransport : HybridCastTransportSpec() {
         promise.resolve(false)
         return@runOnMain
       }
+      val fragmentManager = activity.supportFragmentManager
+      // After onSaveInstanceState (backgrounding race) `show()` would throw an
+      // IllegalStateException — that's a can't-show-right-now, not a failure.
+      if (fragmentManager.isStateSaved) {
+        promise.resolve(false)
+        return@runOnMain
+      }
+      // A dialog is already up (rapid repeated calls): it is shown — done.
+      if (
+        fragmentManager.findFragmentByTag(CHOOSER_DIALOG_TAG) != null ||
+        fragmentManager.findFragmentByTag(CONTROLLER_DIALOG_TAG) != null
+      ) {
+        promise.resolve(true)
+        return@runOnMain
+      }
       try {
         if (castContext.sessionManager.currentCastSession != null) {
           // A session exists (`connecting` included, matching what a
           // MediaRouteButton would present) → in-session controller dialog.
           MediaRouteControllerDialogFragment()
-            .show(activity.supportFragmentManager, CONTROLLER_DIALOG_TAG)
+            .show(fragmentManager, CONTROLLER_DIALOG_TAG)
         } else {
           val selector = castContext.mergedSelector
           if (selector == null) {
@@ -464,7 +479,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
           }
           val fragment = MediaRouteChooserDialogFragment()
           fragment.routeSelector = selector
-          fragment.show(activity.supportFragmentManager, CHOOSER_DIALOG_TAG)
+          fragment.show(fragmentManager, CHOOSER_DIALOG_TAG)
         }
         promise.resolve(true)
       } catch (e: Exception) {

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -552,12 +552,17 @@ class HybridCastTransport : HybridCastTransportSpec() {
       }
       try {
         IntroductoryOverlay.Builder(activity, button)
+          // A user-interaction callback, NOT a lifecycle one: it never fires
+          // when the Activity dies with the overlay up, so the promise must
+          // not wait for it — it only records the once-flag (E2). An
+          // undismissed overlay therefore also re-shows next launch.
           .setOnOverlayDismissedListener {
             prefs.edit().putBoolean(OVERLAY_SHOWN_KEY, true).apply()
-            promise.resolve(true)
           }
           .build()
           .show()
+        // Settle at presentation (matches iOS and the other show* methods).
+        promise.resolve(true)
       } catch (e: Exception) {
         promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
       }

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -1,7 +1,14 @@
 package com.margelo.nitro.googlecast
 
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import android.os.Handler
 import android.os.Looper
+import androidx.fragment.app.FragmentActivity
+import androidx.mediarouter.app.MediaRouteChooserDialogFragment
+import androidx.mediarouter.app.MediaRouteControllerDialogFragment
 import androidx.mediarouter.media.MediaRouter
 import com.google.android.gms.cast.Cast
 import com.google.android.gms.cast.CastDevice
@@ -9,6 +16,7 @@ import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.CastState as GckCastState
 import com.google.android.gms.cast.framework.CastStateListener
+import com.google.android.gms.cast.framework.IntroductoryOverlay
 import com.google.android.gms.cast.framework.SessionManagerListener
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.ConnectionResult
@@ -423,6 +431,135 @@ class HybridCastTransport : HybridCastTransportSpec() {
     return promise
   }
 
+  // MARK: - Cast UI (Phase 6.1 — imperative one-shots; main thread, Invariant 1)
+  //
+  // The boolean means "the present/launch call was issued" (E7); the graceful
+  // can't-show cases (no Cast framework, no/finishing Activity, no visible
+  // button anchor, overlay already shown once) resolve `false`. Only genuine
+  // native failures reject a typed CastError.
+
+  override fun showCastDialog(): Promise<Boolean> {
+    val promise = Promise<Boolean>()
+    runOnMain {
+      val castContext = sharedCastContextOrNull()
+      // The MediaRoute*DialogFragment forms are lifecycle-managed by the
+      // FragmentManager (ReactActivity is a FragmentActivity), so a rotation
+      // cannot leak the dialog window like the raw dialogs would (E9).
+      val activity = currentActivityOrNull() as? FragmentActivity
+      if (castContext == null || activity == null) {
+        promise.resolve(false)
+        return@runOnMain
+      }
+      try {
+        if (castContext.sessionManager.currentCastSession != null) {
+          // A session exists (`connecting` included, matching what a
+          // MediaRouteButton would present) → in-session controller dialog.
+          MediaRouteControllerDialogFragment()
+            .show(activity.supportFragmentManager, CONTROLLER_DIALOG_TAG)
+        } else {
+          val selector = castContext.mergedSelector
+          if (selector == null) {
+            promise.resolve(false)
+            return@runOnMain
+          }
+          val fragment = MediaRouteChooserDialogFragment()
+          fragment.routeSelector = selector
+          fragment.show(activity.supportFragmentManager, CHOOSER_DIALOG_TAG)
+        }
+        promise.resolve(true)
+      } catch (e: Exception) {
+        promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+      }
+    }
+    return promise
+  }
+
+  override fun showExpandedControls(): Promise<Boolean> {
+    val promise = Promise<Boolean>()
+    runOnMain {
+      val activity = currentActivityOrNull()
+      if (activity == null) {
+        promise.resolve(false)
+        return@runOnMain
+      }
+      val intent = Intent(activity, NitroExpandedControllerActivity::class.java)
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      try {
+        activity.startActivity(intent)
+        promise.resolve(true)
+      } catch (e: ActivityNotFoundException) {
+        // Missing manifest registration is a config error and must be loud
+        // (E8): the activity ships in this library, but Android only launches
+        // activities declared by the *app* manifest (automatic wiring → 6.2).
+        promise.reject(
+          CastRejection(
+            castRejectionJson(
+              "notSupported",
+              "NitroExpandedControllerActivity is not registered in your app. " +
+                "Add <activity android:name=\"com.margelo.nitro.googlecast.NitroExpandedControllerActivity\" /> " +
+                "to your AndroidManifest.xml.",
+              null
+            )
+          )
+        )
+      } catch (e: Exception) {
+        promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+      }
+    }
+    return promise
+  }
+
+  override fun showIntroductoryOverlay(once: Boolean): Promise<Boolean> {
+    val promise = Promise<Boolean>()
+    runOnMain {
+      val context = NitroModules.applicationContext
+      if (context == null) {
+        promise.resolve(false)
+        return@runOnMain
+      }
+      // Own once-flag (E2): GCK's `IntroductoryOverlay.setSingleTime()` makes
+      // `show()` a silent no-op when the overlay was ever shown before and the
+      // dismiss listener never fires — one of the two v4 promise hangs. It is
+      // therefore never used; this SharedPreferences flag is the only "once"
+      // bookkeeping, and every path below settles the promise.
+      val prefs = context.getSharedPreferences(OVERLAY_PREFS, Context.MODE_PRIVATE)
+      if (once && prefs.getBoolean(OVERLAY_SHOWN_KEY, false)) {
+        promise.resolve(false)
+        return@runOnMain
+      }
+      val activity = currentActivityOrNull()
+      val button = CastButtonRegistry.current
+      if (activity == null || button == null) {
+        // No Activity or no attached+visible CastButton anchor: resolve
+        // `false` instead of hanging forever (the other v4 hang).
+        promise.resolve(false)
+        return@runOnMain
+      }
+      try {
+        IntroductoryOverlay.Builder(activity, button)
+          .setOnOverlayDismissedListener {
+            prefs.edit().putBoolean(OVERLAY_SHOWN_KEY, true).apply()
+            promise.resolve(true)
+          }
+          .build()
+          .show()
+      } catch (e: Exception) {
+        promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
+      }
+    }
+    return promise
+  }
+
+  /**
+   * The foreground Activity, re-resolved per call (Invariant 1 — never cached);
+   * `null` when there is none or it is already finishing/destroyed.
+   */
+  private fun currentActivityOrNull(): Activity? {
+    val activity = NitroModules.applicationContext?.currentActivity ?: return null
+    if (activity.isFinishing || activity.isDestroyed) return null
+    return activity
+  }
+
   // MARK: - media transport (route to the active session's RemoteMediaClient)
   //
   // Every call re-resolves the current `RemoteMediaClient` on the main thread (Invariant 1 —
@@ -802,5 +939,18 @@ class HybridCastTransport : HybridCastTransportSpec() {
     // GoogleApiClient.ConnectionCallbacks suspend causes.
     const val CAUSE_SERVICE_DISCONNECTED = 1
     const val CAUSE_NETWORK_LOST = 2
+  }
+
+  private companion object {
+    // FragmentManager tags for the Cast UI dialogs (E9).
+    const val CHOOSER_DIALOG_TAG = "NitroGoogleCastChooserDialog"
+    const val CONTROLLER_DIALOG_TAG = "NitroGoogleCastControllerDialog"
+
+    // Our own introductory-overlay once-flag (E2 — GCK's `setSingleTime` is
+    // never used because it silently swallows the dismiss callback). Note the
+    // iOS flag is GCK's own and lives in a different store; the two are
+    // independent (documented in the guide).
+    const val OVERLAY_PREFS = "nitro_googlecast"
+    const val OVERLAY_SHOWN_KEY = "nitro_googlecast_intro_overlay_shown"
   }
 }

--- a/android/src/main/java/com/margelo/nitro/googlecast/NitroExpandedControllerActivity.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/NitroExpandedControllerActivity.kt
@@ -1,0 +1,29 @@
+package com.margelo.nitro.googlecast
+
+import android.view.Menu
+import com.google.android.gms.cast.framework.CastButtonFactory
+import com.google.android.gms.cast.framework.media.widget.ExpandedControllerActivity
+
+/**
+ * GCK's default expanded controller with a Cast button in the toolbar (the v4
+ * `RNGCExpandedControllerActivity`, ported). Launched by
+ * `CastContext.showExpandedControls()`.
+ *
+ * Android only launches activities declared in the *app* manifest, so the
+ * consuming app must register it (automatic wiring lands in slice 6.2):
+ *
+ * ```xml
+ * <activity
+ *   android:name="com.margelo.nitro.googlecast.NitroExpandedControllerActivity"
+ *   android:exported="false"
+ *   android:theme="@style/Theme.AppCompat.NoActionBar" />
+ * ```
+ */
+class NitroExpandedControllerActivity : ExpandedControllerActivity() {
+  override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    super.onCreateOptionsMenu(menu)
+    menuInflater.inflate(R.menu.cast_expanded_controller_menu, menu)
+    CastButtonFactory.setUpMediaRouteButton(this, menu, R.id.media_route_menu_item)
+    return true
+  }
+}

--- a/android/src/main/java/com/margelo/nitro/googlecast/NitroExpandedControllerActivity.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/NitroExpandedControllerActivity.kt
@@ -23,7 +23,12 @@ class NitroExpandedControllerActivity : ExpandedControllerActivity() {
   override fun onCreateOptionsMenu(menu: Menu): Boolean {
     super.onCreateOptionsMenu(menu)
     menuInflater.inflate(R.menu.cast_expanded_controller_menu, menu)
-    CastButtonFactory.setUpMediaRouteButton(this, menu, R.id.media_route_menu_item)
+    try {
+      CastButtonFactory.setUpMediaRouteButton(this, menu, R.id.media_route_menu_item)
+    } catch (e: Exception) {
+      // Cast framework unavailable: degrade to a button-less toolbar instead
+      // of crashing the launched activity (same posture as HybridCastButton).
+    }
     return true
   }
 }

--- a/android/src/main/java/com/margelo/nitro/googlecast/NitroGoogleCastPackage.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/NitroGoogleCastPackage.kt
@@ -4,16 +4,24 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
+import com.margelo.nitro.googlecast.views.HybridCastButtonManager
 
 /**
  * React Native autolinking entry point for react-native-google-cast on Android.
  *
  * The Cast API is exposed as a Nitro HybridObject (registered in C++ via the
- * generated OnLoad), not as a TurboModule — so this package intentionally
- * provides no native modules or view managers. Its sole purpose is to load the
- * native library on construction, which triggers HybridObject registration
- * before any JS `createHybridObject('CastTransport')` call. This is what lets
- * consumers rely on autolinking with no manual MainApplication setup.
+ * generated OnLoad), not as a TurboModule — so this package provides no native
+ * modules; loading the native library on construction triggers HybridObject
+ * registration before any JS `createHybridObject('CastTransport')` call. This
+ * is what lets consumers rely on autolinking with no manual MainApplication
+ * setup.
+ *
+ * Views are different (E1): nitrogen *generates* the `HybridCastButtonManager`
+ * ViewManager but registers nothing into RN's ViewManager registry — neither
+ * the generated autolinking nor `NitroModulesPackage` does. `<CastButton />`
+ * therefore must be registered here; without it the button compiles clean and
+ * fails only at runtime as an unimplemented component. (iOS needs no
+ * counterpart — the generated `.mm` self-registers via `+load`.)
  */
 class NitroGoogleCastPackage : ReactPackage {
   init {
@@ -26,5 +34,5 @@ class NitroGoogleCastPackage : ReactPackage {
 
   override fun createViewManagers(
     reactContext: ReactApplicationContext
-  ): List<ViewManager<*, *>> = emptyList()
+  ): List<ViewManager<*, *>> = listOf(HybridCastButtonManager())
 }

--- a/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
@@ -28,7 +28,9 @@ internal class TintableMediaRouteButton(context: Context) : MediaRouteButton(con
   fun applyTint(color: Int?) {
     tintColor = color
     val drawable = indicatorDrawable ?: return
-    val wrapped = DrawableCompat.wrap(drawable)
+    // mutate() un-shares the ConstantState: without it, tinting one mounted
+    // CastButton bleeds onto every other one using the same theme drawable.
+    val wrapped = DrawableCompat.wrap(drawable).mutate()
     if (color != null) {
       DrawableCompat.setTint(wrapped, color)
     } else {

--- a/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
@@ -1,0 +1,38 @@
+package com.margelo.nitro.googlecast
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.mediarouter.app.MediaRouteButton
+
+/**
+ * [MediaRouteButton] whose remote-indicator drawable can be tinted (the v4
+ * `ColorableMediaRouteButton`, https://stackoverflow.com/a/41496796).
+ *
+ * MediaRouteButton swaps its indicator drawable as the route state changes, so
+ * the tint is stored and re-applied from [setRemoteIndicatorDrawable] whenever
+ * a new drawable lands. A `null` tint clears back to the default color (E11) —
+ * v4 could only ever set a tint, never remove one.
+ */
+internal class TintableMediaRouteButton(context: Context) : MediaRouteButton(context) {
+  private var indicatorDrawable: Drawable? = null
+  private var tintColor: Int? = null
+
+  override fun setRemoteIndicatorDrawable(d: Drawable?) {
+    indicatorDrawable = d
+    super.setRemoteIndicatorDrawable(d)
+    if (tintColor != null) applyTint(tintColor)
+  }
+
+  /** Tint the current indicator drawable; `null` clears to the default (E11). */
+  fun applyTint(color: Int?) {
+    tintColor = color
+    val drawable = indicatorDrawable ?: return
+    val wrapped = DrawableCompat.wrap(drawable)
+    if (color != null) {
+      DrawableCompat.setTint(wrapped, color)
+    } else {
+      DrawableCompat.setTintList(wrapped, null)
+    }
+  }
+}

--- a/android/src/main/res/menu/cast_expanded_controller_menu.xml
+++ b/android/src/main/res/menu/cast_expanded_controller_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto" >
+  <item
+    android:id="@+id/media_route_menu_item"
+    app:actionProviderClass="androidx.mediarouter.app.MediaRouteActionProvider"
+    app:showAsAction="always" />
+</menu>

--- a/docs/components/CastButton.md
+++ b/docs/components/CastButton.md
@@ -8,17 +8,34 @@ The Cast button displays the Cast icon. It automatically changes appearance base
 
 When clicking the button, the native [Cast Dialog](https://developers.google.com/cast/docs/design_checklist/cast-dialog) is presented which enables the user to connect to a Chromecast, and, when casting, to play/pause and change volume.
 
-```js
+```jsx
 import { CastButton } from 'react-native-google-cast'
 
-// ...
-  render() {
-    // ...
-    <CastButton style={{width: 24, height: 24, tintColor: 'black'}} />
-  }
+function MyComponent() {
+  return <CastButton tintColor="black" style={{ width: 24, height: 24 }} />
+}
 ```
 
-The default Cast button behavior can be customized but this is not supported yet by this library.
+## Props
+
+Besides the standard React Native `View` props:
+
+| Prop        | Type         | Description                                                                              |
+| ----------- | ------------ | ---------------------------------------------------------------------------------------- |
+| `tintColor` | `ColorValue` | Color of the Cast icon (e.g. `'black'`, `'#ff0000'`). Omit to use the platform default. Removing the prop resets to the default. |
+
+> In v4 the tint was set via `style={{ tintColor }}`; in v5 it is a dedicated prop.
+
+## Why keep a CastButton mounted
+
+Besides being the standard way to start casting, a mounted, visible `CastButton` also:
+
+- **anchors the introductory overlay** — [`showIntroductoryOverlay`](../api/classes/castcontext) attaches to the most recently attached visible button and resolves `false` when there is none;
+- **(Android) triggers active device discovery** — the Cast framework only performs an ACTIVE scan while a Cast button (or dialog) is on screen, so devices are discovered reliably while one is mounted.
+
+Note that unlike v4, [`showCastDialog`](../api/classes/castcontext) no longer requires a mounted `CastButton` — it presents the dialog directly.
+
+On web, `CastButton` renders nothing (web sender support comes in a later phase).
 
 ## Custom Cast Button and Cast Dialog
 
@@ -27,7 +44,7 @@ Instead of using the `CastButton` component and the default Cast dialog, you may
 First, you need to retrieve a list of nearby Cast devices using [DiscoveryManager](../api/classes/discoverymanager) or the `useDevices` hook. You may then use [startSession](../api/classes/sessionmanager#startsession) to connect to a device, and [endCurrentSession](../api/classes/sessionmanager#endcurrentsession) to stop casting.
 
 ```js
-import GoogleCast, { useDevices } from 'react-native-google-cast'
+import GoogleCast, { useCastDevice, useDevices } from 'react-native-google-cast'
 
 function MyComponent() {
   const castDevice = useCastDevice()
@@ -51,3 +68,5 @@ function MyComponent() {
   })
 }
 ```
+
+Note that on Android, active device discovery only runs while native Cast UI (a `CastButton` or Cast dialog) is on screen — a fully custom UI may see an empty or stale device list. Keep a (possibly invisible) `CastButton` mounted, or present the native dialog, to keep the list fresh.

--- a/docs/components/ExpandedController.md
+++ b/docs/components/ExpandedController.md
@@ -8,63 +8,33 @@ The [expanded controller](https://developers.google.com/cast/docs/design_checkli
 
 ### Setup
 
-To use the default expanded controller:
-
-#### Expo
-
-```json
-{
-  "expo": {
-    "plugins": [
-      [
-        "react-native-google-cast",
-        {
-          // ...
-          "expandedController": true
-        }
-      ]
-    ]
-  }
-}
-```
-
 #### iOS
 
-In `AppDelegate`'s `application:didFinishLaunchingWithOptions` method add
-
-<!--DOCUSAURUS_CODE_TABS-->
-<!--Objective-C-->
-
-```obj-c
-[GCKCastContext sharedInstance].useDefaultExpandedMediaControls = true;
-```
-
-<!--Swift-->
-
-```swift
-GCKCastContext.sharedInstance().useDefaultExpandedMediaControls = true
-```
-
-<!--END_DOCUSAURUS_CODE_TABS-->
+No setup is needed — `showExpandedControls()` presents the Cast SDK's default expanded controls directly.
 
 #### Android
 
-In `AndroidManifest.xml` add
+Register the library's expanded controller activity in your app's `AndroidManifest.xml`:
 
 ```xml
-<activity android:name="com.reactnative.googlecast.RNGCExpandedControllerActivity" />
+<activity
+  android:name="com.margelo.nitro.googlecast.NitroExpandedControllerActivity"
+  android:exported="false"
+  android:theme="@style/Theme.AppCompat.NoActionBar" />
 ```
+
+> Automatic wiring (including the Expo config plugin) ships in a later v5 release. Until then the manifest entry is required — calling `showExpandedControls()` without it rejects a `CastError` with code `notSupported` whose message points you here.
 
 ### Usage
 
-Then, to show the expanded controller, call
+To show the expanded controller, call
 
 ```js
-GoogleCast.showExpandedControls()
+const shown = await GoogleCast.showExpandedControls()
 ```
 
-The expanded controller will also be shown automatically when the user taps the mini controller.
+It resolves `true` once the present/launch call was issued (what the launched controller does next is not observable from JS), and `false` when there is no current Activity (Android).
 
 ## Customizing expanded controller
 
-Not implemented yet
+Not implemented yet (planned for a later v5 release, along with notifications and the mini controller integration).

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -16,13 +16,15 @@ import { useCastState } from 'react-native-google-cast'
 function MyComponent() {
   const castState = useCastState()
 
-  // ...
+  // 'noDevicesAvailable' | 'notConnected' | 'connecting' | 'connected'
 }
 ```
 
-## Device Hook
+Unlike v4 (which returned `null` until its async initialization finished), v5 always returns a `CastState` — during the brief native-init window it reports the seeded `noDevicesAvailable`.
 
-Receive a list of available [Device](../api/interfaces/device)s.
+## Devices Hook
+
+Receive a list of available [Device](../api/interfaces/device)s. The array is frozen and referentially stable while the list is unchanged.
 
 ```js
 import GoogleCast, { useDevices } from 'react-native-google-cast'
@@ -59,6 +61,41 @@ function MyComponent() {
   }
 }
 ```
+
+The same session reference is returned for the lifetime of a session, then a fresh one once a new session starts.
+
+By default, a **suspended** session (e.g. the app was backgrounded on iOS) reads as `null` until it resumes. Pass `{ ignoreSessionUpdatesInBackground: true }` to keep the last session visible across the suspension instead:
+
+```js
+const castSession = useCastSession({ ignoreSessionUpdatesInBackground: true })
+```
+
+Two caveats with this option:
+
+- The retained session is **inert while suspended** — calling methods on it rejects a `CastError` with code `noSession`. Use it for rendering ("still connected to X"), not for calls.
+- Once the session **resumes**, the hook hands out a **fresh object reference** (even though it's the same session). Key your effects on `castSession?.id`, which is stable across a suspend/resume of the same session, rather than on the object:
+
+```js
+useEffect(() => {
+  // ...
+}, [castSession?.id])
+```
+
+## Cast Device Hook
+
+Receive the [Device](../api/interfaces/device) the current session is connected to, or `null` when not connected.
+
+```js
+import { useCastDevice } from 'react-native-google-cast'
+
+function MyComponent() {
+  const castDevice = useCastDevice()
+
+  // castDevice?.friendlyName
+}
+```
+
+It delegates to `useCastSession`, so the same options apply — `useCastDevice({ ignoreSessionUpdatesInBackground: true })` keeps the device visible while the session is suspended. The device reference is stable for the session's lifetime.
 
 ## Custom Channel Hook
 

--- a/docs/guides/migrating-v4-to-v5.md
+++ b/docs/guides/migrating-v4-to-v5.md
@@ -145,7 +145,8 @@ with these changes:
   worked by `performClick()` on a rendered button and resolved `false` without
   one; v5 presents the MediaRouter chooser/controller dialog directly (an
   in-session controller dialog when a session exists, the device chooser
-  otherwise). It resolves `false` only when there is no current Activity.
+  otherwise). It resolves `false` when the dialog cannot be presented — no
+  current Activity, the Cast framework unavailable, or no route selector.
 - **`showIntroductoryOverlay` resolves `false` instead of hanging.** v4's
   Android promise never settled when no `CastButton` was on screen, and — via
   the SDK's `setSingleTime()` — when the overlay had already been shown once.

--- a/docs/guides/migrating-v4-to-v5.md
+++ b/docs/guides/migrating-v4-to-v5.md
@@ -6,8 +6,8 @@ sidebar_label: Migrating v4 → v5
 
 > **Status:** v5 is a ground-up rewrite onto the React Native New Architecture
 > (Nitro Modules). This page is the running migration log; it is finalized in the
-> Phase 7 migration guide. It currently covers the Phase 3 changes (context,
-> discovery, sessions).
+> Phase 7 migration guide. It currently covers the Phase 3–6.1 changes (context,
+> discovery, sessions, media, channels, Cast UI + hooks).
 
 ## Read getters are now synchronous
 
@@ -123,9 +123,67 @@ with these changes:
   `sendMessage` / `remove` (channels are auto-removed with their session), and
   its retained listener can never receive a later session's messages.
 
+## Cast UI: `CastButton` and the `show*` methods
+
+`CastButton`, `CastContext.showCastDialog()`, `showExpandedControls()` and
+`showIntroductoryOverlay()` keep their v4 shape, with these changes:
+
+- **`CastButton` tint is a prop.** v4 read `style.tintColor`; v5 has a
+  dedicated `tintColor` prop (any `ColorValue`):
+
+  ```diff
+  - <CastButton style={{ width: 24, height: 24, tintColor: 'black' }} />
+  + <CastButton tintColor="black" style={{ width: 24, height: 24 }} />
+  ```
+
+- **The `show*` booleans mean "the present/launch call was issued."** iOS's
+  present APIs are void and Android cannot observe the launched activity, so
+  `true` does not guarantee what the presented UI did next. Only
+  `showIntroductoryOverlay` verifies actual presentation. Graceful can't-show
+  cases resolve `false`; genuine native failures reject a typed `CastError`.
+- **`showCastDialog` no longer needs a mounted `CastButton`.** v4 Android
+  worked by `performClick()` on a rendered button and resolved `false` without
+  one; v5 presents the MediaRouter chooser/controller dialog directly (an
+  in-session controller dialog when a session exists, the device chooser
+  otherwise). It resolves `false` only when there is no current Activity.
+- **`showIntroductoryOverlay` resolves `false` instead of hanging.** v4's
+  Android promise never settled when no `CastButton` was on screen, and — via
+  the SDK's `setSingleTime()` — when the overlay had already been shown once.
+  v5 resolves `false` in both cases (every path settles). A mounted, *visible*
+  `CastButton` is still required as the overlay's anchor on both platforms.
+- **The overlay's "shown once" flags are platform-local.** iOS uses the Cast
+  SDK's flag (cleared when you pass `{ once: false }`); Android uses this
+  library's own preference. The two stores are independent — resetting one
+  platform does not reset the other.
+- **`showExpandedControls` on Android requires a manifest entry.** Register
+  `com.margelo.nitro.googlecast.NitroExpandedControllerActivity` (see the
+  [ExpandedController](../../components/ExpandedController) doc); a missing
+  registration rejects `notSupported` instead of failing silently. Automatic
+  wiring (Expo plugin) comes later in v5.
+
+## Hooks: `useCastState` / `useDevices` / `useCastSession` / `useCastDevice`
+
+All four keep their v4 signatures. Behavioral notes:
+
+- **`useCastState` returns `CastState`, never `null`.** v4 returned `null`
+  before its async init; v5's store seeds synchronously, so during the brief
+  native-init window v5 reports `noDevicesAvailable` where v4 reported `null`.
+- **`useCastSession({ ignoreSessionUpdatesInBackground: true })` is
+  best-effort in v5.** The option still suppresses the `null` render while the
+  session is suspended, but the retained object is **inert during the
+  suspension** — calling methods on it rejects `noSession` (materially the
+  same as v4, whose retained object also failed natively while suspended).
+- **On resume, `useCastSession` hands out a fresh object reference** for the
+  same session (v4 kept the old object). Key effects on `castSession?.id` —
+  stable across a suspend/resume of the same session — not on the object
+  identity.
+- **`useCastDevice(options?)`** keeps its v4 parameter and delegates to
+  `useCastSession`, so the option keeps the device visible across a
+  suspension.
+
 ## Deferred to later phases
 
-- `CastContext.showCastDialog()` / `showExpandedControls()` /
-  `showIntroductoryOverlay()` / `showPlayServicesErrorDialog()` — **Phase 6**
-  (they depend on the `CastButton` / cast activity).
+- `CastContext.showPlayServicesErrorDialog()`, cast options / OptionsProvider
+  configuration, notifications & lock-screen controls, expanded-controller
+  customization, and the Expo config plugin — **Phase 6.2**.
 - Web / Chrome sender support — **Phase 8**.

--- a/docs/superpowers/specs/2026-07-12-castbutton-ui-design.md
+++ b/docs/superpowers/specs/2026-07-12-castbutton-ui-design.md
@@ -319,7 +319,10 @@ the amendment wins.
   *without* single-time, and on dismiss set the flag + resolve `true`. Every
   path settles. (iOS keeps GCK's native flag — its API returns `BOOL` and has
   `clearCastInstructionsShownFlag`.) Platform note: the two "once" flags are
-  independent stores; documented in the guide.
+  independent stores; documented in the guide. *PR #611 review addendum:* the
+  promise settles at presentation, not dismissal — GCK's dismiss listener is a
+  user-interaction callback and never fires if the Activity dies with the
+  overlay up; the listener only records the once-flag.
 - **E3 — `CastButton.web.tsx` split (P2).** `getHostComponent` deep-imports
   `react-native/Libraries/NativeComponent/NativeComponentRegistry`, which
   react-native-web does not provide — importing the native wrapper breaks web

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -40,6 +40,9 @@ function App() {
     discoveryManager.getDevices(),
   );
   const [log, setLog] = useState<string[]>([]);
+  // Device-pass toggle: unmounting the CastButton exercises the overlay's
+  // no-anchor → false path (and, on Android, stops the ACTIVE scan trigger).
+  const [showCastButton, setShowCastButton] = useState(true);
 
   const seq = useRef(0);
   const append = (line: string) => {
@@ -150,10 +153,16 @@ function App() {
           <Text style={[styles.title, isDarkMode && styles.textLight]}>
             react-native-google-cast v5 — spike
           </Text>
-          <CastButton
-            style={styles.castButton}
-            tintColor={isDarkMode ? '#fff' : '#1a73e8'}
-          />
+          <Pressable onLongPress={() => setShowCastButton(v => !v)}>
+            {showCastButton ? (
+              <CastButton
+                style={styles.castButton}
+                tintColor={isDarkMode ? '#fff' : '#1a73e8'}
+              />
+            ) : (
+              <Text style={text}>⌫</Text>
+            )}
+          </Pressable>
         </View>
         <Text style={text}>Cast state: {state}</Text>
         <Text style={text}>Play Services: {playServices}</Text>
@@ -171,14 +180,18 @@ function App() {
         <View style={styles.buttons}>
           <Pressable
             style={styles.button}
-            onPress={() => probeShow('showCastDialog', GoogleCast.showCastDialog)}
+            onPress={() =>
+              probeShow('showCastDialog', () => GoogleCast.showCastDialog())
+            }
           >
             <Text style={styles.buttonText}>Dialog</Text>
           </Pressable>
           <Pressable
             style={styles.button}
             onPress={() =>
-              probeShow('showExpandedControls', GoogleCast.showExpandedControls)
+              probeShow('showExpandedControls', () =>
+                GoogleCast.showExpandedControls(),
+              )
             }
           >
             <Text style={styles.buttonText}>Expanded</Text>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -21,6 +21,7 @@ import {
   View,
 } from 'react-native';
 import GoogleCast, {
+  CastButton,
   type CastError,
   type CastState,
   type Device,
@@ -122,6 +123,21 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Phase 6.1 — Cast UI one-shots; each logs its boolean resolution (or the
+  // typed CastError) into the event log for the device pass.
+  const probeShow = async (
+    name: string,
+    call: () => Promise<boolean>,
+  ) => {
+    try {
+      const shown = await call();
+      append(`${name} → ${shown}`);
+    } catch (e) {
+      const err = e as CastError;
+      append(`${name} rejected: ${err.code} / ${err.message}`);
+    }
+  };
+
   const text = [styles.text, isDarkMode && styles.textLight];
 
   return (
@@ -130,9 +146,15 @@ function App() {
     >
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
       <View style={styles.content}>
-        <Text style={[styles.title, isDarkMode && styles.textLight]}>
-          react-native-google-cast v5 — spike
-        </Text>
+        <View style={styles.header}>
+          <Text style={[styles.title, isDarkMode && styles.textLight]}>
+            react-native-google-cast v5 — spike
+          </Text>
+          <CastButton
+            style={styles.castButton}
+            tintColor={isDarkMode ? '#fff' : '#1a73e8'}
+          />
+        </View>
         <Text style={text}>Cast state: {state}</Text>
         <Text style={text}>Play Services: {playServices}</Text>
         <Text style={text}>Devices: {devices.length}</Text>
@@ -143,6 +165,43 @@ function App() {
           </Pressable>
           <Pressable style={styles.button} onPress={endSession}>
             <Text style={styles.buttonText}>End session</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.buttons}>
+          <Pressable
+            style={styles.button}
+            onPress={() => probeShow('showCastDialog', GoogleCast.showCastDialog)}
+          >
+            <Text style={styles.buttonText}>Dialog</Text>
+          </Pressable>
+          <Pressable
+            style={styles.button}
+            onPress={() =>
+              probeShow('showExpandedControls', GoogleCast.showExpandedControls)
+            }
+          >
+            <Text style={styles.buttonText}>Expanded</Text>
+          </Pressable>
+          <Pressable
+            style={styles.button}
+            onPress={() =>
+              probeShow('showIntroductoryOverlay', () =>
+                GoogleCast.showIntroductoryOverlay(),
+              )
+            }
+          >
+            <Text style={styles.buttonText}>Overlay</Text>
+          </Pressable>
+          <Pressable
+            style={styles.button}
+            onPress={() =>
+              probeShow('overlay(once:false)', () =>
+                GoogleCast.showIntroductoryOverlay({ once: false }),
+              )
+            }
+          >
+            <Text style={styles.buttonText}>Overlay∞</Text>
           </Pressable>
         </View>
 
@@ -175,7 +234,13 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff' },
   containerDark: { backgroundColor: '#000' },
   content: { flex: 1, padding: 20, gap: 8 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   title: { fontSize: 18, fontWeight: '600', marginBottom: 4, color: '#000' },
+  castButton: { width: 28, height: 28 },
   text: { fontSize: 15, color: '#000' },
   textLight: { color: '#fff' },
   buttons: { flexDirection: 'row', gap: 8, marginTop: 8 },

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -28,5 +28,12 @@
       <meta-data
         android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
         android:value="com.castexample.CastOptionsProvider" />
+
+      <!-- Google Cast: expanded media controls (showExpandedControls). Manual
+           registration until the 6.2 Expo-plugin/consumer wiring lands. -->
+      <activity
+        android:name="com.margelo.nitro.googlecast.NitroExpandedControllerActivity"
+        android:exported="false"
+        android:theme="@style/Theme.AppCompat.NoActionBar" />
     </application>
 </manifest>

--- a/ios/NitroGoogleCast/CastButtonHostView.swift
+++ b/ios/NitroGoogleCast/CastButtonHostView.swift
@@ -1,0 +1,42 @@
+import GoogleCast
+import UIKit
+
+/// Host `UIView` for the CastButton HybridView (iOS).
+///
+/// Owns exactly ONE `GCKUICastButton`, created in `init` and pinned to the
+/// host's bounds in `layoutSubviews` — fixing the v4 bug where a brand-new
+/// button was re-created (and stacked as another subview) on every
+/// `layoutSubviews` pass.
+///
+/// Window attach/detach is reported via `onWindowChanged` from
+/// `didMoveToWindow` (the E10 attach hook) so `CastButtonRegistry` can keep
+/// its attach-ordered entries in sync.
+final class CastButtonHostView: UIView {
+  /// The single Cast button this host owns for its whole lifetime.
+  let castButton: GCKUICastButton
+
+  /// Fired from `didMoveToWindow`; `attached == true` when the view just
+  /// entered a window, `false` when it left one.
+  var onWindowChanged: ((_ attached: Bool) -> Void)?
+
+  override init(frame: CGRect) {
+    castButton = GCKUICastButton(frame: CGRect(origin: .zero, size: frame.size))
+    super.init(frame: frame)
+    addSubview(castButton)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("CastButtonHostView does not support NSCoder")
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    castButton.frame = bounds
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    onWindowChanged?(window != nil)
+  }
+}

--- a/ios/NitroGoogleCast/CastButtonRegistry.swift
+++ b/ios/NitroGoogleCast/CastButtonRegistry.swift
@@ -1,0 +1,51 @@
+import GoogleCast
+import UIKit
+
+/// Attach-ordered registry of mounted CastButton host views (E10). The single
+/// consumer is `showIntroductoryOverlay`, which needs a visible
+/// `GCKUICastButton` anchor for GCK's non-deprecated
+/// `presentCastInstructionsViewControllerOnce(with:)` API.
+///
+/// - **Main thread only** (asserted): registration is driven by
+///   `didMoveToWindow` and consumed by the transport's main-queue hops.
+/// - **Attach order, last attached wins**: `register` (window attach) appends,
+///   `unregister` (window detach / recycle) removes, so `current` resolves the
+///   most recently attached candidate — mirroring the Android registry.
+/// - **Weak entries**: a deallocated host can never be handed out; dead
+///   entries are compacted on every mutation.
+enum CastButtonRegistry {
+  private struct Entry {
+    weak var host: CastButtonHostView?
+  }
+
+  private static var entries: [Entry] = []
+
+  /// Append `host` as the most recently attached button. Re-registering an
+  /// already-known host moves it to the end (it just re-attached — it IS the
+  /// last-attached one). Main thread only.
+  static func register(_ host: CastButtonHostView) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    entries.removeAll { $0.host == nil || $0.host === host }
+    entries.append(Entry(host: host))
+  }
+
+  /// Remove `host` (window detach, recycle). Idempotent. Main thread only.
+  static func unregister(_ host: CastButtonHostView) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    entries.removeAll { $0.host == nil || $0.host === host }
+  }
+
+  /// The overlay anchor: the last-attached host that is still in a window and
+  /// not hidden (E10 anchor check — attached + `!isHidden`; the hidden check
+  /// is on the host because RN applies `style` visibility there), else `nil`.
+  /// Main thread only.
+  static var current: GCKUICastButton? {
+    dispatchPrecondition(condition: .onQueue(.main))
+    for entry in entries.reversed() {
+      if let host = entry.host, host.window != nil, !host.isHidden {
+        return host.castButton
+      }
+    }
+    return nil
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastButton.swift
+++ b/ios/NitroGoogleCast/HybridCastButton.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GoogleCast
+import NitroModules
+import UIKit
+
+/// Nitro implementation of the `CastButton` HybridView (iOS).
+///
+/// Holds one `CastButtonHostView` (which owns a single `GCKUICastButton`
+/// created once — the v4 recreate-every-`layoutSubviews` bug is dead). The
+/// host's window attach/detach drives `CastButtonRegistry` (E10) so
+/// `showIntroductoryOverlay` can anchor on the last-attached visible button.
+///
+/// All view/prop work happens on the main thread (Nitro applies view props
+/// there); no GCK state is cached here (Invariant 1 — the button itself is
+/// UI, not a session handle).
+final class HybridCastButton: HybridCastButtonSpec {
+  private let hostView: CastButtonHostView
+
+  override init() {
+    hostView = CastButtonHostView(frame: .zero)
+    super.init()
+    hostView.onWindowChanged = { [weak hostView] attached in
+      guard let hostView else { return }
+      if attached {
+        CastButtonRegistry.register(hostView)
+      } else {
+        CastButtonRegistry.unregister(hostView)
+      }
+    }
+  }
+
+  var view: UIView { hostView }
+
+  /// Processed AARRGGBB color int (RN `processColor` output, sent as a
+  /// number). `nil` restores the default (inherited) tint — the React wrapper
+  /// always includes the key so removing the prop resets instead of
+  /// stranding the old tint (E11).
+  var tintColor: Double? {
+    didSet { hostView.castButton.tintColor = tintColor.flatMap(Self.color(fromProcessed:)) }
+  }
+
+  /// A HybridView's default `memorySize` measures the native view; this
+  /// wrapper adds only a fixed-size host + button, so report a small constant.
+  var memorySize: Int { 128 }
+
+  /// Convert an RN processed color (AARRGGBB packed into a 32-bit int, which
+  /// may arrive as a negative signed value) to `UIColor`. Unrepresentable
+  /// numbers map to `nil` (default tint) instead of trapping in a bridge hop.
+  private static func color(fromProcessed value: Double) -> UIColor? {
+    guard let packed = Int64(exactly: value.rounded()) else { return nil }
+    let bits = UInt32(truncatingIfNeeded: packed)
+    return UIColor(
+      red: CGFloat((bits >> 16) & 0xFF) / 255.0,
+      green: CGFloat((bits >> 8) & 0xFF) / 255.0,
+      blue: CGFloat(bits & 0xFF) / 255.0,
+      alpha: CGFloat((bits >> 24) & 0xFF) / 255.0
+    )
+  }
+}
+
+extension HybridCastButton: RecyclableView {
+  /// Reset to the default-props state before this view instance is re-used
+  /// for a different React node: leave the registry (E10 — a recycled button
+  /// is not an overlay anchor until it re-attaches) and drop the tint.
+  func prepareForRecycle() {
+    CastButtonRegistry.unregister(hostView)
+    tintColor = nil
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -661,17 +661,19 @@ final class HybridCastTransport: HybridCastTransportSpec {
     let promise = Promise<Bool>()
     DispatchQueue.main.async {
       let context = GCKCastContext.sharedInstance()
-      // iOS keeps GCK's own persistent "shown once" flag (E2 note): clearing
-      // it first makes the anchored present call below show again.
-      if !once {
-        context.clearCastInstructionsShownFlag()
-      }
       // The non-deprecated overlay API needs a visible button anchor; without
       // one the overlay cannot show → resolve `false` (never hang, never
       // reject).
       guard let button = CastButtonRegistry.current else {
         promise.resolve(withResult: false)
         return
+      }
+      // iOS keeps GCK's own persistent "shown once" flag (E2 note): clearing
+      // it makes the anchored present call below show again. Cleared only
+      // AFTER the anchor guard so a failed `{once: false}` call leaves the
+      // flag untouched — matching Android, whose false paths never write.
+      if !once {
+        context.clearCastInstructionsShownFlag()
       }
       // GCK's BOOL is authoritative here: `false` = not shown (already shown
       // before, or GCK could not locate the button).

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -631,6 +631,56 @@ final class HybridCastTransport: HybridCastTransportSpec {
     }
   }
 
+  // MARK: - Cast UI (Phase 6.1 — main queue, Invariant 1)
+
+  // The `Bool` contract is E7: `true` means "the present call was issued" —
+  // GCK's `presentCastDialog` / `presentDefaultExpandedMediaControls` are
+  // `void`, so actual presentation is not observable. Only the introductory
+  // overlay verifies presentation (its GCK API returns a real `BOOL`). These
+  // resolve `false` only for the graceful can't-show cases; they never reject.
+
+  func showCastDialog() throws -> Promise<Bool> {
+    let promise = Promise<Bool>()
+    DispatchQueue.main.async {
+      GCKCastContext.sharedInstance().presentCastDialog()
+      promise.resolve(withResult: true)
+    }
+    return promise
+  }
+
+  func showExpandedControls() throws -> Promise<Bool> {
+    let promise = Promise<Bool>()
+    DispatchQueue.main.async {
+      GCKCastContext.sharedInstance().presentDefaultExpandedMediaControls()
+      promise.resolve(withResult: true)
+    }
+    return promise
+  }
+
+  func showIntroductoryOverlay(once: Bool) throws -> Promise<Bool> {
+    let promise = Promise<Bool>()
+    DispatchQueue.main.async {
+      let context = GCKCastContext.sharedInstance()
+      // iOS keeps GCK's own persistent "shown once" flag (E2 note): clearing
+      // it first makes the anchored present call below show again.
+      if !once {
+        context.clearCastInstructionsShownFlag()
+      }
+      // The non-deprecated overlay API needs a visible button anchor; without
+      // one the overlay cannot show → resolve `false` (never hang, never
+      // reject).
+      guard let button = CastButtonRegistry.current else {
+        promise.resolve(withResult: false)
+        return
+      }
+      // GCK's BOOL is authoritative here: `false` = not shown (already shown
+      // before, or GCK could not locate the button).
+      promise.resolve(
+        withResult: context.presentCastInstructionsViewControllerOnce(with: button))
+    }
+    return promise
+  }
+
   // MARK: - helpers
 
   private func handleCastStateChange() {

--- a/src/api/CastContext.ts
+++ b/src/api/CastContext.ts
@@ -10,9 +10,10 @@ import type { EventSubscription } from './subscribeSelector'
  * of the library (`GoogleCast` and `CastContext` are equivalent).
  *
  * Read getters are **synchronous** in v5 (they were Promises in v4); they read
- * the central {@link CastStore} cache. The `show*` dialog / expanded-controller
- * methods are deferred to Phase 6 (they depend on the CastButton/activity that
- * don't exist yet).
+ * the central {@link CastStore} cache. The `show*` Cast-UI methods present
+ * GCK's own native UI and are async one-shots: they resolve a boolean meaning
+ * "the present/launch call was issued" (graceful can't-show cases resolve
+ * `false`; genuine native failures reject a typed `CastError`).
  */
 export class CastContext {
   private static readonly discoveryManager = new DiscoveryManager(
@@ -45,6 +46,51 @@ export class CastContext {
   /** The {@link SessionManager} for Cast sessions. */
   static getSessionManager(): SessionManager {
     return this.sessionManager
+  }
+
+  // --- Cast UI one-shots (Phase 6.1) ---
+  //
+  // The boolean means "the present/launch call was issued" — GCK's iOS present
+  // APIs are void and Android can't observe the launched activity, so only
+  // `showIntroductoryOverlay` verifies actual presentation. Graceful can't-show
+  // cases resolve `false`; genuine native failures reject a typed `CastError`.
+
+  /**
+   * Show the Cast dialog: the device chooser, or on Android the in-session
+   * controller dialog when a session exists. Unlike v4, no mounted
+   * {@link CastButton} is required. Resolves `false` when there is no current
+   * Activity (Android); on web it always resolves `false`.
+   */
+  static showCastDialog(): Promise<boolean> {
+    return castTransport.showCastDialog()
+  }
+
+  /**
+   * Present the platform's default expanded media controls. Resolves `true`
+   * once the present/launch call was issued (the launched UI is not
+   * observable). On Android, `NitroExpandedControllerActivity` must be
+   * registered in the app manifest — a missing registration rejects a
+   * `CastError` with code `notSupported`.
+   */
+  static showExpandedControls(): Promise<boolean> {
+    return castTransport.showExpandedControls()
+  }
+
+  /**
+   * Present the introductory overlay anchored to the currently attached,
+   * visible {@link CastButton}. Resolves `true` once the overlay was actually
+   * presented, and `false` when there is no visible button anchor or (with
+   * `once`) when it was already shown before. Android resolves on dismissal;
+   * iOS at presentation. The once-flag is platform-local (iOS: GCK's flag;
+   * Android: this library's own preference).
+   *
+   * @param options `once` (default `true`) shows the overlay only once per
+   * install; pass `false` to show it again (iOS clears GCK's shown-flag).
+   */
+  static showIntroductoryOverlay(options?: {
+    once?: boolean
+  }): Promise<boolean> {
+    return castTransport.showIntroductoryOverlay(options?.once ?? true)
   }
 
   /** Listen for changes of the cast state. */

--- a/src/api/CastContext.ts
+++ b/src/api/CastContext.ts
@@ -58,8 +58,10 @@ export class CastContext {
   /**
    * Show the Cast dialog: the device chooser, or on Android the in-session
    * controller dialog when a session exists. Unlike v4, no mounted
-   * {@link CastButton} is required. Resolves `false` when there is no current
-   * Activity (Android); on web it always resolves `false`.
+   * {@link CastButton} is required. Resolves `false` when Android cannot
+   * present it (no current Activity, Cast framework unavailable, no route
+   * selector, or saved FragmentManager state); on web it always resolves
+   * `false`.
    */
   static showCastDialog(): Promise<boolean> {
     return castTransport.showCastDialog()
@@ -80,9 +82,10 @@ export class CastContext {
    * Present the introductory overlay anchored to the currently attached,
    * visible {@link CastButton}. Resolves `true` once the overlay was actually
    * presented, and `false` when there is no visible button anchor or (with
-   * `once`) when it was already shown before. Android resolves on dismissal;
-   * iOS at presentation. The once-flag is platform-local (iOS: GCK's flag;
-   * Android: this library's own preference).
+   * `once`) when it was already shown before. Resolves at presentation on
+   * both platforms; Android records its "shown" flag when the user dismisses
+   * the overlay. The once-flag is platform-local (iOS: GCK's flag; Android:
+   * this library's own preference).
    *
    * @param options `once` (default `true`) shows the overlay only once per
    * install; pass `false` to show it again (iOS clears GCK's shown-flag).

--- a/src/api/__tests__/castUi.test.ts
+++ b/src/api/__tests__/castUi.test.ts
@@ -1,0 +1,102 @@
+import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import { castTransport } from '../../state/castStore.singleton'
+import { CastContext } from '../CastContext'
+
+// CastContext pulls the native singleton; swap it for a fake-backed one
+// (same pattern as channels.test.ts / useCastChannel.test.tsx).
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+const transport = castTransport as unknown as FakeCastTransport
+
+beforeEach(() => {
+  transport.showCastDialogCalls = 0
+  transport.showExpandedControlsCalls = 0
+  transport.showIntroductoryOverlayCalls.length = 0
+  transport.showCastDialogBehavior = async () => true
+  transport.showExpandedControlsBehavior = async () => true
+  transport.showIntroductoryOverlayBehavior = async () => true
+})
+
+describe('CastContext.showCastDialog', () => {
+  it('delegates to the transport and resolves `true` when shown', async () => {
+    await expect(CastContext.showCastDialog()).resolves.toBe(true)
+    expect(transport.showCastDialogCalls).toBe(1)
+  })
+
+  it('passes a `false` resolution through (dialog not shown)', async () => {
+    transport.showCastDialogBehavior = async () => false
+    await expect(CastContext.showCastDialog()).resolves.toBe(false)
+  })
+
+  it('surfaces a typed CastError rejection', async () => {
+    transport.showCastDialogBehavior = async () => {
+      throw { code: 'notSupported', message: 'nope' }
+    }
+    await expect(CastContext.showCastDialog()).rejects.toMatchObject({
+      code: 'notSupported',
+    })
+  })
+})
+
+describe('CastContext.showExpandedControls', () => {
+  it('delegates to the transport and resolves `true` when launched', async () => {
+    await expect(CastContext.showExpandedControls()).resolves.toBe(true)
+    expect(transport.showExpandedControlsCalls).toBe(1)
+  })
+
+  it('passes a `false` resolution through (no Activity)', async () => {
+    transport.showExpandedControlsBehavior = async () => false
+    await expect(CastContext.showExpandedControls()).resolves.toBe(false)
+  })
+
+  it('surfaces the E8 misconfiguration rejection', async () => {
+    transport.showExpandedControlsBehavior = async () => {
+      throw {
+        code: 'notSupported',
+        message: 'Register NitroExpandedControllerActivity in your manifest.',
+      }
+    }
+    await expect(CastContext.showExpandedControls()).rejects.toMatchObject({
+      code: 'notSupported',
+    })
+  })
+})
+
+describe('CastContext.showIntroductoryOverlay', () => {
+  it('forwards `once=true` by default (no arguments)', async () => {
+    await expect(CastContext.showIntroductoryOverlay()).resolves.toBe(true)
+    expect(transport.showIntroductoryOverlayCalls).toEqual([true])
+  })
+
+  it('forwards `once=true` for an empty options object', async () => {
+    await CastContext.showIntroductoryOverlay({})
+    expect(transport.showIntroductoryOverlayCalls).toEqual([true])
+  })
+
+  it('forwards an explicit `once: false`', async () => {
+    await CastContext.showIntroductoryOverlay({ once: false })
+    expect(transport.showIntroductoryOverlayCalls).toEqual([false])
+  })
+
+  it('passes a `false` resolution through (no visible button / already shown)', async () => {
+    transport.showIntroductoryOverlayBehavior = async () => false
+    await expect(CastContext.showIntroductoryOverlay()).resolves.toBe(false)
+  })
+
+  it('surfaces a typed CastError rejection', async () => {
+    transport.showIntroductoryOverlayBehavior = async () => {
+      throw { code: 'unknown', message: 'native failure' }
+    }
+    await expect(
+      CastContext.showIntroductoryOverlay({ once: false })
+    ).rejects.toMatchObject({ code: 'unknown' })
+  })
+})

--- a/src/api/__tests__/uiHooks.test.tsx
+++ b/src/api/__tests__/uiHooks.test.tsx
@@ -1,0 +1,342 @@
+import * as React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import type { CastState, Device, SessionInfo } from '../../transport/types'
+import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import { castTransport } from '../../state/castStore.singleton'
+import type { CastSession } from '../CastSession'
+import { useCastState } from '../useCastState'
+import { useDevices } from '../useDevices'
+import { useCastSession } from '../useCastSession'
+import type { UseCastSessionOptions } from '../useCastSession'
+import { useCastDevice } from '../useCastDevice'
+
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+const transport = castTransport as unknown as FakeCastTransport
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+
+/** Flush effects (the option-path subscribe/seed runs in an effect). */
+async function flush() {
+  await act(async () => {})
+}
+
+/** Mount inside act() so the initial render/effects are properly flushed. */
+function createProbe(
+  element: React.ReactElement
+): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(element)
+  })
+  return renderer
+}
+
+let latestState: CastState | null = null
+function StateProbe() {
+  latestState = useCastState()
+  return null
+}
+
+let latestDevices: readonly Device[] | null = null
+function DevicesProbe() {
+  latestDevices = useDevices()
+  return null
+}
+
+let latestSession: CastSession | null = null
+function SessionProbe({ options }: { options?: UseCastSessionOptions }) {
+  latestSession = useCastSession(options)
+  return null
+}
+
+let latestDevice: Device | null = null
+function DeviceProbe({ options }: { options?: UseCastSessionOptions }) {
+  latestDevice = useCastDevice(options)
+  return null
+}
+
+beforeEach(async () => {
+  latestState = null
+  latestDevices = null
+  latestSession = null
+  latestDevice = null
+  await flush()
+})
+
+afterEach(() => {
+  // Reset the singleton store's session state between tests.
+  act(() => {
+    transport.emitLifecycle({ type: 'ended' })
+    transport.emitState('noDevicesAvailable')
+    transport.emitDevices([])
+  })
+})
+
+describe('useCastState', () => {
+  it('returns the seeded state synchronously and re-renders on state events', () => {
+    const renderer = createProbe(<StateProbe />)
+    expect(latestState).toBe('noDevicesAvailable')
+
+    act(() => {
+      transport.emitState('connecting')
+    })
+    expect(latestState).toBe('connecting')
+
+    act(() => {
+      transport.emitState('connected')
+    })
+    expect(latestState).toBe('connected')
+    act(() => renderer.unmount())
+  })
+})
+
+describe('useDevices', () => {
+  it('re-renders on device-list events', () => {
+    const renderer = createProbe(<DevicesProbe />)
+    expect(latestDevices).toEqual([])
+
+    act(() => {
+      transport.emitDevices([device('d1'), device('d2')])
+    })
+    expect(latestDevices!.map((d) => d.deviceId)).toEqual(['d1', 'd2'])
+    act(() => renderer.unmount())
+  })
+
+  it('is ref-stable across unrelated store changes', () => {
+    const renderer = createProbe(<DevicesProbe />)
+    act(() => {
+      transport.emitDevices([device('d1')])
+    })
+    const before = latestDevices
+
+    act(() => {
+      transport.emitState('connecting')
+    })
+    expect(latestDevices).toBe(before)
+    act(() => renderer.unmount())
+  })
+})
+
+describe('useCastSession — default path', () => {
+  it('is null with no session and returns the memoized façade once started', () => {
+    const renderer = createProbe(<SessionProbe />)
+    expect(latestSession).toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    expect(latestSession).not.toBeNull()
+    expect(latestSession!.id).toBe('s1')
+    act(() => renderer.unmount())
+  })
+
+  it('drops to null when the session ends', () => {
+    const renderer = createProbe(<SessionProbe />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    expect(latestSession).not.toBeNull()
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+    expect(latestSession).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('drops to null on suspended (default behavior)', () => {
+    const renderer = createProbe(<SessionProbe />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    act(() => {
+      transport.emitLifecycle({ type: 'suspended' })
+    })
+    expect(latestSession).toBeNull()
+    act(() => renderer.unmount())
+  })
+})
+
+describe('useCastSession — ignoreSessionUpdatesInBackground', () => {
+  const OPTS: UseCastSessionOptions = { ignoreSessionUpdatesInBackground: true }
+
+  it('seeds from an already-live session on mount (subscribe-then-reread, E4)', async () => {
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    const renderer = createProbe(<SessionProbe options={OPTS} />)
+    await flush()
+    expect(latestSession).not.toBeNull()
+    expect(latestSession!.id).toBe('s1')
+    act(() => renderer.unmount())
+  })
+
+  it('retains the same reference across suspended', async () => {
+    const renderer = createProbe(<SessionProbe options={OPTS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    const retained = latestSession
+    expect(retained).not.toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'suspended' })
+    })
+    expect(latestSession).toBe(retained)
+    act(() => renderer.unmount())
+  })
+
+  it('hands out a FRESH generation-bound reference on resumed (E5)', async () => {
+    const renderer = createProbe(<SessionProbe options={OPTS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    const suspendedRef = latestSession
+
+    act(() => {
+      transport.emitLifecycle({ type: 'suspended' })
+    })
+    expect(latestSession).toBe(suspendedRef)
+
+    act(() => {
+      transport.emitLifecycle({ type: 'resumed', session: session('s1') })
+    })
+    expect(latestSession).not.toBeNull()
+    expect(latestSession!.id).toBe('s1')
+    // Same session id, but a NEW generation-bound façade — the pre-suspend
+    // object is stale (every call would reject noSession).
+    expect(latestSession).not.toBe(suspendedRef)
+    expect(latestSession!.isActive).toBe(true)
+    expect(suspendedRef!.isActive).toBe(false)
+    act(() => renderer.unmount())
+  })
+
+  it('drops to null on ended / startFailed / resumeFailed', async () => {
+    const renderer = createProbe(<SessionProbe options={OPTS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    expect(latestSession).not.toBeNull()
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+    expect(latestSession).toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s2') })
+    })
+    expect(latestSession).not.toBeNull()
+    act(() => {
+      transport.emitLifecycle({
+        type: 'resumeFailed',
+        error: { code: 'network' },
+      })
+    })
+    expect(latestSession).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('re-subscribes when the option flips', async () => {
+    // Start WITHOUT the option: suspended nulls the session.
+    const renderer = createProbe(<SessionProbe />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    expect(latestSession).not.toBeNull()
+
+    // Flip the option ON — the event path must subscribe + seed.
+    act(() => {
+      renderer.update(<SessionProbe options={OPTS} />)
+    })
+    await flush()
+    expect(latestSession).not.toBeNull()
+    const retained = latestSession
+
+    act(() => {
+      transport.emitLifecycle({ type: 'suspended' })
+    })
+    expect(latestSession).toBe(retained)
+
+    // Flip the option OFF mid-suspension — back to the store read (null).
+    act(() => {
+      renderer.update(<SessionProbe />)
+    })
+    await flush()
+    expect(latestSession).toBeNull()
+    act(() => renderer.unmount())
+  })
+})
+
+describe('useCastDevice', () => {
+  it('flips device ↔ null across the session lifecycle', () => {
+    const renderer = createProbe(<DeviceProbe />)
+    expect(latestDevice).toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    expect(latestDevice).not.toBeNull()
+    expect(latestDevice!.deviceId).toBe('s1')
+
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+    expect(latestDevice).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('is ref-stable for the lifetime of a session', () => {
+    const renderer = createProbe(<DeviceProbe />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    const before = latestDevice
+    act(() => {
+      transport.emitState('connected')
+    })
+    expect(latestDevice).toBe(before)
+    act(() => renderer.unmount())
+  })
+
+  it('honors ignoreSessionUpdatesInBackground across suspension (E6)', async () => {
+    const renderer = createProbe(
+      <DeviceProbe options={{ ignoreSessionUpdatesInBackground: true }} />
+    )
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    await flush()
+    const before = latestDevice
+    expect(before).not.toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'suspended' })
+    })
+    expect(latestDevice).toBe(before)
+    act(() => renderer.unmount())
+  })
+})

--- a/src/api/__tests__/uiHooks.test.tsx
+++ b/src/api/__tests__/uiHooks.test.tsx
@@ -257,6 +257,18 @@ describe('useCastSession — ignoreSessionUpdatesInBackground', () => {
       })
     })
     expect(latestSession).toBeNull()
+
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s3') })
+    })
+    expect(latestSession).not.toBeNull()
+    act(() => {
+      transport.emitLifecycle({
+        type: 'startFailed',
+        error: { code: 'network' },
+      })
+    })
+    expect(latestSession).toBeNull()
     act(() => renderer.unmount())
   })
 

--- a/src/api/useCastDevice.ts
+++ b/src/api/useCastDevice.ts
@@ -1,0 +1,27 @@
+import type { Device } from '../transport/types'
+import { useCastSession } from './useCastSession'
+import type { UseCastSessionOptions } from './useCastSession'
+
+/**
+ * Hook that provides the {@link Device} the current session is connected to,
+ * or `null` when no session is connected.
+ *
+ * Delegates to {@link useCastSession} (v4 parity), so the same options apply:
+ * with `ignoreSessionUpdatesInBackground` the device stays visible while the
+ * session is suspended. The device reference is frozen per session and
+ * ref-stable for the session's lifetime.
+ *
+ * @example
+ * ```js
+ * import { useCastDevice } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const castDevice = useCastDevice()
+ *   // castDevice?.friendlyName
+ * }
+ * ```
+ */
+export function useCastDevice(options?: UseCastSessionOptions): Device | null {
+  const castSession = useCastSession(options)
+  return castSession?.device ?? null
+}

--- a/src/api/useCastSession.ts
+++ b/src/api/useCastSession.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import { castStore } from '../state/castStore.singleton'
+import { CastContext } from './CastContext'
+import type { CastSession } from './CastSession'
+
+export interface UseCastSessionOptions {
+  /**
+   * Keep returning the last session while it is **suspended** (e.g. the app
+   * was backgrounded on iOS), instead of `null`. Best-effort v4 parity:
+   *
+   * - The retained façade is **inert while suspended** — mutations reject a
+   *   `CastError` `noSession` (materially the same as v4, whose retained
+   *   object also failed natively during suspension). Use it for rendering
+   *   ("still connected to X"), not for calls.
+   * - On `resumed` the hook always hands out the **fresh** generation-bound
+   *   façade — a **new object reference**, even for the same session. Key
+   *   effects on `castSession?.id` (stable across suspend/resume of the same
+   *   session), not on the object identity.
+   */
+  ignoreSessionUpdatesInBackground?: boolean
+}
+
+/**
+ * Hook that provides the current {@link CastSession}, or `null` when no
+ * session is connected.
+ *
+ * The same session reference is returned for the lifetime of a session
+ * (memoized per generation), then a fresh one once a new session starts.
+ * By default a **suspended** session reads as `null` until it resumes; see
+ * {@link UseCastSessionOptions.ignoreSessionUpdatesInBackground} to keep the
+ * last session visible across a suspension (and its caveats).
+ *
+ * @example
+ * ```js
+ * import { useCastSession } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const castSession = useCastSession()
+ *
+ *   useEffect(() => {
+ *     // key effects on the id, not the object (fresh reference on resume)
+ *   }, [castSession?.id])
+ * }
+ * ```
+ */
+export function useCastSession(
+  options?: UseCastSessionOptions
+): CastSession | null {
+  const ignoreInBackground = options?.ignoreSessionUpdatesInBackground === true
+
+  // Default path (E4): a plain, race-free store read — the memoized façade
+  // tracks the snapshot, so `suspended` (which tears the session down) nulls.
+  const live = useSyncExternalStore(castStore.subscribe, () =>
+    CastContext.getSessionManager().getCurrentCastSession()
+  )
+
+  // Event path, in effect only with `ignoreSessionUpdatesInBackground`:
+  // driven by the SessionManager lifecycle events, with `suspended`
+  // deliberately NOT nulling the retained façade.
+  const [retained, setRetained] = useState<CastSession | null>(null)
+
+  useEffect(() => {
+    if (!ignoreInBackground) return
+
+    const sessionManager = CastContext.getSessionManager()
+    // The handlers receive the post-event `getCurrentCastSession()`: the fresh
+    // façade for started/resumed, `null` for the teardown events.
+    const subscriptions = [
+      sessionManager.onSessionStarted(setRetained),
+      sessionManager.onSessionResumed(setRetained),
+      sessionManager.onSessionEnded(setRetained),
+      sessionManager.onSessionStartFailed(setRetained),
+      sessionManager.onSessionResumeFailed(setRetained),
+      // `suspended` intentionally unhandled — that's the whole option.
+    ]
+    // Subscribe FIRST, then re-read synchronously: an event landing between
+    // render and this effect is now either caught by a subscription or
+    // reflected in this read — the mount gap is closed (E4).
+    setRetained(sessionManager.getCurrentCastSession())
+
+    return () => {
+      for (const subscription of subscriptions) subscription.remove()
+      setRetained(null)
+    }
+  }, [ignoreInBackground])
+
+  return ignoreInBackground ? retained : live
+}

--- a/src/api/useCastState.ts
+++ b/src/api/useCastState.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react'
+import type { CastState } from '../transport/types'
+import { castStore } from '../state/castStore.singleton'
+
+/**
+ * Hook that provides the current {@link CastState}, re-rendering whenever it
+ * changes.
+ *
+ * Migration note (v4 → v5): v4 returned `null` until its async initialization
+ * completed; v5's store seeds synchronously, so this always returns a
+ * `CastState`. During the brief native-init window v5 reports
+ * `noDevicesAvailable` where v4 reported `null`.
+ *
+ * @example
+ * ```js
+ * import { useCastState } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const castState = useCastState()
+ *   // 'noDevicesAvailable' | 'notConnected' | 'connecting' | 'connected'
+ * }
+ * ```
+ */
+export function useCastState(): CastState {
+  return useSyncExternalStore(
+    castStore.subscribe,
+    () => castStore.getSnapshot().castState
+  )
+}

--- a/src/api/useDevices.ts
+++ b/src/api/useDevices.ts
@@ -1,0 +1,35 @@
+import { useSyncExternalStore } from 'react'
+import type { Device } from '../transport/types'
+import { castStore } from '../state/castStore.singleton'
+
+/**
+ * Hook that provides the list of {@link Device}s currently available for
+ * casting, re-rendering when the list changes.
+ *
+ * The array is frozen and referentially stable while the list is unchanged,
+ * so it is safe to use directly in dependency arrays.
+ *
+ * @example
+ * ```js
+ * import GoogleCast, { useDevices } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const devices = useDevices()
+ *   return devices.map((device) => (
+ *     <Button
+ *       key={device.deviceId}
+ *       onPress={() =>
+ *         GoogleCast.getSessionManager().startSession(device.deviceId)
+ *       }
+ *       title={device.friendlyName}
+ *     />
+ *   ))
+ * }
+ * ```
+ */
+export function useDevices(): readonly Device[] {
+  return useSyncExternalStore(
+    castStore.subscribe,
+    () => castStore.getSnapshot().devices
+  )
+}

--- a/src/components/CastButton.tsx
+++ b/src/components/CastButton.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { processColor, type ColorValue, type ViewProps } from 'react-native'
+import { getHostComponent } from 'react-native-nitro-modules'
+import type {
+  CastButtonProps as NativeCastButtonProps,
+  CastButtonMethods,
+} from '../specs/CastButton.nitro'
+import CastButtonConfig from '../../nitrogen/generated/shared/json/CastButtonConfig.json'
+
+export interface CastButtonProps extends ViewProps {
+  /** Tint color of the Cast icon (any RN `ColorValue`). Omit for the platform default. */
+  tintColor?: ColorValue
+}
+
+const NativeCastButton = getHostComponent<
+  NativeCastButtonProps,
+  CastButtonMethods
+>('CastButton', () => CastButtonConfig)
+
+// The generated prop is `tintColor?: number` (a processed color int), but the
+// E11 reset path must pass an explicit `null` — nitrogen's prop parser keeps
+// the cached value when a key is *absent* from the prop diff, so removing the
+// prop would strand the old tint. Both native lanes treat null as "reset to
+// the default color". Widen the component type once for that null.
+const TintResettableCastButton =
+  NativeCastButton as unknown as React.ComponentType<
+    ViewProps & { tintColor: number | null }
+  >
+
+/**
+ * Button that displays the Cast icon and automatically changes appearance
+ * based on the cast state (available / connecting / connected). Pressing it
+ * opens the native Cast dialog.
+ *
+ * Keeping one mounted also anchors
+ * {@link CastContext.showIntroductoryOverlay} and (on Android) triggers GCK's
+ * ACTIVE device scan, so devices are discovered while it is on screen.
+ *
+ * @example
+ * ```jsx
+ * import { CastButton } from 'react-native-google-cast'
+ *
+ * <CastButton tintColor="black" style={{ width: 24, height: 24 }} />
+ * ```
+ */
+export function CastButton({ tintColor, ...props }: CastButtonProps) {
+  const processed = tintColor != null ? processColor(tintColor) : null
+  return (
+    <TintResettableCastButton
+      {...props}
+      // Always include the key (E11): explicit null resets the native default.
+      tintColor={typeof processed === 'number' ? processed : null}
+    />
+  )
+}

--- a/src/components/CastButton.tsx
+++ b/src/components/CastButton.tsx
@@ -5,7 +5,24 @@ import type {
   CastButtonProps as NativeCastButtonProps,
   CastButtonMethods,
 } from '../specs/CastButton.nitro'
-import CastButtonConfig from '../../nitrogen/generated/shared/json/CastButtonConfig.json'
+
+// Inline mirror of nitrogen/generated/shared/json/CastButtonConfig.json. It
+// must live in src/ (not be imported from nitrogen/): builder-bob preserves
+// relative paths when emitting lib/commonjs + lib/module, so a source-relative
+// `../../nitrogen/...` import would resolve to the non-existent lib/nitrogen/
+// for consumers of the `main`/`module` entry points. A jest drift test
+// (CastButton.test.tsx) fails the suite if this ever diverges from the
+// generated file after `yarn specs`.
+const CastButtonConfig = {
+  uiViewClassName: 'CastButton',
+  supportsRawText: false,
+  bubblingEventTypes: {},
+  directEventTypes: {},
+  validAttributes: {
+    tintColor: true,
+    hybridRef: true,
+  },
+}
 
 export interface CastButtonProps extends ViewProps {
   /** Tint color of the Cast icon (any RN `ColorValue`). Omit for the platform default. */

--- a/src/components/CastButton.web.tsx
+++ b/src/components/CastButton.web.tsx
@@ -1,0 +1,19 @@
+import type { ColorValue, ViewProps } from 'react-native'
+
+export interface CastButtonProps extends ViewProps {
+  /** Tint color of the Cast icon (any RN `ColorValue`). Omit for the platform default. */
+  tintColor?: ColorValue
+}
+
+/**
+ * Web build of {@link CastButton}: renders nothing (E3).
+ *
+ * The native wrapper's `getHostComponent` deep-imports React Native
+ * internals that react-native-web does not provide, so this split keeps the
+ * import out of web *bundles* entirely. A real web Cast button ships with the
+ * Phase 8 web transport; until then this matches the web transport stub
+ * (Cast UI is never shown on web).
+ */
+export function CastButton(_props: CastButtonProps): null {
+  return null
+}

--- a/src/components/__tests__/CastButton.test.tsx
+++ b/src/components/__tests__/CastButton.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import TestRenderer, { act } from 'react-test-renderer'
 import { processColor } from 'react-native'
 import { getHostComponent } from 'react-native-nitro-modules'
-import CastButtonConfig from '../../../nitrogen/generated/shared/json/CastButtonConfig.json'
+import GeneratedCastButtonConfig from '../../../nitrogen/generated/shared/json/CastButtonConfig.json'
 import { CastButton } from '../CastButton'
 import { CastButton as CastButtonWeb } from '../CastButton.web'
 
@@ -46,7 +46,10 @@ describe('CastButton', () => {
     expect(mock).toHaveBeenCalledTimes(1)
     const [name, getViewConfig] = mock.mock.calls[0]!
     expect(name).toBe('CastButton')
-    expect(getViewConfig()).toBe(CastButtonConfig)
+    // The wrapper's config is an inline mirror (a nitrogen/ import would break
+    // bob's lib/ outputs); deep-equality against the generated JSON is the
+    // drift guard that keeps it honest across `yarn specs` runs.
+    expect(getViewConfig()).toEqual(GeneratedCastButtonConfig)
     act(() => renderer.unmount())
   })
 
@@ -102,10 +105,9 @@ describe('generated view config (drift guard)', () => {
   it('validAttributes covers exactly tintColor + hybridRef', () => {
     // A spec/regen drift (new/renamed prop) must fail the suite: the wrapper
     // and both native lanes key off these exact attributes.
-    expect(Object.keys(CastButtonConfig.validAttributes).sort()).toEqual([
-      'hybridRef',
-      'tintColor',
-    ])
-    expect(CastButtonConfig.uiViewClassName).toBe('CastButton')
+    expect(
+      Object.keys(GeneratedCastButtonConfig.validAttributes).sort()
+    ).toEqual(['hybridRef', 'tintColor'])
+    expect(GeneratedCastButtonConfig.uiViewClassName).toBe('CastButton')
   })
 })

--- a/src/components/__tests__/CastButton.test.tsx
+++ b/src/components/__tests__/CastButton.test.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import { processColor } from 'react-native'
+import { getHostComponent } from 'react-native-nitro-modules'
+import CastButtonConfig from '../../../nitrogen/generated/shared/json/CastButtonConfig.json'
+import { CastButton } from '../CastButton'
+import { CastButton as CastButtonWeb } from '../CastButton.web'
+
+// The real getHostComponent deep-imports RN internals
+// (react-native/Libraries/NativeComponent/NativeComponentRegistry), which
+// jest cannot provide — stub it with a recording host component.
+jest.mock('react-native-nitro-modules', () => ({
+  getHostComponent: jest.fn(() => {
+    const React = require('react')
+    return (props: Record<string, unknown>) =>
+      React.createElement('NativeCastButton', props)
+  }),
+}))
+
+function render(element: React.ReactElement): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(element)
+  })
+  return renderer
+}
+
+function hostProps(
+  renderer: TestRenderer.ReactTestRenderer
+): Record<string, unknown> {
+  return renderer.root.findByType(
+    'NativeCastButton' as unknown as React.ElementType
+  ).props
+}
+
+describe('CastButton', () => {
+  it('renders the generated host component registered as "CastButton"', () => {
+    const renderer = render(<CastButton />)
+    expect(
+      renderer.root.findAllByType(
+        'NativeCastButton' as unknown as React.ElementType
+      )
+    ).toHaveLength(1)
+
+    const mock = getHostComponent as jest.Mock
+    expect(mock).toHaveBeenCalledTimes(1)
+    const [name, getViewConfig] = mock.mock.calls[0]!
+    expect(name).toBe('CastButton')
+    expect(getViewConfig()).toBe(CastButtonConfig)
+    act(() => renderer.unmount())
+  })
+
+  it('converts a string tintColor via processColor', () => {
+    const renderer = render(<CastButton tintColor="red" />)
+    expect(hostProps(renderer).tintColor).toBe(processColor('red'))
+    expect(typeof hostProps(renderer).tintColor).toBe('number')
+    act(() => renderer.unmount())
+  })
+
+  it('always passes the tintColor key — null when absent (E11 reset path)', () => {
+    const renderer = render(<CastButton />)
+    const props = hostProps(renderer)
+    expect('tintColor' in props).toBe(true)
+    expect(props.tintColor).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('resets to null when the tintColor prop is removed (E11)', () => {
+    const renderer = render(<CastButton tintColor="#ff0000" />)
+    expect(typeof hostProps(renderer).tintColor).toBe('number')
+    act(() => {
+      renderer.update(<CastButton />)
+    })
+    expect(hostProps(renderer).tintColor).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('passes style and other ViewProps through', () => {
+    const style = { width: 24, height: 24 }
+    const renderer = render(
+      <CastButton style={style} testID="cast" accessibilityLabel="Cast" />
+    )
+    const props = hostProps(renderer)
+    expect(props.style).toBe(style)
+    expect(props.testID).toBe('cast')
+    expect(props.accessibilityLabel).toBe('Cast')
+    act(() => renderer.unmount())
+  })
+})
+
+describe('CastButton.web (E3)', () => {
+  it('renders null (graceful degradation; native wrapper never imported)', () => {
+    const renderer = render(
+      <CastButtonWeb tintColor="red" style={{ width: 24 }} />
+    )
+    expect(renderer.toJSON()).toBeNull()
+    act(() => renderer.unmount())
+  })
+})
+
+describe('generated view config (drift guard)', () => {
+  it('validAttributes covers exactly tintColor + hybridRef', () => {
+    // A spec/regen drift (new/renamed prop) must fail the suite: the wrapper
+    // and both native lanes key off these exact attributes.
+    expect(Object.keys(CastButtonConfig.validAttributes).sort()).toEqual([
+      'hybridRef',
+      'tintColor',
+    ])
+    expect(CastButtonConfig.uiViewClassName).toBe('CastButton')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,15 @@ export { useRemoteMediaClient } from './api/useRemoteMediaClient'
 export { useMediaStatus } from './api/useMediaStatus'
 export { useStreamPosition } from './api/useStreamPosition'
 export { useCastChannel } from './api/useCastChannel'
+export { useCastState } from './api/useCastState'
+export { useDevices } from './api/useDevices'
+export { useCastSession } from './api/useCastSession'
+export { useCastDevice } from './api/useCastDevice'
+export type { UseCastSessionOptions } from './api/useCastSession'
+
+// Components (CastButton resolves to CastButton.web on web — renders null).
+export { CastButton } from './components/CastButton'
+export type { CastButtonProps } from './components/CastButton'
 export type { SessionEventHandler } from './api/SessionManager'
 export type { EventSubscription } from './api/subscribeSelector'
 

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -256,7 +256,8 @@ export interface CastTransportApi {
   /**
    * Show the Cast dialog: the device chooser, or on Android the in-session
    * controller dialog when a session exists. Unlike v4, no mounted CastButton
-   * is required. Resolves `false` when there is no Activity (Android).
+   * is required. Resolves `false` when it cannot be presented (Android: no
+   * Activity, Cast framework unavailable, or no route selector).
    */
   showCastDialog(): Promise<boolean>
   /**

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -269,8 +269,11 @@ export interface CastTransportApi {
   /**
    * Present the introductory overlay anchored to the currently attached,
    * visible CastButton. Resolves `false` with no anchor or (with `once`) when
-   * already shown before. Android resolves on dismissal; the once-flag is
-   * platform-local (iOS: GCK's flag; Android: our own SharedPreferences — E2).
+   * already shown before. Resolves at presentation on both platforms — GCK's
+   * Android dismiss listener is a user-interaction callback, not a lifecycle
+   * one, so settling there could strand the promise if the Activity dies
+   * while the overlay is up. Android records its once-flag on dismissal; the
+   * flag is platform-local (iOS: GCK's flag; Android: SharedPreferences — E2).
    */
   showIntroductoryOverlay(once: boolean): Promise<boolean>
 


### PR DESCRIPTION
## Phase 6 Slice 6.1 — CastButton + Cast UI dialogs

First Nitro **HybridView** in the repo plus the Cast-UI one-shots and the remaining v4 hooks. Design: `docs/superpowers/specs/2026-07-12-castbutton-ui-design.md` (incl. eng-review amendments E1–E11); plan: `docs/superpowers/plans/2026-07-12-castbutton-ui-implementation.md`.

### What's in
- **`<CastButton tintColor style />`** — Nitro view (`CastButton.nitro.ts` + nitro.json autolinking entry): iOS `GCKUICastButton` created once (fixes v4's recreate-per-layout bug); Android `MediaRouteButton` with the themed-drawable-before-setup dance + mutate()d tint; `CastButton.web.tsx` renders null so web bundles keep working (E3). tintColor crosses as a processed color int; the wrapper always passes the key so removing the prop resets the default (E11).
- **`CastContext.showCastDialog / showExpandedControls / showIntroductoryOverlay`** — boolean = "the present/launch call was issued"; only the overlay verifies presentation (E7). Android dialog shows the MediaRouter chooser/controller **directly** (no mounted-button `performClick()` hack), via lifecycle-managed DialogFragments (E9). Overlay: **both v4 promise hangs are dead** — no-button resolves `false`, and Android owns its once-flag instead of GCK's silent `setSingleTime()` no-op (E2). Missing expanded-controller manifest registration rejects a typed `notSupported` with a fix hint (E8).
- **Hooks** — `useCastState`, `useDevices`, `useCastSession` (default path `useSyncExternalStore`; event path only for `ignoreSessionUpdatesInBackground`, mount race closed — E4/E5), `useCastDevice(options?)` (v4 parity, E6).
- **E1 (found in review, would've been a silent device-only failure):** `NitroGoogleCastPackage.createViewManagers` now returns the generated `HybridCastButtonManager` — nitrogen registers nothing on Android; iOS self-registers via generated `+load`.
- Example wiring: header CastButton (long-press to unmount → no-anchor overlay check), show* probe buttons, manifest registration.

### Verification
- jest **216 tests / 16 suites**, `yarn typescript`, prettier — green
- iOS `xcodebuild -target NitroGoogleCast` **BUILD SUCCEEDED**; Android `compileDebugKotlin` **BUILD SUCCESSFUL** (native CI on this PR is the authoritative gate)
- Two-stage subagent review (iOS diff / Android diff / holistic): no P1s; all P3 findings fixed in `d4f23fe`; all E1–E11 amendments verified landed
- **Device pass after merge** (Android priority): real Chromecast discovery via the button's ACTIVE scan, dialogs/overlay/expanded flows incl. overlay-across-rotation settlement probe, and `v5-vlv` item 4 (channel handshake)

Lanes were built in parallel worktrees from barrier `fd511fc` and merged `--no-ff` (TS `6b57c86..1a2a8b6`, iOS `cc63af9`, Android `213553d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdMyAWVCpWY8y8ADP8qB68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cross-platform `CastButton` with dedicated `tintColor` prop (web intentionally renders nothing).
  - Added Cast UI one-shot actions: `showCastDialog`, `showExpandedControls`, and `showIntroductoryOverlay` with boolean success semantics.
  - Introduced Cast hooks: `useCastState`, `useDevices`, `useCastSession`, and `useCastDevice`, including session/device retention while backgrounded.
  - Enabled Android expanded-controller support for expanded Cast controls.

- **Documentation**
  - Updated CastButton, ExpandedController, hooks, and v4→v5 migration docs, including `tintColor` and overlay “once” behavior.

- **Tests**
  - Added Jest coverage for Cast UI actions and hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->