### PR TITLE
fix(v5): P5.2 CastChannel follow-ups — remount race, reactive status, KeyedBus hygiene (v5-vlv)

### DIFF
--- a/docs/guides/custom-channels.md
+++ b/docs/guides/custom-channels.md
@@ -19,6 +19,8 @@ const channel = await castSession.addChannel('urn:x-cast:...')
 Or, if you're using hooks:
 
 > Note that a channel with the same namespace can only be registered once at a time (you'd need to unregister previous one to create the same one again). If you need to access the channel from multiple screens, either move the call to their parent (e.g. navigator), or don't use the hook and instead call `addChannel` in a global store (e.g. Redux or Mobx). More info in [issue #316](https://github.com/react-native-google-cast/react-native-google-cast/issues/316#issuecomment-1065734844).
+>
+> While the namespace is registered elsewhere, the hook returns `null` and waits — it registers the channel automatically as soon as the namespace frees (for example when the holding screen unmounts).
 
 ```ts
 import { useCastChannel } from 'react-native-google-cast'
@@ -60,6 +62,28 @@ channel.offMessage()
 
 > The message is always delivered as the **raw string** received from the
 > receiver — if your receiver sends JSON, parse it with `JSON.parse(message)`.
+
+To check whether the channel is connected and writable, read the point-in-time getters:
+
+```ts
+channel.connected // boolean | undefined (undefined once the channel/session is gone)
+channel.writable
+```
+
+These do not cause a re-render when the status changes. For a reactive value, use the `useChannelStatus` hook:
+
+```ts
+import { useChannelStatus } from 'react-native-google-cast'
+
+function MyComponent() {
+  const status = useChannelStatus('urn:x-cast:com.example.custom')
+
+  // status is `null` while no channel is registered for the namespace
+  const canSend = status?.writable ?? false
+}
+```
+
+> Platform note: iOS streams real dynamic values — `connected` is often `false` right after the channel is added, until the connection completes (and stays `false` if the receiver never registered a listener for the namespace). Android reports `{ connected: true, writable: true }` once at registration and never updates (its SDK has no per-channel callbacks).
 
 When you no longer need the channel, you can remove it:
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -114,6 +114,25 @@ function MyComponent() {
 }
 ```
 
+A namespace can only be registered once at a time. If it is currently held elsewhere (including a just-unmounted predecessor of the same hook whose removal is still in flight), the hook returns `null` and waits — it registers the channel automatically as soon as the namespace frees.
+
+## Channel Status Hook
+
+Receive the live connection status of a registered custom channel, or `null` while none is registered for the namespace. This is the reactive counterpart to the point-in-time `channel.connected` / `channel.writable` getters.
+
+```js
+import { useChannelStatus } from 'react-native-google-cast'
+
+function MyComponent() {
+  const status = useChannelStatus('urn:x-cast:com.example.custom')
+
+  // disable sending until the receiver end is up
+  const canSend = status?.writable ?? false
+}
+```
+
+Platform note: iOS streams real dynamic values (often `connected: false` right after the channel is added, until the connection completes); Android reports `{ connected: true, writable: true }` once at registration and never updates (its SDK has no per-channel callbacks).
+
 ## Client Hook
 
 Receive the current [RemoteMediaClient](../api/classes/remotemediaclient).

--- a/src/api/CastChannel.ts
+++ b/src/api/CastChannel.ts
@@ -76,7 +76,8 @@ export class CastChannel {
    * asynchronously); Android always reports `true` (register-once, v4 parity).
    *
    * A point-in-time read of the store cache, not a reactive value: a component
-   * rendering it does not re-render when the status changes (v4 parity).
+   * rendering it does not re-render when the status changes (v4 parity). For
+   * a reactive status, use the {@link useChannelStatus} hook.
    */
   get connected(): boolean | undefined {
     return this.status()?.connected

--- a/src/api/__tests__/useCastChannel.test.tsx
+++ b/src/api/__tests__/useCastChannel.test.tsx
@@ -4,6 +4,7 @@ import type { Device, SessionInfo } from '../../transport/types'
 import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
 import { castTransport } from '../../state/castStore.singleton'
 import type { CastChannel } from '../CastChannel'
+import { CastContext } from '../CastContext'
 import { CastSession } from '../CastSession'
 import { useCastChannel } from '../useCastChannel'
 
@@ -69,6 +70,14 @@ beforeEach(async () => {
   transport.addChannelCalls.length = 0
   transport.removeChannelCalls.length = 0
   await flush()
+})
+
+afterEach(() => {
+  // Restore default scriptable behaviours mutated by the race tests.
+  transport.addChannelBehavior = async (namespace) => {
+    transport.emitChannelStatus(namespace, true, true)
+  }
+  transport.removeChannelBehavior = async () => {}
 })
 
 afterEach(() => {
@@ -181,6 +190,108 @@ describe('useCastChannel', () => {
     expect(transport.addChannelCalls).toEqual([NS, NS_B])
     expect(latest!.namespace).toBe(NS_B)
     act(() => renderer.unmount())
+  })
+
+  it('recovers when a remount races the predecessor’s in-flight registration', async () => {
+    // The narrow PR #610 window: the predecessor's addChannel has dispatched
+    // its initial channelStatus (slice entry present → register-once trips)
+    // but its native promise hasn't resolved, so the predecessor's cleanup
+    // couldn't remove yet (its `created` was still null). The successor must
+    // wait for the deferred removal and then register — never issuing its
+    // native add BEFORE the predecessor's native remove.
+    const order: string[] = []
+    let resolveFirstAdd!: () => void
+    let firstAdd = true
+    transport.addChannelBehavior = async (namespace) => {
+      order.push('add')
+      transport.emitChannelStatus(namespace, true, true)
+      if (firstAdd) {
+        firstAdd = false
+        await new Promise<void>((resolve) => {
+          resolveFirstAdd = resolve
+        })
+      }
+    }
+    transport.removeChannelBehavior = async () => {
+      order.push('remove')
+    }
+
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    const first = createProbe(<Probe namespace={NS} />)
+    await flush()
+    expect(latest).toBeNull() // native add still in flight
+    act(() => first.unmount())
+    const second = createProbe(<Probe namespace={NS} />)
+    await flush()
+    // Successor rejected `alreadyRegistered` (never reached the transport)
+    // and is now waiting on the slice.
+    expect(transport.addChannelCalls).toEqual([NS])
+    expect(latest).toBeNull()
+
+    // Native resolves the predecessor's add → its deferred cleanup removes →
+    // the waiting successor re-registers.
+    await act(async () => {
+      resolveFirstAdd()
+    })
+    await flush()
+    expect(latest).not.toBeNull()
+    expect(latest!.namespace).toBe(NS)
+    expect(latest!.connected).toBe(true)
+    expect(transport.addChannelCalls).toEqual([NS, NS])
+    expect(transport.removeChannelCalls).toEqual([NS])
+    // Native queue ordering preserved: remove precedes the successor's add.
+    expect(order).toEqual(['add', 'remove', 'add'])
+    act(() => second.unmount())
+  })
+
+  it('waits while the namespace is held elsewhere and registers once freed', async () => {
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    const castSession = CastContext.getSessionManager().getCurrentCastSession()!
+    let held!: CastChannel
+    await act(async () => {
+      held = await castSession.addChannel(NS)
+    })
+
+    const renderer = createProbe(<Probe namespace={NS} />)
+    await flush()
+    expect(latest).toBeNull() // register-once: the holder keeps it
+    expect(transport.addChannelCalls).toEqual([NS])
+
+    await act(async () => {
+      await held.remove()
+    })
+    await flush()
+    expect(latest).not.toBeNull()
+    expect(transport.addChannelCalls).toEqual([NS, NS])
+    act(() => renderer.unmount())
+  })
+
+  it('stops waiting on unmount — a later free must not re-register', async () => {
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    const castSession = CastContext.getSessionManager().getCurrentCastSession()!
+    let held!: CastChannel
+    await act(async () => {
+      held = await castSession.addChannel(NS)
+    })
+
+    const renderer = createProbe(<Probe namespace={NS} />)
+    await flush()
+    expect(latest).toBeNull()
+    act(() => renderer.unmount())
+
+    await act(async () => {
+      await held.remove()
+    })
+    await flush()
+    // The unmounted waiter unsubscribed: no stray registration.
+    expect(transport.addChannelCalls).toEqual([NS])
+    expect(transport.removeChannelCalls).toEqual([NS])
   })
 
   it('drops to null when the session ends', async () => {

--- a/src/api/__tests__/useChannelStatus.test.tsx
+++ b/src/api/__tests__/useChannelStatus.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import type { Device, SessionInfo } from '../../transport/types'
+import type { FakeCastTransport } from '../../transport/__fakes__/FakeCastTransport'
+import { castTransport } from '../../state/castStore.singleton'
+import type { ChannelStatus } from '../../state/channel.slice'
+import { useChannelStatus } from '../useChannelStatus'
+
+jest.mock('../../state/castStore.singleton', () => {
+  const { CastStore } = require('../../state/CastStore')
+  const {
+    FakeCastTransport,
+  } = require('../../transport/__fakes__/FakeCastTransport')
+  const transport = new FakeCastTransport()
+  const store = new CastStore(transport)
+  return { castStore: store, castTransport: transport }
+})
+
+const transport = castTransport as unknown as FakeCastTransport
+const NS = 'urn:x-cast:com.example.a'
+const NS_B = 'urn:x-cast:com.example.b'
+
+function device(id: string): Device {
+  return {
+    capabilities: [],
+    deviceId: id,
+    deviceVersion: '1',
+    friendlyName: `Device ${id}`,
+    icons: [],
+    ipAddress: '0.0.0.0',
+    modelName: 'TestCast',
+  }
+}
+function session(id: string): SessionInfo {
+  return { sessionId: id, device: device(id) }
+}
+
+let latest: ChannelStatus | null = null
+function Probe({ namespace }: { namespace: string }) {
+  latest = useChannelStatus(namespace)
+  return null
+}
+
+function createProbe(
+  element: React.ReactElement
+): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer
+  act(() => {
+    renderer = TestRenderer.create(element)
+  })
+  return renderer
+}
+
+beforeEach(async () => {
+  latest = null
+  await act(async () => {})
+})
+
+afterEach(() => {
+  act(() => {
+    transport.emitLifecycle({ type: 'ended' })
+  })
+})
+
+describe('useChannelStatus', () => {
+  it('is null while no channel is registered for the namespace', () => {
+    const renderer = createProbe(<Probe namespace={NS} />)
+    expect(latest).toBeNull()
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+    })
+    expect(latest).toBeNull() // session live, but namespace not registered
+    act(() => renderer.unmount())
+  })
+
+  it('tracks status updates reactively (iOS dynamic values)', () => {
+    const renderer = createProbe(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+      transport.emitChannelStatus(NS, false, false)
+    })
+    expect(latest).toEqual({ connected: false, writable: false })
+    act(() => {
+      transport.emitChannelStatus(NS, true, true)
+    })
+    expect(latest).toEqual({ connected: true, writable: true })
+    act(() => renderer.unmount())
+  })
+
+  it('is referentially stable while the status is unchanged', () => {
+    const renderer = createProbe(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+      transport.emitChannelStatus(NS, true, true)
+    })
+    const before = latest
+    act(() => {
+      transport.emitChannelStatus(NS, true, true) // identical values
+    })
+    expect(latest).toBe(before)
+    act(() => renderer.unmount())
+  })
+
+  it('only reflects its own namespace', () => {
+    const renderer = createProbe(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+      transport.emitChannelStatus(NS_B, true, true)
+    })
+    expect(latest).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('drops to null when the channel is removed or the session ends', () => {
+    const renderer = createProbe(<Probe namespace={NS} />)
+    act(() => {
+      transport.emitLifecycle({ type: 'started', session: session('s1') })
+      transport.emitChannelStatus(NS, true, true)
+    })
+    expect(latest).not.toBeNull()
+    act(() => {
+      transport.emitLifecycle({ type: 'ended' })
+    })
+    expect(latest).toBeNull()
+    act(() => renderer.unmount())
+  })
+})

--- a/src/api/useCastChannel.ts
+++ b/src/api/useCastChannel.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { castStore } from '../state/castStore.singleton'
+import { CHANNEL_SLICE_KEY, type ChannelState } from '../state/channel.slice'
+import type { CastError } from '../transport/types'
 import { CastContext } from './CastContext'
 import type { CastChannel } from './CastChannel'
 
@@ -15,9 +17,13 @@ import type { CastChannel } from './CastChannel'
  * re-registering the channel). Do not also call `channel.onMessage` elsewhere,
  * or the two will clobber each other.
  *
- * Note that a namespace can only be registered once at a time. To use a
- * channel from multiple screens, lift the hook to a common parent (or manage
- * the channel in a global store) — see the Custom Channels guide.
+ * Note that a namespace can only be registered once at a time. If the
+ * namespace is currently registered elsewhere — including by a predecessor of
+ * this very hook whose in-flight registration a fast remount raced — the hook
+ * returns `null` and **waits**: it registers the channel as soon as the
+ * namespace frees, instead of failing permanently. To use a channel from
+ * multiple screens at once, lift the hook to a common parent (or manage the
+ * channel in a global store) — see the Custom Channels guide.
  *
  * @param namespace custom namespace starting with `urn:x-cast:`.
  * @param onMessage listener invoked with each raw message string received.
@@ -59,24 +65,71 @@ export function useCastChannel(
     }
     let active = true
     let created: CastChannel | null = null
-    castSession
-      .addChannel(namespace, (message) => onMessageRef.current?.(message))
-      .then((c) => {
-        if (active) {
-          created = c
-          setChannel(c)
-        } else {
-          // Unmounted while adding — undo immediately.
-          void c.remove().catch(() => {})
-        }
+    let unwatch: (() => void) | null = null
+
+    const namespaceFree = () =>
+      castStore.getSliceState<ChannelState>(CHANNEL_SLICE_KEY).statuses[
+        namespace
+      ] === undefined
+
+    const attempt = () => {
+      castSession
+        .addChannel(namespace, (message) => onMessageRef.current?.(message))
+        .then((c) => {
+          if (active) {
+            created = c
+            setChannel(c)
+          } else {
+            // Unmounted while adding — undo immediately.
+            void c.remove().catch(() => {})
+          }
+        })
+        .catch((error: unknown) => {
+          // Session ended mid-add, or the namespace is registered elsewhere
+          // (register-once). The latter can be transient: a fast remount races
+          // the predecessor's in-flight registration — its initial
+          // channelStatus already holds the slice entry, but its deferred
+          // cleanup `remove()` can only run once that registration resolves.
+          // So on alreadyRegistered we don't give up: wait for the namespace
+          // to free (predecessor removal, another screen releasing it, or
+          // session teardown clearing the slice) and register then.
+          if (!active) return
+          setChannel(null)
+          if ((error as CastError | null)?.code === 'alreadyRegistered') {
+            waitForNamespace()
+          }
+        })
+    }
+
+    const waitForNamespace = () => {
+      if (namespaceFree()) {
+        // Already freed by the time the rejection settled. Safe to re-add
+        // right away: the freeing `remove()` dispatches `channelRemoved` and
+        // issues its native removeChannel back-to-back synchronously, so the
+        // bridge has the remove before this add.
+        attempt()
+        return
+      }
+      unwatch = castStore.subscribe(() => {
+        if (!active || !namespaceFree()) return
+        unwatch?.()
+        unwatch = null
+        // Defer a microtask: this callback fires synchronously from the
+        // `channelRemoved` dispatch inside `CastChannel.remove()`, i.e.
+        // BEFORE its native removeChannel call. Re-adding synchronously here
+        // would issue addChannel first and the trailing remove would then
+        // tear down the fresh native channel (T1 ordering inversion).
+        void Promise.resolve().then(() => {
+          if (active) attempt()
+        })
       })
-      .catch(() => {
-        // Session ended mid-add, or the namespace is registered elsewhere
-        // (register-once — see the guide's lift-to-parent note).
-        if (active) setChannel(null)
-      })
+    }
+
+    attempt()
     return () => {
       active = false
+      unwatch?.()
+      unwatch = null
       setChannel(null)
       // `remove()` frees the namespace synchronously (T1), so a remount /
       // namespace change can re-add immediately without self-colliding. It

--- a/src/api/useChannelStatus.ts
+++ b/src/api/useChannelStatus.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from 'react'
+import { castStore } from '../state/castStore.singleton'
+import {
+  CHANNEL_SLICE_KEY,
+  type ChannelState,
+  type ChannelStatus,
+} from '../state/channel.slice'
+
+/**
+ * Hook returning the live connection status of the custom channel registered
+ * for `namespace`, or `null` while no such channel is registered (no session,
+ * or the channel hasn't been added / was removed).
+ *
+ * This is the **reactive** counterpart to the point-in-time
+ * {@link CastChannel.connected} / {@link CastChannel.writable} getters: a
+ * component using this hook re-renders when the status changes. The returned
+ * object is frozen and referentially stable while the status is unchanged.
+ *
+ * Platform note (same as the getters): iOS streams real dynamic values — often
+ * `connected: false` right after {@link CastSession.addChannel} until the
+ * connection completes; Android reports `{connected: true, writable: true}`
+ * once at registration and never updates (its SDK has no per-channel
+ * callbacks).
+ *
+ * @param namespace custom channel namespace starting with `urn:x-cast:`.
+ * @returns the channel's status, or `null`.
+ *
+ * @example
+ * ```js
+ * import { useCastChannel, useChannelStatus } from 'react-native-google-cast'
+ *
+ * function MyComponent() {
+ *   const channel = useCastChannel('urn:x-cast:com.example.custom')
+ *   const status = useChannelStatus('urn:x-cast:com.example.custom')
+ *
+ *   // disable the send button until the receiver end is up
+ *   const canSend = status?.writable ?? false
+ * }
+ * ```
+ */
+export function useChannelStatus(namespace: string): ChannelStatus | null {
+  return useSyncExternalStore(
+    castStore.subscribe,
+    () =>
+      castStore.getSliceState<ChannelState>(CHANNEL_SLICE_KEY).statuses[
+        namespace
+      ] ?? null
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { useRemoteMediaClient } from './api/useRemoteMediaClient'
 export { useMediaStatus } from './api/useMediaStatus'
 export { useStreamPosition } from './api/useStreamPosition'
 export { useCastChannel } from './api/useCastChannel'
+export { useChannelStatus } from './api/useChannelStatus'
 export { useCastState } from './api/useCastState'
 export { useDevices } from './api/useDevices'
 export { useCastSession } from './api/useCastSession'
@@ -38,6 +39,7 @@ export type {
   SessionEventType,
 } from './transport/types'
 export type { CastError, CastErrorCode } from './types/CastError'
+export type { ChannelStatus } from './state/channel.slice'
 
 // RemoteMediaClient public types (method signatures, returns, status inspection).
 export type { MediaStatus } from './types/MediaStatus'

--- a/src/state/__tests__/keyedBus.test.ts
+++ b/src/state/__tests__/keyedBus.test.ts
@@ -60,4 +60,32 @@ describe('KeyedBus', () => {
     bus.emit('k', 1)
     expect(handler).not.toHaveBeenCalled()
   })
+
+  /** Peek at the private per-key map (hygiene assertions only). */
+  function keyCount(bus: KeyedBus<string, number>): number {
+    return (bus as unknown as { handlers: Map<string, unknown> }).handlers.size
+  }
+
+  it('prunes the key entry once its last handler unsubscribes', () => {
+    const bus = new KeyedBus<string, number>()
+    const offA = bus.subscribe('k', jest.fn())
+    const offB = bus.subscribe('k', jest.fn())
+    expect(keyCount(bus)).toBe(1)
+    offA()
+    expect(keyCount(bus)).toBe(1) // one handler left — entry stays
+    offB()
+    expect(keyCount(bus)).toBe(0) // last one out prunes the key
+  })
+
+  it('a stale double-unsubscribe cannot drop a successor subscriber on the same key', () => {
+    const bus = new KeyedBus<string, number>()
+    const off = bus.subscribe('k', jest.fn())
+    off() // empties + prunes the original Set
+    const successor = jest.fn()
+    bus.subscribe('k', successor) // fresh Set under the same key
+    off() // stale second call — must not delete the successor's Set
+    bus.emit('k', 7)
+    expect(successor).toHaveBeenCalledWith(7)
+    expect(keyCount(bus)).toBe(1)
+  })
 })

--- a/src/state/keyedBus.ts
+++ b/src/state/keyedBus.ts
@@ -8,6 +8,12 @@
  * lifecycle bus (`CastStore.on`) and the Phase 5 per-namespace channel message
  * bus (`CastStore.onChannelMessage`). State replay is `getSnapshot`'s job —
  * nothing emitted through a bus is ever replayed to a late subscriber.
+ *
+ * Handlers are stored in a per-key `Set`, so subscribing the **same function
+ * reference** to the same key twice collapses to a single entry — and a single
+ * unsubscribe then drops it entirely. No current caller does this (each
+ * subscriber passes a fresh closure); if you need duplicate handlers on one
+ * key, wrap each in its own closure.
  */
 export class KeyedBus<K, V> {
   private readonly handlers = new Map<K, Set<(value: V) => void>>()
@@ -22,6 +28,13 @@ export class KeyedBus<K, V> {
     set.add(handler)
     return () => {
       set.delete(handler)
+      // Prune the key's entry once its last handler is gone, so long-lived
+      // buses keyed by unbounded values (channel namespaces) don't accumulate
+      // empty Sets. Guard on identity: a stale double-unsubscribe must not
+      // drop a successor Set created for the same key in the meantime.
+      if (set.size === 0 && this.handlers.get(key) === set) {
+        this.handlers.delete(key)
+      }
     }
   }
 


### PR DESCRIPTION
Implements items 1–3 of **v5-vlv** (P5.2 CastChannel follow-ups). Item 4 is device-gated and deliberately not included.

## 1. `useCastChannel` — transient `alreadyRegistered` recovery

The narrow remount race (PR #610 discussion): a predecessor hook's `addChannel` is still in flight — native's initial `channelStatus` has already populated the channel-slice entry (tripping the register-once check), but the promise hasn't resolved, so the predecessor's cleanup couldn't `remove()` yet (`created` was still `null`; removal happens later in its `.then`). The successor's `addChannel` rejected `alreadyRegistered` and the hook gave up permanently.

**Fix (retry-on-alreadyRegistered-while-active):** on `alreadyRegistered`, the hook now subscribes to the store and re-attempts registration once the namespace frees. Two ordering subtleties are handled:

- The store notification for `channelRemoved` fires synchronously **inside** `CastChannel.remove()`, *before* its native `removeChannel` bridge call — re-adding synchronously from the subscriber would issue the successor's `addChannel` first and the trailing remove would tear down the fresh native channel. The retry is therefore **microtask-deferred** (asserted by the ordering test: `add, remove, add`).
- If the namespace is already free by the time the rejection settles, the retry runs immediately — safe because `remove()` dispatches and issues its bridge call back-to-back synchronously.

Side effect (documented in the hook docstring + both guides): when the namespace is held by *another* owner, the hook now waits and registers when it frees, instead of failing permanently — strictly more useful, and the multi-screen guidance (lift to parent) is unchanged.

New tests: the in-flight remount race with native-queue ordering assertion, waiting on an externally held namespace and claiming it when freed, and unmount-while-waiting (no stray registration).

## 2. Reactive channel status — `useChannelStatus(namespace)`

Fits the existing selector-hook pattern cleanly: the channel slice already carries ref-stable, frozen per-namespace `ChannelStatus`, so the hook is a direct `useSyncExternalStore` selector over `statuses[namespace] ?? null` (same shape as `useMediaStatus`). Reactive counterpart to the point-in-time `channel.connected` / `channel.writable` getters (which now cross-reference it). Exported from the barrel along with the `ChannelStatus` type; documented in the hooks guide and custom-channels guide with the iOS-dynamic / Android-static platform note.

Tests: null when unregistered, reactive updates, referential stability on identical values, per-namespace isolation, reset on session end.

## 3. `KeyedBus` hygiene

- Empty per-key `Set`s are now pruned on last unsubscribe — identity-guarded (`handlers.get(key) === set`) so a stale double-unsubscribe cannot drop a successor `Set` created for the same key in the meantime.
- Doc comment added warning that subscribing the same function reference twice to one key collapses in the `Set` (and one unsubscribe then drops it entirely).
- No other behavior change. Tests cover pruning and the stale double-unsubscribe guard.

## Verification

- `yarn test`: 18 suites, 268 tests passing (10 new)
- `yarn typescript`: clean
- Prettier: clean on all touched files (`yarn lint`'s `prettier/prettier` rule-resolution failure is pre-existing repo-wide on the base branch — 110 problems before this change; this diff adds none beyond the same bogus per-file rule-not-found and one `no-void` warning matching existing file style)

Refs v5-vlv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `useChannelStatus` for reactive channel connection and writability updates.
  * Exported the `useChannelStatus` hook and `ChannelStatus` type.
* **Bug Fixes**
  * Custom channel hooks now wait for occupied namespaces to become available and retry registration automatically.
  * Improved cleanup when channels are unmounted or registration is interrupted.
  * Prevented stale unsubscribe actions from affecting newer subscriptions.
* **Documentation**
  * Clarified channel registration behavior and status-checking options, including platform-specific details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->