### PR TITLE
feat(v5): native-boundary fake seam + tier-1 Maestro E2E in CI (v5-gae)

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -1,0 +1,119 @@
+name: E2E Android (tier-1 Maestro)
+
+# Tier-1 E2E for the v5 (Nitro) rewrite (T3, issue #604): boots the example app
+# on an emulator — no Chromecast (Cast discovery cannot work on emulators) and
+# no Metro (JS is bundled into the debug APK) — and drives the debug-only
+# native fake seam (`CastDebug.inject*`) through a Maestro flow. The flow
+# asserts that injected session-lifecycle events cross the REAL Nitro boundary
+# (JS→native struct in, the transport's stored native→JS callbacks out) and
+# land in the app UI. Android only for now: Maestro on the iOS simulator needs
+# a macOS runner + a bundled-JS debug scheme; tracked as a follow-up in #604.
+#
+# Gated on relevant paths (emulator boots are slow), mirroring android.yml.
+
+on:
+  push:
+    branches: [v5]
+  pull_request:
+    branches: [v5]
+  workflow_dispatch:
+
+# Newer pushes to the same ref cancel in-flight runs.
+concurrency:
+  group: e2e-android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect e2e-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'android/**'
+              - 'src/**'
+              - 'example/**'
+              - 'nitrogen/generated/**'
+              - '.maestro/**'
+              - '.github/workflows/e2e-android.yml'
+
+  maestro:
+    name: Tier-1 Maestro (emulator, fake seam)
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [34]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # KVM hardware acceleration is available on GitHub-hosted Linux runners.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+      - name: Install JS dependencies
+        run: yarn install --immutable
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: android-actions/setup-android@v3
+      - name: Install pinned NDK + CMake (builds the .so)
+        run: sdkmanager "ndk;27.1.12297006" "cmake;3.22.1"
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Install Maestro
+        run: |
+          curl -fsSL https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      # Build before booting the emulator (keeps emulator uptime minimal).
+      # `-PbundleInDebug=true` bakes the JS bundle into the *debug* APK: no
+      # Metro in CI, and the APK stays android:debuggable — the flag the native
+      # fake seam is gated on (a release APK would be a delivered=false no-op).
+      - name: Build example debug APK (bundled JS, x86_64)
+        working-directory: example/android
+        run: ./gradlew :app:assembleDebug -PbundleInDebug=true -PreactNativeArchitectures=x86_64
+
+      - name: Run tier-1 Maestro flow
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            adb install -r example/android/app/build/outputs/apk/debug/app-debug.apk
+            maestro test .maestro/tier1-fake-session.yml
+
+      # Maestro writes screenshots + logs for failed flows under ~/.maestro/tests.
+      - name: Upload Maestro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-artifacts
+          path: ~/.maestro/tests/
+          if-no-files-found: ignore

--- a/.maestro/tier1-fake-session.yml
+++ b/.maestro/tier1-fake-session.yml
@@ -1,0 +1,28 @@
+# Tier-1 E2E (T3, issue #604): drives the REAL Nitro module on an emulator with
+# no Chromecast (Cast discovery does not work on emulators — official Google
+# limitation). "Fake start" / "Fake end" call the debug-only native seam
+# (`CastDebug.inject*`), which delivers synthetic events through the SAME stored
+# `initAndSubscribe` callbacks the real GCK listeners invoke on `CastTransport` —
+# so every assertion below has crossed the genuine native↔JS boundary twice
+# (JS→native struct conversion in, native→JS callback out) before reaching the UI.
+#
+# Requires a debug (android:debuggable) build of the example app; the seam is a
+# `delivered=false` no-op otherwise. Run locally via scripts/e2e-android.sh.
+appId: com.castexample
+---
+- launchApp
+# Bundled-JS debug build: allow time for the RN runtime to boot on a cold CI emulator.
+- extendedWaitUntil:
+    visible: 'Session: none'
+    timeout: 60000
+- tapOn: 'Fake start'
+# The seam must report real native delivery (not a silent no-op)…
+- assertVisible: '.*fake session started delivered=true.*'
+# …and the injected events must round-trip through the Nitro boundary + store into the UI:
+- assertVisible: 'Session: fake-session-1'
+- assertVisible: 'Cast state: connected'
+- assertVisible: 'Devices: 1'
+- tapOn: 'Fake end'
+- assertVisible: '.*fake session ended delivered=true.*'
+- assertVisible: 'Session: none'
+- assertVisible: 'Cast state: notConnected'

--- a/android/src/main/java/com/margelo/nitro/googlecast/CastDebugEventSink.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/CastDebugEventSink.kt
@@ -1,0 +1,57 @@
+package com.margelo.nitro.googlecast
+
+import android.content.pm.ApplicationInfo
+import com.margelo.nitro.NitroModules
+
+/**
+ * Debug-only fake seam (T3): hands `HybridCastDebug.inject*` the *same* stored
+ * `initAndSubscribe` callbacks the real GCK listeners invoke on
+ * [HybridCastTransport], so tier-1 Maestro E2E can drive the real Nitro
+ * boundary (native → JS callback delivery) on an emulator where Cast discovery
+ * cannot work.
+ *
+ * All gating lives here: Android has no compile-time debug split for
+ * source-built libraries, so the seam is armed only when the *host app* is
+ * debuggable (`ApplicationInfo.FLAG_DEBUGGABLE`). The transport calls
+ * [attach]/[detach] unconditionally; in a non-debuggable (release) app both
+ * no-op and [current] always returns null.
+ *
+ * Threading: [attach] runs on the JS thread inside `initAndSubscribe`
+ * (mirroring the transport's own callback-var assignment); [current] is read
+ * by `HybridCastDebug.inject*`, which posts delivery to the main thread,
+ * matching real GCK main-thread event delivery.
+ */
+internal object CastDebugEventSink {
+  internal class Emitters(
+    val emitState: (CastState) -> Unit,
+    val emitDevices: (Array<Device>) -> Unit,
+    val emitLifecycle: (SessionLifecycleEvent) -> Unit,
+    val emitMediaStatus: (MediaStatus) -> Unit,
+  )
+
+  @Volatile private var emitters: Emitters? = null
+
+  private val isHostDebuggable: Boolean
+    get() {
+      val context = NitroModules.applicationContext ?: return false
+      return (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+    }
+
+  /**
+   * Called by `HybridCastTransport.initAndSubscribe` right after it stores the
+   * JS callbacks. The closures must read the transport's *current* callback
+   * vars (not capture the parameters), so a later `dispose()` nulling them
+   * also silences the seam.
+   */
+  fun attach(newEmitters: Emitters) {
+    if (isHostDebuggable) emitters = newEmitters
+  }
+
+  /** Called by `HybridCastTransport.dispose()`. */
+  fun detach() {
+    emitters = null
+  }
+
+  /** The live emitters, or null when the seam is inactive. */
+  fun current(): Emitters? = if (isHostDebuggable) emitters else null
+}

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastDebug.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastDebug.kt
@@ -1,7 +1,10 @@
 package com.margelo.nitro.googlecast
 
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.googlecast.converters.fromGckActiveInputState
 import com.margelo.nitro.googlecast.converters.fromGckConnectionResult
 import com.margelo.nitro.googlecast.converters.fromGckStandbyState
@@ -46,6 +49,11 @@ import com.margelo.nitro.googlecast.converters.toWebImage
  * `struct → GCK → struct` so the shared golden-fixture parity suite (T1) can assert
  * round-trip identity and cross-platform (iOS == Android) equality. Converters live in
  * one-per-type files under `converters/`; this object only wires them together.
+ *
+ * The `inject*` methods are the native-boundary fake seam (T3): they deliver a synthetic
+ * event through the live transport's stored `initAndSubscribe` callbacks (via
+ * [CastDebugEventSink]), posted to the main thread, mirroring real GCK delivery. A
+ * `false` no-op when the host app is not debuggable.
  */
 @DoNotStrip
 @Keep
@@ -112,4 +120,36 @@ class HybridCastDebug : HybridCastDebugSpec() {
     value: PlayServicesState
   ): PlayServicesState =
     PlayServicesState.fromGckConnectionResult(value.toGckConnectionResult())
+
+  // MARK: - Native-boundary fake seam (T3) — debuggable host apps only
+
+  override fun injectCastState(castState: CastState): Promise<Boolean> =
+    inject { it.emitState(castState) }
+
+  override fun injectDevices(devices: Array<Device>): Promise<Boolean> =
+    inject { it.emitDevices(devices) }
+
+  override fun injectLifecycleEvent(event: SessionLifecycleEvent): Promise<Boolean> =
+    inject { it.emitLifecycle(event) }
+
+  override fun injectMediaStatus(status: MediaStatus): Promise<Boolean> =
+    inject { it.emitMediaStatus(status) }
+
+  /**
+   * Resolves `true` after delivering on the main thread; `false` when the seam is
+   * inactive (non-debuggable app, or `CastTransport.initAndSubscribe` has not run).
+   */
+  private fun inject(deliver: (CastDebugEventSink.Emitters) -> Unit): Promise<Boolean> {
+    val promise = Promise<Boolean>()
+    val emitters = CastDebugEventSink.current()
+    if (emitters == null) {
+      promise.resolve(false)
+      return promise
+    }
+    Handler(Looper.getMainLooper()).post {
+      deliver(emitters)
+      promise.resolve(true)
+    }
+    return promise
+  }
 }

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -134,6 +134,18 @@ class HybridCastTransport : HybridCastTransportSpec() {
     this.onChannelMessage = onChannelMessage
     this.onChannelStatus = onChannelStatus
 
+    // Debug-only fake seam (T3): expose the freshly stored callbacks to
+    // `HybridCastDebug.inject*`. Gating (host-app debuggable) lives in the sink;
+    // the closures read the current fields, so `dispose()` also silences the seam.
+    CastDebugEventSink.attach(
+      CastDebugEventSink.Emitters(
+        emitState = { this.onState?.invoke(it) },
+        emitDevices = { this.onDevices?.invoke(it) },
+        emitLifecycle = { this.onLifecycle?.invoke(it) },
+        emitMediaStatus = { this.onMediaStatus?.invoke(it) },
+      )
+    )
+
     val promise = Promise<InitialSnapshot>()
     runOnMain {
       val castContext = sharedCastContextOrNull()
@@ -215,6 +227,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
   }
 
   override fun dispose() {
+    CastDebugEventSink.detach()
     runOnMain {
       detachObservers()
       detachMediaCallback()

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -26,6 +26,11 @@ import GoogleCast, {
   type CastState,
   type Device,
 } from 'react-native-google-cast';
+// Debug-only native fake seam (T3) — deliberately not on the package barrel.
+import {
+  injectFakeSessionEnded,
+  injectFakeSessionStarted,
+} from 'react-native-google-cast/src/debug/fakeSession';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
@@ -40,6 +45,9 @@ function App() {
     discoveryManager.getDevices(),
   );
   const [log, setLog] = useState<string[]>([]);
+  // Live session id, driven purely by the session-lifecycle stream — the
+  // tier-1 Maestro flow asserts on this line after injecting fake events.
+  const [sessionId, setSessionId] = useState<string | null>(null);
   // Device-pass toggle: unmounting the CastButton exercises the overlay's
   // no-anchor → false path (and, on Android, stops the ACTIVE scan trigger).
   const [showCastButton, setShowCastButton] = useState(true);
@@ -64,20 +72,30 @@ function App() {
       sessionManager.onSessionStarting(s =>
         append(`starting (${s?.id ?? '—'})`),
       ),
-      sessionManager.onSessionStarted(s => append(`started (${s?.id ?? '—'})`)),
+      sessionManager.onSessionStarted(s => {
+        setSessionId(s?.id ?? null);
+        append(`started (${s?.id ?? '—'})`);
+      }),
       sessionManager.onSessionStartFailed((_s, e) =>
         append(`startFailed: ${e?.code} / native ${e?.nativeCode}`),
       ),
       sessionManager.onSessionEnding(s => append(`ending (${s?.id ?? '—'})`)),
-      sessionManager.onSessionEnded((_s, e) =>
-        append(`ended${e ? `: ${e.code} / native ${e.nativeCode}` : ''}`),
-      ),
+      sessionManager.onSessionEnded((_s, e) => {
+        setSessionId(null);
+        append(`ended${e ? `: ${e.code} / native ${e.nativeCode}` : ''}`);
+      }),
       sessionManager.onSessionResuming(() => append('resuming')),
-      sessionManager.onSessionResumed(s => append(`resumed (${s?.id ?? '—'})`)),
+      sessionManager.onSessionResumed(s => {
+        setSessionId(s?.id ?? null);
+        append(`resumed (${s?.id ?? '—'})`);
+      }),
       sessionManager.onSessionResumeFailed((_s, e) =>
         append(`resumeFailed: ${e?.code} / native ${e?.nativeCode}`),
       ),
-      sessionManager.onSessionSuspended(() => append('suspended')),
+      sessionManager.onSessionSuspended(() => {
+        setSessionId(null);
+        append('suspended');
+      }),
     ];
     return () => subs.forEach(s => s.remove());
   }, [sessionManager, discoveryManager]);
@@ -126,6 +144,22 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // T3 — native-boundary fake seam: injects synthetic events through the real
+  // Nitro callbacks (debug builds only). `delivered=false` means the seam is
+  // inactive (release build or transport not initialized).
+  const fakeSeam = async (
+    name: string,
+    call: () => Promise<boolean>,
+  ) => {
+    try {
+      const delivered = await call();
+      append(`fake ${name} delivered=${delivered}`);
+    } catch (e) {
+      const err = e as Error;
+      append(`fake ${name} threw: ${err.message}`);
+    }
+  };
+
   // Phase 6.1 — Cast UI one-shots; each logs its boolean resolution (or the
   // typed CastError) into the event log for the device pass.
   const probeShow = async (
@@ -164,9 +198,14 @@ function App() {
             )}
           </Pressable>
         </View>
-        <Text style={text}>Cast state: {state}</Text>
+        <Text testID="castStateText" style={text}>
+          Cast state: {state}
+        </Text>
         <Text style={text}>Play Services: {playServices}</Text>
         <Text style={text}>Devices: {devices.length}</Text>
+        <Text testID="sessionStateText" style={text}>
+          Session: {sessionId ?? 'none'}
+        </Text>
 
         <View style={styles.buttons}>
           <Pressable style={styles.button} onPress={probeError}>
@@ -230,6 +269,29 @@ function App() {
           </Pressable>
         </View>
 
+        {/* T3 fake seam — no `__DEV__` gate: the CI tier-1 build bundles JS
+            with dev=false (debuggableVariants=[]) while staying
+            android:debuggable. The native seam is the real gate: in a release
+            (non-debuggable) build these buttons just log `delivered=false`. */}
+        <View style={styles.buttons}>
+          <Pressable
+            testID="injectFakeSessionStarted"
+            style={[styles.button, styles.fakeButton]}
+            onPress={() =>
+              fakeSeam('session started', injectFakeSessionStarted)
+            }
+          >
+            <Text style={styles.buttonText}>Fake start</Text>
+          </Pressable>
+          <Pressable
+            testID="injectFakeSessionEnded"
+            style={[styles.button, styles.fakeButton]}
+            onPress={() => fakeSeam('session ended', injectFakeSessionEnded)}
+          >
+            <Text style={styles.buttonText}>Fake end</Text>
+          </Pressable>
+        </View>
+
         {devices.map(d => (
           <Pressable
             key={d.deviceId}
@@ -276,6 +338,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   deviceButton: { backgroundColor: '#188038', marginTop: 6 },
+  fakeButton: { backgroundColor: '#9334e6' },
   buttonText: { color: '#fff', fontWeight: '600' },
   logTitle: { fontSize: 15, fontWeight: '600', marginTop: 12, color: '#000' },
   logBox: { flex: 1, backgroundColor: '#1112', borderRadius: 8, padding: 8 },

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -18,6 +18,13 @@ react {
     //   skip the bundling of the JS bundle and the assets. Default is "debug", "debugOptimized".
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
     // debuggableVariants = ["liteDebug", "liteDebugOptimized", "prodDebug", "prodDebugOptimized"]
+    //
+    //   Tier-1 Maestro E2E (T3): `-PbundleInDebug=true` bundles the JS into the
+    //   *debug* APK so CI can run the app without a Metro server, while the APK
+    //   stays android:debuggable (the native fake seam is gated on that flag).
+    if (project.hasProperty("bundleInDebug") && project.property("bundleInDebug") == "true") {
+        debuggableVariants = []
+    }
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.
@@ -42,6 +49,12 @@ react {
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
     // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    //
+    //   RN 0.86 ships hermesc in the `hermes-compiler` npm package; in this
+    //   monorepo it is hoisted to the repo-root node_modules, which the
+    //   plugin's default lookup (reactNativeDir/sdks/hermesc) misses. Only
+    //   exercised when a variant bundles JS (release, or -PbundleInDebug=true).
+    hermesCommand = "$rootDir/../../node_modules/hermes-compiler/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "extends": "@react-native/typescript-config",
   "compilerOptions": {
-    "types": ["jest"]
+    "types": ["jest"],
+    // Deep (non-barrel) imports of the workspace library, e.g. the debug-only
+    // fake seam `react-native-google-cast/src/debug/fakeSession`. Metro
+    // resolves these via react-native-builder-bob's monorepo config; this
+    // mirrors that mapping for TypeScript (Yarn does not self-symlink the
+    // root workspace into node_modules).
+    "paths": {
+      "react-native-google-cast/src/*": ["../src/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["**/node_modules", "**/Pods"]

--- a/ios/NitroGoogleCast/CastDebugEventSink.swift
+++ b/ios/NitroGoogleCast/CastDebugEventSink.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Debug-only fake seam (T3): hands `HybridCastDebug.inject*` the *same* stored
+/// `initAndSubscribe` callbacks the real GCK listeners invoke on
+/// `HybridCastTransport`, so tier-1 Maestro E2E can drive the real Nitro
+/// boundary (native → JS callback delivery) on a simulator where Cast
+/// discovery cannot work.
+///
+/// All gating lives here: the storage and both mutators compile to no-ops
+/// outside `DEBUG`, so the transport can call `attach`/`detach`
+/// unconditionally and release builds carry no seam.
+///
+/// Threading: `attach` runs on the JS thread inside `initAndSubscribe`
+/// (mirroring the transport's own callback-var assignment); `emitters` is read
+/// on the main thread by `HybridCastDebug.inject*`, matching real GCK
+/// main-thread event delivery.
+enum CastDebugEventSink {
+  /// Unconditionally declared so `HybridCastDebug.inject`'s signature compiles
+  /// in every configuration; the *storage* below only exists under `DEBUG`.
+  struct Emitters {
+    let emitState: (CastState) -> Void
+    let emitDevices: ([Device]) -> Void
+    let emitLifecycle: (SessionLifecycleEvent) -> Void
+    let emitMediaStatus: (MediaStatus) -> Void
+  }
+
+  #if DEBUG
+    private(set) static var emitters: Emitters?
+  #endif
+
+  /// Called by `HybridCastTransport.initAndSubscribe` right after it stores
+  /// the JS callbacks. The closures must read the transport's *current*
+  /// callback vars (not capture the parameters), so a later `dispose()`
+  /// nulling them also silences the seam.
+  static func attach(
+    emitState: @escaping (CastState) -> Void,
+    emitDevices: @escaping ([Device]) -> Void,
+    emitLifecycle: @escaping (SessionLifecycleEvent) -> Void,
+    emitMediaStatus: @escaping (MediaStatus) -> Void
+  ) {
+    #if DEBUG
+      emitters = Emitters(
+        emitState: emitState,
+        emitDevices: emitDevices,
+        emitLifecycle: emitLifecycle,
+        emitMediaStatus: emitMediaStatus)
+    #endif
+  }
+
+  /// Called by `HybridCastTransport.dispose()`.
+  static func detach() {
+    #if DEBUG
+      emitters = nil
+    #endif
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastDebug.swift
+++ b/ios/NitroGoogleCast/HybridCastDebug.swift
@@ -8,6 +8,11 @@ import NitroModules
 /// round-trip identity and cross-platform (iOS == Android) equality. Converters live in
 /// one-per-type files under `Converters/`; this object only wires them together.
 ///
+/// The `inject*` methods are the native-boundary fake seam (T3): they deliver a
+/// synthetic event through the live transport's stored `initAndSubscribe` callbacks
+/// (via `CastDebugEventSink`), on the main thread, mirroring real GCK delivery.
+/// Compiled to a `false` no-op outside `DEBUG`.
+///
 /// `PlayServicesState` has no iOS GCK counterpart (Android-only), so its round-trip is an
 /// identity pass-through; every other type runs through its real struct↔GCK converters.
 final class HybridCastDebug: HybridCastDebugSpec {
@@ -107,6 +112,45 @@ final class HybridCastDebug: HybridCastDebugSpec {
     value: PlayServicesState
   ) throws -> PlayServicesState {
     value
+  }
+
+  // MARK: - Native-boundary fake seam (T3) — debug builds only
+
+  func injectCastState(castState: CastState) throws -> Promise<Bool> {
+    inject { $0.emitState(castState) }
+  }
+
+  func injectDevices(devices: [Device]) throws -> Promise<Bool> {
+    inject { $0.emitDevices(devices) }
+  }
+
+  func injectLifecycleEvent(event: SessionLifecycleEvent) throws -> Promise<Bool> {
+    inject { $0.emitLifecycle(event) }
+  }
+
+  func injectMediaStatus(status: MediaStatus) throws -> Promise<Bool> {
+    inject { $0.emitMediaStatus(status) }
+  }
+
+  /// Resolves `true` after delivering on the main thread; `false` when the seam is
+  /// inactive (release build, or `CastTransport.initAndSubscribe` has not run).
+  private func inject(
+    _ deliver: @escaping (CastDebugEventSink.Emitters) -> Void
+  ) -> Promise<Bool> {
+    let promise = Promise<Bool>()
+    #if DEBUG
+      DispatchQueue.main.async {
+        guard let emitters = CastDebugEventSink.emitters else {
+          promise.resolve(withResult: false)
+          return
+        }
+        deliver(emitters)
+        promise.resolve(withResult: true)
+      }
+    #else
+      promise.resolve(withResult: false)
+    #endif
+    return promise
   }
 
   /// Signals a receive-only GCK type whose iOS class cannot be constructed (so the synthetic

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -92,6 +92,15 @@ final class HybridCastTransport: HybridCastTransportSpec {
     self.onChannelMessage = onChannelMessage
     self.onChannelStatus = onChannelStatus
 
+    // Debug-only fake seam (T3): expose the freshly stored callbacks to
+    // `HybridCastDebug.inject*`. Gating (`#if DEBUG`) lives in the sink; the
+    // closures read the current vars, so `dispose()` also silences the seam.
+    CastDebugEventSink.attach(
+      emitState: { [weak self] in self?.onState?($0) },
+      emitDevices: { [weak self] in self?.onDevices?($0) },
+      emitLifecycle: { [weak self] in self?.onLifecycle?($0) },
+      emitMediaStatus: { [weak self] in self?.onMediaStatus?($0) })
+
     let promise = Promise<InitialSnapshot>()
     DispatchQueue.main.async { [weak self] in
       guard let self else {
@@ -183,6 +192,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
 
   /// Override of `HybridObject.dispose()` — detach every GCK observer.
   func dispose() {
+    CastDebugEventSink.detach()
     DispatchQueue.main.async { [weak self] in
       guard let self else { return }
       self.detachObservers()

--- a/nitrogen/generated/android/c++/JHybridCastDebugSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridCastDebugSpec.cpp
@@ -79,6 +79,18 @@ namespace margelo::nitro::googlecast { enum class ActiveInputState; }
 namespace margelo::nitro::googlecast { enum class StandbyState; }
 // Forward declaration of `PlayServicesState` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class PlayServicesState; }
+// Forward declaration of `CastState` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastState; }
+// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
+// Forward declaration of `SessionEventType` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class SessionEventType; }
+// Forward declaration of `SessionInfo` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionInfo; }
+// Forward declaration of `CastError` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct CastError; }
+// Forward declaration of `CastErrorCode` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastErrorCode; }
 
 #include "WebImage.hpp"
 #include "JWebImage.hpp"
@@ -157,6 +169,20 @@ namespace margelo::nitro::googlecast { enum class PlayServicesState; }
 #include "JStandbyState.hpp"
 #include "PlayServicesState.hpp"
 #include "JPlayServicesState.hpp"
+#include <NitroModules/Promise.hpp>
+#include <NitroModules/JPromise.hpp>
+#include "CastState.hpp"
+#include "JCastState.hpp"
+#include "SessionLifecycleEvent.hpp"
+#include "JSessionLifecycleEvent.hpp"
+#include "SessionEventType.hpp"
+#include "JSessionEventType.hpp"
+#include "SessionInfo.hpp"
+#include "JSessionInfo.hpp"
+#include "CastError.hpp"
+#include "JCastError.hpp"
+#include "CastErrorCode.hpp"
+#include "JCastErrorCode.hpp"
 
 namespace margelo::nitro::googlecast {
 
@@ -280,6 +306,79 @@ namespace margelo::nitro::googlecast {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPlayServicesState>(jni::alias_ref<JPlayServicesState> /* value */)>("roundTripPlayServicesState");
     auto __result = method(_javaPart, JPlayServicesState::fromCpp(value));
     return __result->toCpp();
+  }
+  std::shared_ptr<Promise<bool>> JHybridCastDebugSpec::injectCastState(CastState castState) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JCastState> /* castState */)>("injectCastState");
+    auto __result = method(_javaPart, JCastState::fromCpp(castState));
+    return [&]() {
+      auto __promise = Promise<bool>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JBoolean>(__boxedResult);
+        __promise->resolve(static_cast<bool>(__result->value()));
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<bool>> JHybridCastDebugSpec::injectDevices(const std::vector<Device>& devices) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JArrayClass<JDevice>> /* devices */)>("injectDevices");
+    auto __result = method(_javaPart, [&](auto&& __input) {
+      size_t __size = __input.size();
+      jni::local_ref<jni::JArrayClass<JDevice>> __array = jni::JArrayClass<JDevice>::newArray(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        const auto& __element = __input[__i];
+        auto __elementJni = JDevice::fromCpp(__element);
+        __array->setElement(__i, *__elementJni);
+      }
+      return __array;
+    }(devices));
+    return [&]() {
+      auto __promise = Promise<bool>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JBoolean>(__boxedResult);
+        __promise->resolve(static_cast<bool>(__result->value()));
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<bool>> JHybridCastDebugSpec::injectLifecycleEvent(const SessionLifecycleEvent& event) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JSessionLifecycleEvent> /* event */)>("injectLifecycleEvent");
+    auto __result = method(_javaPart, JSessionLifecycleEvent::fromCpp(event));
+    return [&]() {
+      auto __promise = Promise<bool>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JBoolean>(__boxedResult);
+        __promise->resolve(static_cast<bool>(__result->value()));
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<bool>> JHybridCastDebugSpec::injectMediaStatus(const MediaStatus& status) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JMediaStatus> /* status */)>("injectMediaStatus");
+    auto __result = method(_javaPart, JMediaStatus::fromCpp(status));
+    return [&]() {
+      auto __promise = Promise<bool>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
+        auto __result = jni::static_ref_cast<jni::JBoolean>(__boxedResult);
+        __promise->resolve(static_cast<bool>(__result->value()));
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
 
 } // namespace margelo::nitro::googlecast

--- a/nitrogen/generated/android/c++/JHybridCastDebugSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridCastDebugSpec.hpp
@@ -72,6 +72,10 @@ namespace margelo::nitro::googlecast {
     ActiveInputState roundTripActiveInputState(ActiveInputState value) override;
     StandbyState roundTripStandbyState(StandbyState value) override;
     PlayServicesState roundTripPlayServicesState(PlayServicesState value) override;
+    std::shared_ptr<Promise<bool>> injectCastState(CastState castState) override;
+    std::shared_ptr<Promise<bool>> injectDevices(const std::vector<Device>& devices) override;
+    std::shared_ptr<Promise<bool>> injectLifecycleEvent(const SessionLifecycleEvent& event) override;
+    std::shared_ptr<Promise<bool>> injectMediaStatus(const MediaStatus& status) override;
 
   private:
     jni::global_ref<JHybridCastDebugSpec::JavaPart> _javaPart;

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/HybridCastDebugSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/HybridCastDebugSpec.kt
@@ -10,6 +10,7 @@ package com.margelo.nitro.googlecast
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.HybridObject
 
 /**
@@ -99,6 +100,22 @@ abstract class HybridCastDebugSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun roundTripPlayServicesState(value: PlayServicesState): PlayServicesState
+  
+  @DoNotStrip
+  @Keep
+  abstract fun injectCastState(castState: CastState): Promise<Boolean>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun injectDevices(devices: Array<Device>): Promise<Boolean>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun injectLifecycleEvent(event: SessionLifecycleEvent): Promise<Boolean>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun injectMediaStatus(status: MediaStatus): Promise<Boolean>
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.cpp
+++ b/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.cpp
@@ -32,6 +32,22 @@ namespace margelo::nitro::googlecast::bridge::swift {
     return swiftPart.toUnsafe();
   }
   
+  // pragma MARK: std::function<void(bool /* result */)>
+  Func_void_bool create_Func_void_bool(void* NON_NULL swiftClosureWrapper) noexcept {
+    auto swiftClosure = NitroGoogleCast::Func_void_bool::fromUnsafe(swiftClosureWrapper);
+    return [swiftClosure = std::move(swiftClosure)](bool result) mutable -> void {
+      swiftClosure.call(result);
+    };
+  }
+  
+  // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* NON_NULL swiftClosureWrapper) noexcept {
+    auto swiftClosure = NitroGoogleCast::Func_void_std__exception_ptr::fromUnsafe(swiftClosureWrapper);
+    return [swiftClosure = std::move(swiftClosure)](const std::exception_ptr& error) mutable -> void {
+      swiftClosure.call(error);
+    };
+  }
+  
   // pragma MARK: std::shared_ptr<HybridCastDebugSpec>
   std::shared_ptr<HybridCastDebugSpec> create_std__shared_ptr_HybridCastDebugSpec_(void* NON_NULL swiftUnsafePointer) noexcept {
     NitroGoogleCast::HybridCastDebugSpec_cxx swiftPart = NitroGoogleCast::HybridCastDebugSpec_cxx::fromUnsafe(swiftUnsafePointer);
@@ -53,14 +69,6 @@ namespace margelo::nitro::googlecast::bridge::swift {
     auto swiftClosure = NitroGoogleCast::Func_void_InitialSnapshot::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const InitialSnapshot& result) mutable -> void {
       swiftClosure.call(result);
-    };
-  }
-  
-  // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* NON_NULL swiftClosureWrapper) noexcept {
-    auto swiftClosure = NitroGoogleCast::Func_void_std__exception_ptr::fromUnsafe(swiftClosureWrapper);
-    return [swiftClosure = std::move(swiftClosure)](const std::exception_ptr& error) mutable -> void {
-      swiftClosure.call(error);
     };
   }
   
@@ -117,14 +125,6 @@ namespace margelo::nitro::googlecast::bridge::swift {
     auto swiftClosure = NitroGoogleCast::Func_void::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> void {
       swiftClosure.call();
-    };
-  }
-  
-  // pragma MARK: std::function<void(bool /* result */)>
-  Func_void_bool create_Func_void_bool(void* NON_NULL swiftClosureWrapper) noexcept {
-    auto swiftClosure = NitroGoogleCast::Func_void_bool::fromUnsafe(swiftClosureWrapper);
-    return [swiftClosure = std::move(swiftClosure)](bool result) mutable -> void {
-      swiftClosure.call(result);
     };
   }
   

--- a/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.hpp
@@ -727,6 +727,148 @@ namespace margelo::nitro::googlecast::bridge::swift {
     return optional.value();
   }
   
+  // pragma MARK: std::shared_ptr<Promise<bool>>
+  /**
+   * Specialized version of `std::shared_ptr<Promise<bool>>`.
+   */
+  using std__shared_ptr_Promise_bool__ = std::shared_ptr<Promise<bool>>;
+  inline std::shared_ptr<Promise<bool>> create_std__shared_ptr_Promise_bool__() noexcept {
+    return Promise<bool>::create();
+  }
+  inline PromiseHolder<bool> wrap_std__shared_ptr_Promise_bool__(std::shared_ptr<Promise<bool>> promise) noexcept {
+    return PromiseHolder<bool>(std::move(promise));
+  }
+  
+  // pragma MARK: std::function<void(bool /* result */)>
+  /**
+   * Specialized version of `std::function<void(bool)>`.
+   */
+  using Func_void_bool = std::function<void(bool /* result */)>;
+  /**
+   * Wrapper class for a `std::function<void(bool / * result * /)>`, this can be used from Swift.
+   */
+  class Func_void_bool_Wrapper final {
+  public:
+    explicit Func_void_bool_Wrapper(std::function<void(bool /* result */)>&& func): _function(std::make_unique<std::function<void(bool /* result */)>>(std::move(func))) {}
+    inline void call(bool result) const noexcept {
+      _function->operator()(result);
+    }
+  private:
+    std::unique_ptr<std::function<void(bool /* result */)>> _function;
+  } SWIFT_NONCOPYABLE;
+  Func_void_bool create_Func_void_bool(void* NON_NULL swiftClosureWrapper) noexcept;
+  inline Func_void_bool_Wrapper wrap_Func_void_bool(Func_void_bool value) noexcept {
+    return Func_void_bool_Wrapper(std::move(value));
+  }
+  
+  // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
+  /**
+   * Specialized version of `std::function<void(const std::exception_ptr&)>`.
+   */
+  using Func_void_std__exception_ptr = std::function<void(const std::exception_ptr& /* error */)>;
+  /**
+   * Wrapper class for a `std::function<void(const std::exception_ptr& / * error * /)>`, this can be used from Swift.
+   */
+  class Func_void_std__exception_ptr_Wrapper final {
+  public:
+    explicit Func_void_std__exception_ptr_Wrapper(std::function<void(const std::exception_ptr& /* error */)>&& func): _function(std::make_unique<std::function<void(const std::exception_ptr& /* error */)>>(std::move(func))) {}
+    inline void call(std::exception_ptr error) const noexcept {
+      _function->operator()(error);
+    }
+  private:
+    std::unique_ptr<std::function<void(const std::exception_ptr& /* error */)>> _function;
+  } SWIFT_NONCOPYABLE;
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* NON_NULL swiftClosureWrapper) noexcept;
+  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) noexcept {
+    return Func_void_std__exception_ptr_Wrapper(std::move(value));
+  }
+  
+  // pragma MARK: std::vector<Device>
+  /**
+   * Specialized version of `std::vector<Device>`.
+   */
+  using std__vector_Device_ = std::vector<Device>;
+  inline std::vector<Device> create_std__vector_Device_(size_t size) noexcept {
+    std::vector<Device> vector;
+    vector.reserve(size);
+    return vector;
+  }
+  
+  // pragma MARK: std::optional<ApplicationMetadata>
+  /**
+   * Specialized version of `std::optional<ApplicationMetadata>`.
+   */
+  using std__optional_ApplicationMetadata_ = std::optional<ApplicationMetadata>;
+  inline std::optional<ApplicationMetadata> create_std__optional_ApplicationMetadata_(const ApplicationMetadata& value) noexcept {
+    return std::optional<ApplicationMetadata>(value);
+  }
+  inline bool has_value_std__optional_ApplicationMetadata_(const std::optional<ApplicationMetadata>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline ApplicationMetadata get_std__optional_ApplicationMetadata_(const std::optional<ApplicationMetadata>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::optional<StandbyState>
+  /**
+   * Specialized version of `std::optional<StandbyState>`.
+   */
+  using std__optional_StandbyState_ = std::optional<StandbyState>;
+  inline std::optional<StandbyState> create_std__optional_StandbyState_(const StandbyState& value) noexcept {
+    return std::optional<StandbyState>(value);
+  }
+  inline bool has_value_std__optional_StandbyState_(const std::optional<StandbyState>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline StandbyState get_std__optional_StandbyState_(const std::optional<StandbyState>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::optional<ActiveInputState>
+  /**
+   * Specialized version of `std::optional<ActiveInputState>`.
+   */
+  using std__optional_ActiveInputState_ = std::optional<ActiveInputState>;
+  inline std::optional<ActiveInputState> create_std__optional_ActiveInputState_(const ActiveInputState& value) noexcept {
+    return std::optional<ActiveInputState>(value);
+  }
+  inline bool has_value_std__optional_ActiveInputState_(const std::optional<ActiveInputState>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline ActiveInputState get_std__optional_ActiveInputState_(const std::optional<ActiveInputState>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::optional<SessionInfo>
+  /**
+   * Specialized version of `std::optional<SessionInfo>`.
+   */
+  using std__optional_SessionInfo_ = std::optional<SessionInfo>;
+  inline std::optional<SessionInfo> create_std__optional_SessionInfo_(const SessionInfo& value) noexcept {
+    return std::optional<SessionInfo>(value);
+  }
+  inline bool has_value_std__optional_SessionInfo_(const std::optional<SessionInfo>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline SessionInfo get_std__optional_SessionInfo_(const std::optional<SessionInfo>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::optional<CastError>
+  /**
+   * Specialized version of `std::optional<CastError>`.
+   */
+  using std__optional_CastError_ = std::optional<CastError>;
+  inline std::optional<CastError> create_std__optional_CastError_(const CastError& value) noexcept {
+    return std::optional<CastError>(value);
+  }
+  inline bool has_value_std__optional_CastError_(const std::optional<CastError>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline CastError get_std__optional_CastError_(const std::optional<CastError>& optional) noexcept {
+    return optional.value();
+  }
+  
   // pragma MARK: std::shared_ptr<HybridCastDebugSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridCastDebugSpec>`.
@@ -901,75 +1043,13 @@ namespace margelo::nitro::googlecast::bridge::swift {
     return Result<PlayServicesState>::withError(error);
   }
   
-  // pragma MARK: std::vector<Device>
-  /**
-   * Specialized version of `std::vector<Device>`.
-   */
-  using std__vector_Device_ = std::vector<Device>;
-  inline std::vector<Device> create_std__vector_Device_(size_t size) noexcept {
-    std::vector<Device> vector;
-    vector.reserve(size);
-    return vector;
+  // pragma MARK: Result<std::shared_ptr<Promise<bool>>>
+  using Result_std__shared_ptr_Promise_bool___ = Result<std::shared_ptr<Promise<bool>>>;
+  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::shared_ptr<Promise<bool>>& value) noexcept {
+    return Result<std::shared_ptr<Promise<bool>>>::withValue(value);
   }
-  
-  // pragma MARK: std::optional<ApplicationMetadata>
-  /**
-   * Specialized version of `std::optional<ApplicationMetadata>`.
-   */
-  using std__optional_ApplicationMetadata_ = std::optional<ApplicationMetadata>;
-  inline std::optional<ApplicationMetadata> create_std__optional_ApplicationMetadata_(const ApplicationMetadata& value) noexcept {
-    return std::optional<ApplicationMetadata>(value);
-  }
-  inline bool has_value_std__optional_ApplicationMetadata_(const std::optional<ApplicationMetadata>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline ApplicationMetadata get_std__optional_ApplicationMetadata_(const std::optional<ApplicationMetadata>& optional) noexcept {
-    return optional.value();
-  }
-  
-  // pragma MARK: std::optional<StandbyState>
-  /**
-   * Specialized version of `std::optional<StandbyState>`.
-   */
-  using std__optional_StandbyState_ = std::optional<StandbyState>;
-  inline std::optional<StandbyState> create_std__optional_StandbyState_(const StandbyState& value) noexcept {
-    return std::optional<StandbyState>(value);
-  }
-  inline bool has_value_std__optional_StandbyState_(const std::optional<StandbyState>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline StandbyState get_std__optional_StandbyState_(const std::optional<StandbyState>& optional) noexcept {
-    return optional.value();
-  }
-  
-  // pragma MARK: std::optional<ActiveInputState>
-  /**
-   * Specialized version of `std::optional<ActiveInputState>`.
-   */
-  using std__optional_ActiveInputState_ = std::optional<ActiveInputState>;
-  inline std::optional<ActiveInputState> create_std__optional_ActiveInputState_(const ActiveInputState& value) noexcept {
-    return std::optional<ActiveInputState>(value);
-  }
-  inline bool has_value_std__optional_ActiveInputState_(const std::optional<ActiveInputState>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline ActiveInputState get_std__optional_ActiveInputState_(const std::optional<ActiveInputState>& optional) noexcept {
-    return optional.value();
-  }
-  
-  // pragma MARK: std::optional<SessionInfo>
-  /**
-   * Specialized version of `std::optional<SessionInfo>`.
-   */
-  using std__optional_SessionInfo_ = std::optional<SessionInfo>;
-  inline std::optional<SessionInfo> create_std__optional_SessionInfo_(const SessionInfo& value) noexcept {
-    return std::optional<SessionInfo>(value);
-  }
-  inline bool has_value_std__optional_SessionInfo_(const std::optional<SessionInfo>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline SessionInfo get_std__optional_SessionInfo_(const std::optional<SessionInfo>& optional) noexcept {
-    return optional.value();
+  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::exception_ptr& error) noexcept {
+    return Result<std::shared_ptr<Promise<bool>>>::withError(error);
   }
   
   // pragma MARK: std::shared_ptr<Promise<InitialSnapshot>>
@@ -1004,28 +1084,6 @@ namespace margelo::nitro::googlecast::bridge::swift {
   Func_void_InitialSnapshot create_Func_void_InitialSnapshot(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_InitialSnapshot_Wrapper wrap_Func_void_InitialSnapshot(Func_void_InitialSnapshot value) noexcept {
     return Func_void_InitialSnapshot_Wrapper(std::move(value));
-  }
-  
-  // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
-  /**
-   * Specialized version of `std::function<void(const std::exception_ptr&)>`.
-   */
-  using Func_void_std__exception_ptr = std::function<void(const std::exception_ptr& /* error */)>;
-  /**
-   * Wrapper class for a `std::function<void(const std::exception_ptr& / * error * /)>`, this can be used from Swift.
-   */
-  class Func_void_std__exception_ptr_Wrapper final {
-  public:
-    explicit Func_void_std__exception_ptr_Wrapper(std::function<void(const std::exception_ptr& /* error */)>&& func): _function(std::make_unique<std::function<void(const std::exception_ptr& /* error */)>>(std::move(func))) {}
-    inline void call(std::exception_ptr error) const noexcept {
-      _function->operator()(error);
-    }
-  private:
-    std::unique_ptr<std::function<void(const std::exception_ptr& /* error */)>> _function;
-  } SWIFT_NONCOPYABLE;
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* NON_NULL swiftClosureWrapper) noexcept;
-  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) noexcept {
-    return Func_void_std__exception_ptr_Wrapper(std::move(value));
   }
   
   // pragma MARK: std::function<void(CastState /* castState */)>
@@ -1070,21 +1128,6 @@ namespace margelo::nitro::googlecast::bridge::swift {
   Func_void_std__vector_Device_ create_Func_void_std__vector_Device_(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_std__vector_Device__Wrapper wrap_Func_void_std__vector_Device_(Func_void_std__vector_Device_ value) noexcept {
     return Func_void_std__vector_Device__Wrapper(std::move(value));
-  }
-  
-  // pragma MARK: std::optional<CastError>
-  /**
-   * Specialized version of `std::optional<CastError>`.
-   */
-  using std__optional_CastError_ = std::optional<CastError>;
-  inline std::optional<CastError> create_std__optional_CastError_(const CastError& value) noexcept {
-    return std::optional<CastError>(value);
-  }
-  inline bool has_value_std__optional_CastError_(const std::optional<CastError>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline CastError get_std__optional_CastError_(const std::optional<CastError>& optional) noexcept {
-    return optional.value();
   }
   
   // pragma MARK: std::function<void(const SessionLifecycleEvent& /* event */)>
@@ -1209,40 +1252,6 @@ namespace margelo::nitro::googlecast::bridge::swift {
     return Func_void_Wrapper(std::move(value));
   }
   
-  // pragma MARK: std::shared_ptr<Promise<bool>>
-  /**
-   * Specialized version of `std::shared_ptr<Promise<bool>>`.
-   */
-  using std__shared_ptr_Promise_bool__ = std::shared_ptr<Promise<bool>>;
-  inline std::shared_ptr<Promise<bool>> create_std__shared_ptr_Promise_bool__() noexcept {
-    return Promise<bool>::create();
-  }
-  inline PromiseHolder<bool> wrap_std__shared_ptr_Promise_bool__(std::shared_ptr<Promise<bool>> promise) noexcept {
-    return PromiseHolder<bool>(std::move(promise));
-  }
-  
-  // pragma MARK: std::function<void(bool /* result */)>
-  /**
-   * Specialized version of `std::function<void(bool)>`.
-   */
-  using Func_void_bool = std::function<void(bool /* result */)>;
-  /**
-   * Wrapper class for a `std::function<void(bool / * result * /)>`, this can be used from Swift.
-   */
-  class Func_void_bool_Wrapper final {
-  public:
-    explicit Func_void_bool_Wrapper(std::function<void(bool /* result */)>&& func): _function(std::make_unique<std::function<void(bool /* result */)>>(std::move(func))) {}
-    inline void call(bool result) const noexcept {
-      _function->operator()(result);
-    }
-  private:
-    std::unique_ptr<std::function<void(bool /* result */)>> _function;
-  } SWIFT_NONCOPYABLE;
-  Func_void_bool create_Func_void_bool(void* NON_NULL swiftClosureWrapper) noexcept;
-  inline Func_void_bool_Wrapper wrap_Func_void_bool(Func_void_bool value) noexcept {
-    return Func_void_bool_Wrapper(std::move(value));
-  }
-  
   // pragma MARK: std::shared_ptr<HybridCastTransportSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridCastTransportSpec>`.
@@ -1271,15 +1280,6 @@ namespace margelo::nitro::googlecast::bridge::swift {
   }
   inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
-  }
-  
-  // pragma MARK: Result<std::shared_ptr<Promise<bool>>>
-  using Result_std__shared_ptr_Promise_bool___ = Result<std::shared_ptr<Promise<bool>>>;
-  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::shared_ptr<Promise<bool>>& value) noexcept {
-    return Result<std::shared_ptr<Promise<bool>>>::withValue(value);
-  }
-  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::exception_ptr& error) noexcept {
-    return Result<std::shared_ptr<Promise<bool>>>::withError(error);
   }
   
   // pragma MARK: Result<void>

--- a/nitrogen/generated/ios/c++/HybridCastDebugSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridCastDebugSpecSwift.hpp
@@ -84,6 +84,18 @@ namespace margelo::nitro::googlecast { enum class ActiveInputState; }
 namespace margelo::nitro::googlecast { enum class StandbyState; }
 // Forward declaration of `PlayServicesState` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class PlayServicesState; }
+// Forward declaration of `CastState` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastState; }
+// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
+// Forward declaration of `SessionEventType` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class SessionEventType; }
+// Forward declaration of `SessionInfo` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionInfo; }
+// Forward declaration of `CastError` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct CastError; }
+// Forward declaration of `CastErrorCode` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastErrorCode; }
 
 #include "WebImage.hpp"
 #include <string>
@@ -125,6 +137,13 @@ namespace margelo::nitro::googlecast { enum class PlayServicesState; }
 #include "ActiveInputState.hpp"
 #include "StandbyState.hpp"
 #include "PlayServicesState.hpp"
+#include <NitroModules/Promise.hpp>
+#include "CastState.hpp"
+#include "SessionLifecycleEvent.hpp"
+#include "SessionEventType.hpp"
+#include "SessionInfo.hpp"
+#include "CastError.hpp"
+#include "CastErrorCode.hpp"
 
 #include "NitroGoogleCast-Swift-Cxx-Umbrella.hpp"
 
@@ -314,6 +333,38 @@ namespace margelo::nitro::googlecast {
     }
     inline PlayServicesState roundTripPlayServicesState(PlayServicesState value) override {
       auto __result = _swiftPart.roundTripPlayServicesState(static_cast<int>(value));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<bool>> injectCastState(CastState castState) override {
+      auto __result = _swiftPart.injectCastState(static_cast<int>(castState));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<bool>> injectDevices(const std::vector<Device>& devices) override {
+      auto __result = _swiftPart.injectDevices(devices);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<bool>> injectLifecycleEvent(const SessionLifecycleEvent& event) override {
+      auto __result = _swiftPart.injectLifecycleEvent(std::forward<decltype(event)>(event));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<bool>> injectMediaStatus(const MediaStatus& status) override {
+      auto __result = _swiftPart.injectMediaStatus(std::forward<decltype(status)>(status));
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/nitrogen/generated/ios/swift/HybridCastDebugSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridCastDebugSpec.swift
@@ -31,6 +31,10 @@ public protocol HybridCastDebugSpec_protocol: HybridObject {
   func roundTripActiveInputState(value: ActiveInputState) throws -> ActiveInputState
   func roundTripStandbyState(value: StandbyState) throws -> StandbyState
   func roundTripPlayServicesState(value: PlayServicesState) throws -> PlayServicesState
+  func injectCastState(castState: CastState) throws -> Promise<Bool>
+  func injectDevices(devices: [Device]) throws -> Promise<Bool>
+  func injectLifecycleEvent(event: SessionLifecycleEvent) throws -> Promise<Bool>
+  func injectMediaStatus(status: MediaStatus) throws -> Promise<Bool>
 }
 
 public extension HybridCastDebugSpec_protocol {

--- a/nitrogen/generated/ios/swift/HybridCastDebugSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridCastDebugSpec_cxx.swift
@@ -339,4 +339,80 @@ open class HybridCastDebugSpec_cxx {
       return bridge.create_Result_PlayServicesState_(__exceptionPtr)
     }
   }
+  
+  @inline(__always)
+  public final func injectCastState(castState: Int32) -> bridge.Result_std__shared_ptr_Promise_bool___ {
+    do {
+      let __result = try self.__implementation.injectCastState(castState: margelo.nitro.googlecast.CastState(rawValue: castState)!)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_bool__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_bool__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_bool__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve(__result) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func injectDevices(devices: bridge.std__vector_Device_) -> bridge.Result_std__shared_ptr_Promise_bool___ {
+    do {
+      let __result = try self.__implementation.injectDevices(devices: devices.map({ __item in __item }))
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_bool__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_bool__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_bool__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve(__result) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func injectLifecycleEvent(event: SessionLifecycleEvent) -> bridge.Result_std__shared_ptr_Promise_bool___ {
+    do {
+      let __result = try self.__implementation.injectLifecycleEvent(event: event)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_bool__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_bool__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_bool__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve(__result) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func injectMediaStatus(status: MediaStatus) -> bridge.Result_std__shared_ptr_Promise_bool___ {
+    do {
+      let __result = try self.__implementation.injectMediaStatus(status: status)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_bool__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_bool__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_bool__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve(__result) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_bool___(__exceptionPtr)
+    }
+  }
 }

--- a/nitrogen/generated/shared/c++/HybridCastDebugSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridCastDebugSpec.cpp
@@ -32,6 +32,10 @@ namespace margelo::nitro::googlecast {
       prototype.registerHybridMethod("roundTripActiveInputState", &HybridCastDebugSpec::roundTripActiveInputState);
       prototype.registerHybridMethod("roundTripStandbyState", &HybridCastDebugSpec::roundTripStandbyState);
       prototype.registerHybridMethod("roundTripPlayServicesState", &HybridCastDebugSpec::roundTripPlayServicesState);
+      prototype.registerHybridMethod("injectCastState", &HybridCastDebugSpec::injectCastState);
+      prototype.registerHybridMethod("injectDevices", &HybridCastDebugSpec::injectDevices);
+      prototype.registerHybridMethod("injectLifecycleEvent", &HybridCastDebugSpec::injectLifecycleEvent);
+      prototype.registerHybridMethod("injectMediaStatus", &HybridCastDebugSpec::injectMediaStatus);
     });
   }
 

--- a/nitrogen/generated/shared/c++/HybridCastDebugSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridCastDebugSpec.hpp
@@ -49,6 +49,10 @@ namespace margelo::nitro::googlecast { enum class ActiveInputState; }
 namespace margelo::nitro::googlecast { enum class StandbyState; }
 // Forward declaration of `PlayServicesState` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class PlayServicesState; }
+// Forward declaration of `CastState` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastState; }
+// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
 
 #include "WebImage.hpp"
 #include "Device.hpp"
@@ -68,6 +72,10 @@ namespace margelo::nitro::googlecast { enum class PlayServicesState; }
 #include "ActiveInputState.hpp"
 #include "StandbyState.hpp"
 #include "PlayServicesState.hpp"
+#include <NitroModules/Promise.hpp>
+#include "CastState.hpp"
+#include <vector>
+#include "SessionLifecycleEvent.hpp"
 
 namespace margelo::nitro::googlecast {
 
@@ -118,6 +126,10 @@ namespace margelo::nitro::googlecast {
       virtual ActiveInputState roundTripActiveInputState(ActiveInputState value) = 0;
       virtual StandbyState roundTripStandbyState(StandbyState value) = 0;
       virtual PlayServicesState roundTripPlayServicesState(PlayServicesState value) = 0;
+      virtual std::shared_ptr<Promise<bool>> injectCastState(CastState castState) = 0;
+      virtual std::shared_ptr<Promise<bool>> injectDevices(const std::vector<Device>& devices) = 0;
+      virtual std::shared_ptr<Promise<bool>> injectLifecycleEvent(const SessionLifecycleEvent& event) = 0;
+      virtual std::shared_ptr<Promise<bool>> injectMediaStatus(const MediaStatus& status) = 0;
 
     protected:
       // Hybrid Setup

--- a/scripts/e2e-android.sh
+++ b/scripts/e2e-android.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tier-1 Maestro E2E (T3) — Android, local runner.
+#
+# Builds the example DEBUG APK with the JS bundle baked in (-PbundleInDebug=true,
+# so no Metro server is needed), installs it on the connected emulator/device,
+# and runs the tier-1 Maestro flow against the debug-only native fake seam.
+#
+# Prereqs: a booted emulator or connected device (`adb devices`), the Maestro
+# CLI (https://maestro.mobile.dev — `curl -fsSL https://get.maestro.mobile.dev | bash`),
+# and JAVA_HOME pointing at a JDK 17 (on macOS with Android Studio:
+# export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home").
+#
+# Optional: REACT_NATIVE_ARCHITECTURES=x86_64 to build a single ABI (faster).
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+gradle_args=(":app:assembleDebug" "-PbundleInDebug=true")
+if [ -n "${REACT_NATIVE_ARCHITECTURES:-}" ]; then
+  gradle_args+=("-PreactNativeArchitectures=${REACT_NATIVE_ARCHITECTURES}")
+fi
+
+(cd "$root/example/android" && ./gradlew "${gradle_args[@]}")
+
+adb install -r "$root/example/android/app/build/outputs/apk/debug/app-debug.apk"
+
+maestro test "$root/.maestro/tier1-fake-session.yml"

--- a/src/debug/fakeSession.ts
+++ b/src/debug/fakeSession.ts
@@ -1,0 +1,74 @@
+import { NitroModules } from 'react-native-nitro-modules'
+import type { CastDebug } from '../specs/CastDebug.nitro'
+import type { SessionInfo } from '../transport/types'
+import type { Device } from '../types/Device'
+
+/**
+ * Native-boundary fake seam (T3) — tier-1 E2E helpers.
+ *
+ * NOT part of the public API and NOT exported from the package barrel: this is
+ * a debug-only test seam for driving the real Nitro boundary on an
+ * emulator/simulator, where Cast discovery cannot work (official Google Cast
+ * limitation). Each helper builds a fixed fixture and delivers it through the
+ * `CastDebug.inject*` methods, which invoke the *same* stored
+ * `initAndSubscribe` callbacks the real GCK listeners use on `CastTransport` —
+ * so the event crosses the genuine native↔JS boundary in both directions
+ * (JS → native struct conversion in, native → JS callback out) before it
+ * reaches the store, the façades, and the app UI.
+ *
+ * Every helper resolves `true` only when native actually delivered the event
+ * (debug build + live transport); `false` means the seam is inactive.
+ */
+
+let cachedDebug: CastDebug | null = null
+
+function getCastDebug(): CastDebug {
+  if (cachedDebug == null) {
+    cachedDebug = NitroModules.createHybridObject<CastDebug>('CastDebug')
+  }
+  return cachedDebug
+}
+
+/** The synthetic receiver device used by the fake-session fixtures. */
+export const FAKE_DEVICE: Device = {
+  capabilities: ['VideoOut', 'AudioOut'],
+  deviceId: 'fake-device-1',
+  deviceVersion: '1',
+  friendlyName: 'Fake Living Room TV',
+  icons: [],
+  ipAddress: '192.0.2.1',
+  isOnLocalNetwork: true,
+  modelName: 'Fake Chromecast',
+}
+
+/** The synthetic live session used by the fake-session fixtures. */
+export const FAKE_SESSION: SessionInfo = {
+  sessionId: 'fake-session-1',
+  device: FAKE_DEVICE,
+  deviceVolume: 0.5,
+  deviceMuted: false,
+}
+
+/**
+ * Simulate the receiver appearing on the network, then a session connecting to
+ * it: `devices → [FAKE_DEVICE]`, `castState → connected`, `lifecycle started`
+ * with {@link FAKE_SESSION}.
+ */
+export async function injectFakeSessionStarted(): Promise<boolean> {
+  const debug = getCastDebug()
+  const devices = await debug.injectDevices([FAKE_DEVICE])
+  const state = await debug.injectCastState('connected')
+  const started = await debug.injectLifecycleEvent({
+    type: 'started',
+    session: FAKE_SESSION,
+  })
+  return devices && state && started
+}
+
+/** Simulate a clean disconnect: `lifecycle ended`, `castState → notConnected`. */
+export async function injectFakeSessionEnded(): Promise<boolean> {
+  const debug = getCastDebug()
+  const ended = await debug.injectLifecycleEvent({ type: 'ended' })
+  const state = await debug.injectCastState('notConnected')
+  return ended && state
+}

--- a/src/specs/CastDebug.nitro.ts
+++ b/src/specs/CastDebug.nitro.ts
@@ -1,6 +1,8 @@
 import type { HybridObject } from 'react-native-nitro-modules'
+import type { SessionLifecycleEvent } from '../transport/types'
 import type { ActiveInputState } from '../types/ActiveInputState'
 import type { ApplicationMetadata } from '../types/ApplicationMetadata'
+import type { CastState } from '../types/CastState'
 import type { Device } from '../types/Device'
 import type { MediaInfo } from '../types/MediaInfo'
 import type { MediaLiveSeekableRange } from '../types/MediaLiveSeekableRange'
@@ -32,8 +34,15 @@ import type { WebImage } from '../types/WebImage'
  *    `struct → GCK → struct` natively, so the shared golden-fixture suite can assert
  *    round-trip identity and cross-platform (iOS == Android) equality on a real device or
  *    simulator without a physical Chromecast.
+ * 3. **Native-boundary fake seam (T3).** The `inject*` methods feed a synthetic event
+ *    through the *same* stored `initAndSubscribe` callbacks the real GCK listeners
+ *    invoke on `CastTransport` (via `CastDebugEventSink`), so tier-1 Maestro E2E can
+ *    drive the real Nitro boundary — JS→native struct conversion in, native→JS
+ *    callback out — on an emulator/simulator where Cast discovery cannot work.
+ *    Active in debug builds only (`#if DEBUG` on iOS; host-app `FLAG_DEBUGGABLE` on
+ *    Android); in release builds they resolve `false` and deliver nothing.
  *
- * All methods are synchronous pure transforms (no native session, no I/O).
+ * All `roundTrip*` methods are synchronous pure transforms (no native session, no I/O).
  */
 export interface CastDebug
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
@@ -59,4 +68,20 @@ export interface CastDebug
   roundTripActiveInputState(value: ActiveInputState): ActiveInputState
   roundTripStandbyState(value: StandbyState): StandbyState
   roundTripPlayServicesState(value: PlayServicesState): PlayServicesState
+
+  // --- Native-boundary fake seam (T3) — debug builds only ---
+  //
+  // Each resolves `true` when the event was delivered through the live
+  // transport's stored callbacks, `false` when the seam is inactive (release
+  // build, or `CastTransport.initAndSubscribe` has not run). Delivery happens
+  // on the platform main thread, mirroring real GCK event delivery.
+
+  /** Deliver a synthetic cast-state change through the transport's `onState`. */
+  injectCastState(castState: CastState): Promise<boolean>
+  /** Deliver a synthetic device-list update through the transport's `onDevices`. */
+  injectDevices(devices: Device[]): Promise<boolean>
+  /** Deliver a synthetic session-lifecycle event through the transport's `onLifecycle`. */
+  injectLifecycleEvent(event: SessionLifecycleEvent): Promise<boolean>
+  /** Deliver a synthetic media-status push through the transport's `onMediaStatus`. */
+  injectMediaStatus(status: MediaStatus): Promise<boolean>
 }


### PR DESCRIPTION
Part of #604 (T3). Adds a debug-only native injection seam so a tier-1 E2E test runs the **real Nitro module** on an emulator without a Chromecast (Cast discovery cannot work on emulators — official limitation), plus one Maestro flow and an Android-emulator CI job that runs it.

## Feasibility verdict

**The native seam is feasible and implemented — no TS-mock fallback needed.** Verified end-to-end locally: 11/11 Maestro steps green on a Pixel_10 emulator (see evidence below).

## The seam

- `CastDebug` (the existing debug-only HybridObject, still not on the package barrel) gains `injectCastState` / `injectDevices` / `injectLifecycleEvent` / `injectMediaStatus`.
- Each delivers a synthetic event **on the main thread through the SAME stored `initAndSubscribe` callbacks the real GCK listeners invoke** on `CastTransport`, via a new `CastDebugEventSink` (new file per platform). An injected event therefore crosses the genuine Nitro boundary twice — JS→native struct conversion in, native→JS callback out — before hitting the store/façades/UI. Nothing is mocked in TS.
- **Gating lives entirely in the sink**: `#if DEBUG` on iOS (storage + attach compile out in Release), host-app `ApplicationInfo.FLAG_DEBUGGABLE` on Android. `HybridCastTransport` only gained an unconditional `attach()` in `initAndSubscribe` and a `detach()` in `dispose()` (kept tiny + far from #615's hunks; rebased on latest v5).
- `inject*` resolve `true` only when native actually delivered; release builds / pre-init calls resolve `false`, and the Maestro flow asserts `delivered=true` so it cannot silently pass on a no-op.
- TS helpers in `src/debug/fakeSession.ts` (not exported from the barrel) build the fixtures; the example app consumes them via a deep import (Metro resolves it via builder-bob's monorepo config; `example/tsconfig.json` mirrors the mapping).

## The Maestro flow (`.maestro/tier1-fake-session.yml`)

launch → wait for `Session: none` → tap **Fake start** → assert `delivered=true`, `Session: fake-session-1`, `Cast state: connected`, `Devices: 1` → tap **Fake end** → assert `delivered=true`, `Session: none`, `Cast state: notConnected`.

Run locally: `scripts/e2e-android.sh` (booted emulator + Maestro CLI + JDK 17 required; `REACT_NATIVE_ARCHITECTURES=arm64-v8a` speeds it up on Apple Silicon).

## CI job (`.github/workflows/e2e-android.yml`)

Mirrors the instrumented job's emulator setup (KVM, API 34 `google_apis` x86_64, pinned NDK 27.1/CMake 3.22.1, path-gated). Builds the example **debug** APK with the new `-PbundleInDebug=true` gradle toggle — JS bundled (no Metro in CI) while the APK stays `android:debuggable`, which is the seam's gate — then installs it and runs the flow. Uploads Maestro logs/screenshots on failure.

**Android-only for now**: Maestro on the iOS simulator needs a macOS runner plus a bundled-JS debug scheme; tracked as a follow-up under #604. The seam itself is fully implemented and compile-verified on iOS.

## Verification evidence

- **Local tier-1 run (the deliverable, end-to-end)**: all 11 flow steps `COMPLETED` on a Pixel_10 emulator against the bundled-JS debug APK. Notable local quirks handled: a foreign Metro on :8081 hijacks debug builds (pointed `debug_http_host` at a dead port; CI has no Metro), and `debuggableVariants=[]` bundles with `dev=false`, so the seam panel is not `__DEV__`-gated (the native debuggable flag is the real gate — buttons log `delivered=false` in release).
- `yarn typescript` clean; `yarn test` 275/275 (post-rebase).
- Android `compileDebugKotlin` + `compileReleaseKotlin` pass.
- iOS `xcodebuild` Debug (workspace, simulator) **and** the `NitroGoogleCast` pod in **Release** config pass — proving the `#else` (seam compiled out) path builds.
- `yarn nitrogen` output committed; example `eslint App.tsx` clean.

## Pre-existing issues observed (not addressed here)

- `yarn prepare` (bob 0.40) fails on clean v5: emits `lib/typescript/src/index.d.ts` while `package.json#types` expects `lib/typescript/index.d.ts`.
- `example` tsc can't resolve the barrel types without a built `lib/` (consequence of the above); repo-wide `yarn lint` prettier-rule baseline failure.

## Follow-ups

- iOS-simulator Maestro job (macOS runner + bundled-JS debug scheme) — #604.
- Optional: extend the flow with `injectMediaStatus` to cover the media slice, and a `resumed`/`suspended` scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr