### PR TITLE
fix(progress): request fresh MediaStatus on first progress subscriber (v5-aug.7)

### DIFF
--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -43,8 +43,18 @@ async function makeTicker(now: () => number) {
   const transport = new FakeCastTransport()
   const store = new CastStore(transport)
   await store.ready
-  const ticker = new ProgressTicker(store, now)
+  // Mirror the singleton wiring: the first subscriber fires a one-shot
+  // requestMediaStatus through the transport (recorded in `mediaCalls`).
+  const ticker = new ProgressTicker(store, now, () =>
+    transport.requestMediaStatus()
+  )
   return { transport, store, ticker }
+}
+
+/** Number of requestMediaStatus calls the fake transport has recorded. */
+function statusRequests(transport: FakeCastTransport): number {
+  return transport.mediaCalls.filter((c) => c.method === 'requestMediaStatus')
+    .length
 }
 
 describe('ProgressTicker — derivation', () => {
@@ -192,6 +202,130 @@ describe('ProgressTicker — derivation', () => {
     const off2 = ticker.subscribe(() => {})
     expect(ticker.getPosition()).toBe(20)
     off2()
+  })
+})
+
+describe('ProgressTicker — fresh status on first subscriber', () => {
+  it('the first subscriber triggers a one-shot requestMediaStatus', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    expect(statusRequests(transport)).toBe(0)
+
+    const off = ticker.subscribe(() => {})
+    expect(statusRequests(transport)).toBe(1)
+    off()
+  })
+
+  it('subsequent subscribers while already ticking do NOT re-request', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    const off1 = ticker.subscribe(() => {})
+    const off2 = ticker.subscribe(() => {}, 5)
+    const off3 = ticker.subscribe(() => {}, 0.5)
+    expect(statusRequests(transport)).toBe(1)
+    off1()
+    off2()
+    off3()
+  })
+
+  it('re-requests once per idle→active transition (rapid unsubscribe/resubscribe)', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    const off1 = ticker.subscribe(() => {})
+    expect(statusRequests(transport)).toBe(1)
+
+    // Last subscriber leaves, a new first subscriber attaches: exactly one
+    // more request — per 0→1 transition, never per subscriber.
+    off1()
+    const off2 = ticker.subscribe(() => {})
+    const off3 = ticker.subscribe(() => {})
+    expect(statusRequests(transport)).toBe(2)
+    off2()
+    off3()
+  })
+
+  it('re-subscribe after an idle gap re-times the anchor from the fresh push', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    const off1 = ticker.subscribe(() => {})
+    off1()
+
+    // Idle gap: cast playback continues, but the receiver seeks to 100 with
+    // NO status push (GCK is event-driven) — the local derivation is stale.
+    clock.advance(30000)
+    transport.mediaBehavior.requestMediaStatus = async () => {
+      // The receiver answers the request with a fresh, correctly-timed push.
+      transport.emitMediaStatus(
+        status({ streamPosition: 100, playerState: 'playing' })
+      )
+    }
+
+    // Re-subscribing requests a fresh status; the push re-anchors at 100
+    // (stale derivation would have reported 10 + 30 = 40).
+    const off2 = ticker.subscribe(() => {})
+    expect(statusRequests(transport)).toBe(2)
+    expect(ticker.getPosition()).toBe(100)
+
+    // And the anchor is re-timed off the push, not the old base.
+    clock.advance(1000)
+    expect(ticker.getPosition()).toBe(101)
+    off2()
+  })
+
+  it('swallows a requestMediaStatus rejection (no active session)', async () => {
+    const clock = makeClock()
+    const { ticker, transport } = await makeTicker(clock.now)
+    transport.mediaBehavior.requestMediaStatus = async () => {
+      throw { code: 'noSession' }
+    }
+
+    const onUnhandled = jest.fn()
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      // No session: subscribing must not throw…
+      const off = ticker.subscribe(() => {})
+      expect(statusRequests(transport)).toBe(1)
+      expect(ticker.getPosition()).toBeNull()
+      off()
+      // …and the rejection must be swallowed, not left unhandled.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(onUnhandled).not.toHaveBeenCalled()
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+    }
+  })
+
+  it('works without a fresh-status dependency (none injected)', async () => {
+    const clock = makeClock()
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    const ticker = new ProgressTicker(store, clock.now)
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    const off = ticker.subscribe(() => {})
+    expect(statusRequests(transport)).toBe(0)
+    clock.advance(2000)
+    expect(ticker.getPosition()).toBe(12)
+    off()
   })
 })
 

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -310,6 +310,35 @@ describe('ProgressTicker — fresh status on first subscriber', () => {
     }
   })
 
+  it('swallows a SYNCHRONOUS throw from the injected callback', async () => {
+    const clock = makeClock()
+    const transport = new FakeCastTransport()
+    const store = new CastStore(transport)
+    await store.ready
+    // A callback that throws before ever producing a promise: subscribe()
+    // must not throw, and the ticker must keep working normally.
+    const ticker = new ProgressTicker(store, clock.now, () => {
+      throw new Error('sync boom')
+    })
+    transport.emitLifecycle({ type: 'started', session: session('s1') })
+    transport.emitMediaStatus(
+      status({ streamPosition: 10, playerState: 'playing' })
+    )
+
+    let off: () => void
+    expect(() => {
+      off = ticker.subscribe(() => {})
+    }).not.toThrow()
+
+    // Ticking still works off the last pushed status.
+    clock.advance(2000)
+    expect(ticker.getPosition()).toBe(12)
+    off!()
+
+    // A later idle→active transition tries (and safely swallows) again.
+    expect(() => ticker.subscribe(() => {})()).not.toThrow()
+  })
+
   it('works without a fresh-status dependency (none injected)', async () => {
     const clock = makeClock()
     const transport = new FakeCastTransport()

--- a/src/state/progressTicker.singleton.ts
+++ b/src/state/progressTicker.singleton.ts
@@ -1,4 +1,4 @@
-import { castStore } from './castStore.singleton'
+import { castStore, castTransport } from './castStore.singleton'
 import { ProgressTicker } from './progressTicker'
 
 /**
@@ -7,5 +7,13 @@ import { ProgressTicker } from './progressTicker'
  * `RemoteMediaClient.onMediaProgressUpdated`) — never by the ticker's own tests,
  * which construct a {@link ProgressTicker} over a `FakeCastTransport`-backed
  * store so this module's native import stays out of their path.
+ *
+ * The third argument is the ticker's only transport dependency: a one-shot
+ * fresh-status request fired when the first progress subscriber attaches, so a
+ * re-subscribe after an idle gap re-times the anchor off a live push (the
+ * ticker swallows the no-session rejection). `undefined` keeps the default
+ * monotonic clock.
  */
-export const progressTicker = new ProgressTicker(castStore)
+export const progressTicker = new ProgressTicker(castStore, undefined, () =>
+  castTransport.requestMediaStatus()
+)

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -5,6 +5,13 @@ import type { MediaStatus } from '../types/MediaStatus'
 /** The store capability the ticker needs (both already on {@link CastStore}). */
 type TickerStoreView = Pick<CastStore, 'getSliceState' | 'subscribe'>
 
+/**
+ * Ask the receiver for a fresh media status (the transport's
+ * `requestMediaStatus`). The result arrives as a status push through the
+ * store, never via the return value; the promise only reports settlement.
+ */
+type RequestFreshStatus = () => Promise<void>
+
 /** A progress listener; pulls the current value via the ticker's getters. */
 type Listener = () => void
 
@@ -51,10 +58,20 @@ const monotonicNow: () => number =
  * resubscribe after the timer went idle — reads a live position instead of
  * re-anchoring the wall clock to a stale `streamPosition`. The ticker and its
  * store are paired singletons, so this holds no resource open beyond the store.
+ *
+ * The local anchor can still drift from the receiver across an idle gap — GCK
+ * pushes status event-driven, not on a cadence, so a receiver-side change with
+ * no push (or a JS clock throttled in the background) leaves the derived
+ * position stale. To heal that, the first subscriber after an idle period
+ * triggers a one-shot {@link RequestFreshStatus}: the fresh push re-times the
+ * anchor through the normal store path. Best-effort only — with no active
+ * session the request rejects and is swallowed (the ticker keeps deriving from
+ * the last known status).
  */
 export class ProgressTicker {
   private readonly store: TickerStoreView
   private readonly now: () => number
+  private readonly requestFreshStatus?: RequestFreshStatus
 
   private readonly subs = new Map<object, Subscriber>()
   private timer: ReturnType<typeof setInterval> | null = null
@@ -63,9 +80,14 @@ export class ProgressTicker {
   private anchorStatus: MediaStatus | null = null
   private anchorTime = 0
 
-  constructor(store: TickerStoreView, now: () => number = monotonicNow) {
+  constructor(
+    store: TickerStoreView,
+    now: () => number = monotonicNow,
+    requestFreshStatus?: RequestFreshStatus
+  ) {
     this.store = store
     this.now = now
+    this.requestFreshStatus = requestFreshStatus
     // Lifetime-bound (never unsubscribed): keep the anchor resynced to the last
     // media-status push even while there are no listeners (see class doc). The
     // ticker and its store are paired singletons, so this leaks nothing.
@@ -85,8 +107,14 @@ export class ProgressTicker {
         ? Math.max(interval, MIN_INTERVAL)
         : DEFAULT_INTERVAL
     const key = {}
+    const isFirst = this.subs.size === 0
     this.subs.set(key, { listener, interval: safeInterval })
     this.reconcileTimer()
+    // One-shot per idle→active transition (never per subscriber): the FIRST
+    // subscriber asks the receiver for a fresh status so the anchor re-times
+    // off a live push instead of a possibly stale event-driven one (see class
+    // doc). Best-effort — a rejection (e.g. no active session) is swallowed.
+    if (isFirst) void this.requestFreshStatus?.().catch(() => {})
     return () => {
       if (!this.subs.delete(key)) return
       // The store subscription and anchor are lifetime-bound; only the shared

--- a/src/state/progressTicker.ts
+++ b/src/state/progressTicker.ts
@@ -113,8 +113,15 @@ export class ProgressTicker {
     // One-shot per idle→active transition (never per subscriber): the FIRST
     // subscriber asks the receiver for a fresh status so the anchor re-times
     // off a live push instead of a possibly stale event-driven one (see class
-    // doc). Best-effort — a rejection (e.g. no active session) is swallowed.
-    if (isFirst) void this.requestFreshStatus?.().catch(() => {})
+    // doc). Best-effort — a rejection (e.g. no active session) is swallowed,
+    // and so is a synchronous throw from the injected callback.
+    if (isFirst && this.requestFreshStatus) {
+      try {
+        void this.requestFreshStatus().catch(() => {})
+      } catch {
+        // Best-effort refresh must never break subscription.
+      }
+    }
     return () => {
       if (!this.subs.delete(key)) return
       // The store subscription and anchor are lifetime-bound; only the shared


### PR DESCRIPTION
## Problem (v5-aug.7)

GCK pushes `MediaStatus` event-driven, not on a cadence. When a progress subscriber attaches after an idle gap (player screen unmounts/remounts while cast playback continues), the ticker's locally-derived position can be stale — a receiver-side change with no accompanying push (or a background-throttled JS clock) leaves the anchor pinned to an old base, and the position under-reports until the next push happens to arrive.

## Fix

Fire a one-shot `transport.requestMediaStatus()` when the **first** progress subscriber attaches (the 0→1 idle→active transition — never per subscriber). The receiver answers with a fresh, correctly-timed push, and the anchor re-times through the ticker's existing store path.

**Design choice — how the transport is threaded:** `ProgressTicker` does not get the transport. It takes an optional, narrow `requestFreshStatus: () => Promise<void>` third constructor argument; `progressTicker.singleton.ts` wires it to `castTransport.requestMediaStatus()`. The ticker keeps its `Pick<CastStore, 'getSliceState' | 'subscribe'>` store view untouched, and existing `(store, now)` construction sites keep working.

Best-effort semantics: with no active session the request rejects; the ticker swallows it with the codebase's `void p.catch(() => {})` convention, so no unhandled rejection.

## Tests (`src/state/__tests__/progressTicker.test.ts`)

- first subscriber triggers exactly one `requestMediaStatus`
- subsequent subscribers while already ticking do NOT re-request
- rapid unsubscribe/resubscribe: one request per 0→1 transition, not per subscriber
- re-subscribe after an idle-gap receiver seek re-anchors from the fresh push (stale path would report 40; fresh push yields 100, then 101 after 1 s)
- no-session rejection is swallowed (`unhandledRejection` listener stays silent)
- construction without the dependency still works (no request fired)

## Verification

- `yarn test`: 17 suites, 264 tests passing
- `yarn typescript`: clean (exit 0)
- `yarn lint`: no new errors; the repo-wide `prettier/prettier` rule-not-found errors and the `no-void` warning are pre-existing baseline (same warning on the existing swallow sites in `CastSession.ts` / `useCastChannel.ts`)

TS-only change — no `.nitro.ts` specs, generated, or native code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Progress tracking now performs a one-time media-status refresh when the first subscriber starts, improving accuracy after idle/resume.
  * Re-subscribing after inactivity correctly re-times the ticker using fresh status (avoiding stale anchors).
  * Best-effort status refresh failures (including “no session”) no longer surface as unhandled errors.
  * Progress tracking continues to function normally if the fresh-status refresh capability isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->