### PR TITLE
fix(v5): seed cold-start media status through InitialSnapshot (v5-az2)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -158,6 +158,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
             CastState.NODEVICESAVAILABLE,
             playServicesState(),
             emptyArray(),
+            null,
             null
           )
         )
@@ -172,8 +173,19 @@ class HybridCastTransport : HybridCastTransportSpec() {
       // keeps this idempotent against a later session callback.
       attachMediaCallback(currentSession?.remoteMediaClient)
       attachCastListener(currentSession)
+      // Cold-start media status (v5-az2): a session live before JS init (app
+      // relaunch during playback / auto-resume) already has a MediaStatus that
+      // would otherwise only arrive on the next push. Same convention as the
+      // push path: a null GCK MediaStatus is omitted, never delivered as null.
+      val coldStartMediaStatus = currentSession?.remoteMediaClient?.mediaStatus?.toMediaStatus()
       promise.resolve(
-        InitialSnapshot(cachedCastState, playServicesState(), readDevices(), sessionInfo(currentSession))
+        InitialSnapshot(
+          cachedCastState,
+          playServicesState(),
+          readDevices(),
+          sessionInfo(currentSession),
+          coldStartMediaStatus
+        )
       )
     }
     return promise

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2190,7 +2190,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   google-cast-sdk: 32f65af50d164e3c475e79ad123db3cc26fbcd37
-  hermes-engine: edf411b644bf5e6f70042f399ec9891b0dc248b3
+  hermes-engine: 2814d16bdfa22e819935c53659d873bdc43429bb
   NitroGoogleCast: 0f07e6ce149b7ba81c659d0b29b077af20486454
   NitroModules: 994eaa7fc39d1fb4b76bb61054312c9796c4a649
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2190,7 +2190,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   google-cast-sdk: 32f65af50d164e3c475e79ad123db3cc26fbcd37
-  hermes-engine: 2814d16bdfa22e819935c53659d873bdc43429bb
+  hermes-engine: edf411b644bf5e6f70042f399ec9891b0dc248b3
   NitroGoogleCast: 0f07e6ce149b7ba81c659d0b29b077af20486454
   NitroModules: 994eaa7fc39d1fb4b76bb61054312c9796c4a649
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -126,13 +126,20 @@ final class HybridCastTransport: HybridCastTransportSpec {
       self.cachedCastState = Self.mapState(context.castState)
       self.cachedPassiveScan = context.discoveryManager.passiveScan
       let devices = self.readDevices(context.discoveryManager)
-      let current = Self.sessionInfo(context.sessionManager.currentCastSession)
+      let currentCastSession = context.sessionManager.currentCastSession
+      let current = Self.sessionInfo(currentCastSession)
+      // Cold-start media status (v5-az2): a session live before JS init (app
+      // relaunch during playback / auto-resume) already has a MediaStatus that
+      // would otherwise only arrive on the next push. Same convention as the
+      // push path: a nil GCKMediaStatus is omitted, never delivered as nil.
+      let mediaStatus = currentCastSession?.remoteMediaClient?.mediaStatus?.toMediaStatus()
       promise.resolve(
         withResult: InitialSnapshot(
           castState: self.cachedCastState,
           playServicesState: .success,
           devices: devices,
-          currentSession: current
+          currentSession: current,
+          mediaStatus: mediaStatus
         )
       )
     }

--- a/nitrogen/generated/android/c++/JHybridCastTransportSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridCastTransportSpec.cpp
@@ -27,14 +27,6 @@ namespace margelo::nitro::googlecast { struct ApplicationMetadata; }
 namespace margelo::nitro::googlecast { enum class StandbyState; }
 // Forward declaration of `ActiveInputState` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class ActiveInputState; }
-// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
-namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
-// Forward declaration of `SessionEventType` to properly resolve imports.
-namespace margelo::nitro::googlecast { enum class SessionEventType; }
-// Forward declaration of `CastError` to properly resolve imports.
-namespace margelo::nitro::googlecast { struct CastError; }
-// Forward declaration of `CastErrorCode` to properly resolve imports.
-namespace margelo::nitro::googlecast { enum class CastErrorCode; }
 // Forward declaration of `MediaStatus` to properly resolve imports.
 namespace margelo::nitro::googlecast { struct MediaStatus; }
 // Forward declaration of `MediaInfo` to properly resolve imports.
@@ -79,6 +71,14 @@ namespace margelo::nitro::googlecast { struct MediaLiveSeekableRange; }
 namespace margelo::nitro::googlecast { struct MediaQueueItem; }
 // Forward declaration of `MediaRepeatMode` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class MediaRepeatMode; }
+// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
+// Forward declaration of `SessionEventType` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class SessionEventType; }
+// Forward declaration of `CastError` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct CastError; }
+// Forward declaration of `CastErrorCode` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastErrorCode; }
 // Forward declaration of `MediaLoadRequest` to properly resolve imports.
 namespace margelo::nitro::googlecast { struct MediaLoadRequest; }
 // Forward declaration of `MediaQueueData` to properly resolve imports.
@@ -119,22 +119,7 @@ namespace margelo::nitro::googlecast { enum class MediaSeekResumeState; }
 #include "JStandbyState.hpp"
 #include "ActiveInputState.hpp"
 #include "JActiveInputState.hpp"
-#include <NitroModules/JUnit.hpp>
-#include <functional>
-#include "JFunc_void_CastState.hpp"
-#include <NitroModules/JNICallable.hpp>
-#include "JFunc_void_std__vector_Device_.hpp"
-#include "SessionLifecycleEvent.hpp"
-#include "JFunc_void_SessionLifecycleEvent.hpp"
-#include "JSessionLifecycleEvent.hpp"
-#include "SessionEventType.hpp"
-#include "JSessionEventType.hpp"
-#include "CastError.hpp"
-#include "JCastError.hpp"
-#include "CastErrorCode.hpp"
-#include "JCastErrorCode.hpp"
 #include "MediaStatus.hpp"
-#include "JFunc_void_MediaStatus.hpp"
 #include "JMediaStatus.hpp"
 #include "MediaInfo.hpp"
 #include "JMediaInfo.hpp"
@@ -180,6 +165,21 @@ namespace margelo::nitro::googlecast { enum class MediaSeekResumeState; }
 #include "JMediaQueueItem.hpp"
 #include "MediaRepeatMode.hpp"
 #include "JMediaRepeatMode.hpp"
+#include <NitroModules/JUnit.hpp>
+#include <functional>
+#include "JFunc_void_CastState.hpp"
+#include <NitroModules/JNICallable.hpp>
+#include "JFunc_void_std__vector_Device_.hpp"
+#include "SessionLifecycleEvent.hpp"
+#include "JFunc_void_SessionLifecycleEvent.hpp"
+#include "JSessionLifecycleEvent.hpp"
+#include "SessionEventType.hpp"
+#include "JSessionEventType.hpp"
+#include "CastError.hpp"
+#include "JCastError.hpp"
+#include "CastErrorCode.hpp"
+#include "JCastErrorCode.hpp"
+#include "JFunc_void_MediaStatus.hpp"
 #include "JFunc_void_std__string_std__string.hpp"
 #include "JFunc_void_std__string_bool_bool.hpp"
 #include "MediaLoadRequest.hpp"

--- a/nitrogen/generated/android/c++/JInitialSnapshot.hpp
+++ b/nitrogen/generated/android/c++/JInitialSnapshot.hpp
@@ -20,14 +20,60 @@
 #include "JCastState.hpp"
 #include "JDevice.hpp"
 #include "JDeviceCapability.hpp"
+#include "JMediaHlsSegmentFormat.hpp"
+#include "JMediaHlsVideoSegmentFormat.hpp"
+#include "JMediaInfo.hpp"
+#include "JMediaLiveSeekableRange.hpp"
+#include "JMediaMetadata.hpp"
+#include "JMediaMetadataType.hpp"
+#include "JMediaPlayerIdleReason.hpp"
+#include "JMediaPlayerState.hpp"
+#include "JMediaQueueItem.hpp"
+#include "JMediaRepeatMode.hpp"
+#include "JMediaStatus.hpp"
+#include "JMediaStreamType.hpp"
+#include "JMediaTrack.hpp"
+#include "JMediaTrackSubtype.hpp"
+#include "JMediaTrackType.hpp"
 #include "JPlayServicesState.hpp"
 #include "JSessionInfo.hpp"
 #include "JStandbyState.hpp"
+#include "JTextTrackEdgeType.hpp"
+#include "JTextTrackFontGenericFamily.hpp"
+#include "JTextTrackFontStyle.hpp"
+#include "JTextTrackStyle.hpp"
+#include "JTextTrackWindowType.hpp"
+#include "JVideoHdrType.hpp"
+#include "JVideoInfo.hpp"
 #include "JWebImage.hpp"
+#include "MediaHlsSegmentFormat.hpp"
+#include "MediaHlsVideoSegmentFormat.hpp"
+#include "MediaInfo.hpp"
+#include "MediaLiveSeekableRange.hpp"
+#include "MediaMetadata.hpp"
+#include "MediaMetadataType.hpp"
+#include "MediaPlayerIdleReason.hpp"
+#include "MediaPlayerState.hpp"
+#include "MediaQueueItem.hpp"
+#include "MediaRepeatMode.hpp"
+#include "MediaStatus.hpp"
+#include "MediaStreamType.hpp"
+#include "MediaTrack.hpp"
+#include "MediaTrackSubtype.hpp"
+#include "MediaTrackType.hpp"
 #include "PlayServicesState.hpp"
 #include "SessionInfo.hpp"
 #include "StandbyState.hpp"
+#include "TextTrackEdgeType.hpp"
+#include "TextTrackFontGenericFamily.hpp"
+#include "TextTrackFontStyle.hpp"
+#include "TextTrackStyle.hpp"
+#include "TextTrackWindowType.hpp"
+#include "VideoHdrType.hpp"
+#include "VideoInfo.hpp"
 #include "WebImage.hpp"
+#include <NitroModules/AnyMap.hpp>
+#include <NitroModules/JAnyMap.hpp>
 #include <optional>
 #include <string>
 #include <vector>
@@ -59,6 +105,8 @@ namespace margelo::nitro::googlecast {
       jni::local_ref<jni::JArrayClass<JDevice>> devices = this->getFieldValue(fieldDevices);
       static const auto fieldCurrentSession = clazz->getField<JSessionInfo>("currentSession");
       jni::local_ref<JSessionInfo> currentSession = this->getFieldValue(fieldCurrentSession);
+      static const auto fieldMediaStatus = clazz->getField<JMediaStatus>("mediaStatus");
+      jni::local_ref<JMediaStatus> mediaStatus = this->getFieldValue(fieldMediaStatus);
       return InitialSnapshot(
         castState->toCpp(),
         playServicesState->toCpp(),
@@ -72,7 +120,8 @@ namespace margelo::nitro::googlecast {
           }
           return __vector;
         }(devices),
-        currentSession != nullptr ? std::make_optional(currentSession->toCpp()) : std::nullopt
+        currentSession != nullptr ? std::make_optional(currentSession->toCpp()) : std::nullopt,
+        mediaStatus != nullptr ? std::make_optional(mediaStatus->toCpp()) : std::nullopt
       );
     }
 
@@ -82,7 +131,7 @@ namespace margelo::nitro::googlecast {
      */
     [[maybe_unused]]
     static jni::local_ref<JInitialSnapshot::javaobject> fromCpp(const InitialSnapshot& value) {
-      using JSignature = JInitialSnapshot(jni::alias_ref<JCastState>, jni::alias_ref<JPlayServicesState>, jni::alias_ref<jni::JArrayClass<JDevice>>, jni::alias_ref<JSessionInfo>);
+      using JSignature = JInitialSnapshot(jni::alias_ref<JCastState>, jni::alias_ref<JPlayServicesState>, jni::alias_ref<jni::JArrayClass<JDevice>>, jni::alias_ref<JSessionInfo>, jni::alias_ref<JMediaStatus>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
@@ -99,7 +148,8 @@ namespace margelo::nitro::googlecast {
           }
           return __array;
         }(value.devices),
-        value.currentSession.has_value() ? JSessionInfo::fromCpp(value.currentSession.value()) : nullptr
+        value.currentSession.has_value() ? JSessionInfo::fromCpp(value.currentSession.value()) : nullptr,
+        value.mediaStatus.has_value() ? JMediaStatus::fromCpp(value.mediaStatus.value()) : nullptr
       );
     }
   };

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/InitialSnapshot.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/googlecast/InitialSnapshot.kt
@@ -29,7 +29,10 @@ data class InitialSnapshot(
   val devices: Array<Device>,
   @DoNotStrip
   @Keep
-  val currentSession: SessionInfo?
+  val currentSession: SessionInfo?,
+  @DoNotStrip
+  @Keep
+  val mediaStatus: MediaStatus?
 ) {
   /* primary constructor */
 
@@ -40,6 +43,7 @@ data class InitialSnapshot(
       && Objects.deepEquals(this.playServicesState, other.playServicesState)
       && Objects.deepEquals(this.devices, other.devices)
       && Objects.deepEquals(this.currentSession, other.currentSession)
+      && Objects.deepEquals(this.mediaStatus, other.mediaStatus)
   }
 
   override fun hashCode(): Int {
@@ -47,7 +51,8 @@ data class InitialSnapshot(
       castState,
       playServicesState,
       devices,
-      currentSession
+      currentSession,
+      mediaStatus
     ).contentDeepHashCode()
   }
 
@@ -59,8 +64,8 @@ data class InitialSnapshot(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(castState: CastState, playServicesState: PlayServicesState, devices: Array<Device>, currentSession: SessionInfo?): InitialSnapshot {
-      return InitialSnapshot(castState, playServicesState, devices, currentSession)
+    private fun fromCpp(castState: CastState, playServicesState: PlayServicesState, devices: Array<Device>, currentSession: SessionInfo?, mediaStatus: MediaStatus?): InitialSnapshot {
+      return InitialSnapshot(castState, playServicesState, devices, currentSession, mediaStatus)
     }
   }
 }

--- a/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroGoogleCast-Swift-Cxx-Bridge.hpp
@@ -1052,6 +1052,21 @@ namespace margelo::nitro::googlecast::bridge::swift {
     return Result<std::shared_ptr<Promise<bool>>>::withError(error);
   }
   
+  // pragma MARK: std::optional<MediaStatus>
+  /**
+   * Specialized version of `std::optional<MediaStatus>`.
+   */
+  using std__optional_MediaStatus_ = std::optional<MediaStatus>;
+  inline std::optional<MediaStatus> create_std__optional_MediaStatus_(const MediaStatus& value) noexcept {
+    return std::optional<MediaStatus>(value);
+  }
+  inline bool has_value_std__optional_MediaStatus_(const std::optional<MediaStatus>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline MediaStatus get_std__optional_MediaStatus_(const std::optional<MediaStatus>& optional) noexcept {
+    return optional.value();
+  }
+  
   // pragma MARK: std::shared_ptr<Promise<InitialSnapshot>>
   /**
    * Specialized version of `std::shared_ptr<Promise<InitialSnapshot>>`.

--- a/nitrogen/generated/ios/c++/HybridCastTransportSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridCastTransportSpecSwift.hpp
@@ -32,14 +32,6 @@ namespace margelo::nitro::googlecast { struct ApplicationMetadata; }
 namespace margelo::nitro::googlecast { enum class StandbyState; }
 // Forward declaration of `ActiveInputState` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class ActiveInputState; }
-// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
-namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
-// Forward declaration of `SessionEventType` to properly resolve imports.
-namespace margelo::nitro::googlecast { enum class SessionEventType; }
-// Forward declaration of `CastError` to properly resolve imports.
-namespace margelo::nitro::googlecast { struct CastError; }
-// Forward declaration of `CastErrorCode` to properly resolve imports.
-namespace margelo::nitro::googlecast { enum class CastErrorCode; }
 // Forward declaration of `MediaStatus` to properly resolve imports.
 namespace margelo::nitro::googlecast { struct MediaStatus; }
 // Forward declaration of `MediaInfo` to properly resolve imports.
@@ -84,6 +76,14 @@ namespace margelo::nitro::googlecast { struct MediaLiveSeekableRange; }
 namespace margelo::nitro::googlecast { struct MediaQueueItem; }
 // Forward declaration of `MediaRepeatMode` to properly resolve imports.
 namespace margelo::nitro::googlecast { enum class MediaRepeatMode; }
+// Forward declaration of `SessionLifecycleEvent` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct SessionLifecycleEvent; }
+// Forward declaration of `SessionEventType` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class SessionEventType; }
+// Forward declaration of `CastError` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct CastError; }
+// Forward declaration of `CastErrorCode` to properly resolve imports.
+namespace margelo::nitro::googlecast { enum class CastErrorCode; }
 // Forward declaration of `MediaLoadRequest` to properly resolve imports.
 namespace margelo::nitro::googlecast { struct MediaLoadRequest; }
 // Forward declaration of `MediaQueueData` to properly resolve imports.
@@ -113,11 +113,6 @@ namespace margelo::nitro::googlecast { enum class MediaSeekResumeState; }
 #include "ApplicationMetadata.hpp"
 #include "StandbyState.hpp"
 #include "ActiveInputState.hpp"
-#include <functional>
-#include "SessionLifecycleEvent.hpp"
-#include "SessionEventType.hpp"
-#include "CastError.hpp"
-#include "CastErrorCode.hpp"
 #include "MediaStatus.hpp"
 #include "MediaInfo.hpp"
 #include "MediaStreamType.hpp"
@@ -141,6 +136,11 @@ namespace margelo::nitro::googlecast { enum class MediaSeekResumeState; }
 #include "MediaLiveSeekableRange.hpp"
 #include "MediaQueueItem.hpp"
 #include "MediaRepeatMode.hpp"
+#include <functional>
+#include "SessionLifecycleEvent.hpp"
+#include "SessionEventType.hpp"
+#include "CastError.hpp"
+#include "CastErrorCode.hpp"
 #include "MediaLoadRequest.hpp"
 #include "MediaQueueData.hpp"
 #include "MediaQueueType.hpp"

--- a/nitrogen/generated/ios/swift/InitialSnapshot.swift
+++ b/nitrogen/generated/ios/swift/InitialSnapshot.swift
@@ -18,7 +18,7 @@ public extension InitialSnapshot {
   /**
    * Create a new instance of `InitialSnapshot`.
    */
-  init(castState: CastState, playServicesState: PlayServicesState, devices: [Device], currentSession: SessionInfo?) {
+  init(castState: CastState, playServicesState: PlayServicesState, devices: [Device], currentSession: SessionInfo?, mediaStatus: MediaStatus?) {
     self.init(castState, playServicesState, { () -> bridge.std__vector_Device_ in
       var __vector = bridge.create_std__vector_Device_(devices.count)
       for __item in devices {
@@ -28,6 +28,12 @@ public extension InitialSnapshot {
     }(), { () -> bridge.std__optional_SessionInfo_ in
       if let __unwrappedValue = currentSession {
         return bridge.create_std__optional_SessionInfo_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_MediaStatus_ in
+      if let __unwrappedValue = mediaStatus {
+        return bridge.create_std__optional_MediaStatus_(__unwrappedValue)
       } else {
         return .init()
       }
@@ -52,5 +58,10 @@ public extension InitialSnapshot {
   @inline(__always)
   var currentSession: SessionInfo? {
     return self.__currentSession.value
+  }
+  
+  @inline(__always)
+  var mediaStatus: MediaStatus? {
+    return self.__mediaStatus.value
   }
 }

--- a/nitrogen/generated/shared/c++/InitialSnapshot.hpp
+++ b/nitrogen/generated/shared/c++/InitialSnapshot.hpp
@@ -36,6 +36,8 @@ namespace margelo::nitro::googlecast { enum class PlayServicesState; }
 namespace margelo::nitro::googlecast { struct Device; }
 // Forward declaration of `SessionInfo` to properly resolve imports.
 namespace margelo::nitro::googlecast { struct SessionInfo; }
+// Forward declaration of `MediaStatus` to properly resolve imports.
+namespace margelo::nitro::googlecast { struct MediaStatus; }
 
 #include "CastState.hpp"
 #include "PlayServicesState.hpp"
@@ -43,6 +45,7 @@ namespace margelo::nitro::googlecast { struct SessionInfo; }
 #include <vector>
 #include "SessionInfo.hpp"
 #include <optional>
+#include "MediaStatus.hpp"
 
 namespace margelo::nitro::googlecast {
 
@@ -55,10 +58,11 @@ namespace margelo::nitro::googlecast {
     PlayServicesState playServicesState     SWIFT_PRIVATE;
     std::vector<Device> devices     SWIFT_PRIVATE;
     std::optional<SessionInfo> currentSession     SWIFT_PRIVATE;
+    std::optional<MediaStatus> mediaStatus     SWIFT_PRIVATE;
 
   public:
     InitialSnapshot() = default;
-    explicit InitialSnapshot(CastState castState, PlayServicesState playServicesState, std::vector<Device> devices, std::optional<SessionInfo> currentSession): castState(castState), playServicesState(playServicesState), devices(devices), currentSession(currentSession) {}
+    explicit InitialSnapshot(CastState castState, PlayServicesState playServicesState, std::vector<Device> devices, std::optional<SessionInfo> currentSession, std::optional<MediaStatus> mediaStatus): castState(castState), playServicesState(playServicesState), devices(devices), currentSession(currentSession), mediaStatus(mediaStatus) {}
 
   public:
     friend bool operator==(const InitialSnapshot& lhs, const InitialSnapshot& rhs) = default;
@@ -77,7 +81,8 @@ namespace margelo::nitro {
         JSIConverter<margelo::nitro::googlecast::CastState>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "castState"))),
         JSIConverter<margelo::nitro::googlecast::PlayServicesState>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "playServicesState"))),
         JSIConverter<std::vector<margelo::nitro::googlecast::Device>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "devices"))),
-        JSIConverter<std::optional<margelo::nitro::googlecast::SessionInfo>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "currentSession")))
+        JSIConverter<std::optional<margelo::nitro::googlecast::SessionInfo>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "currentSession"))),
+        JSIConverter<std::optional<margelo::nitro::googlecast::MediaStatus>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "mediaStatus")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::googlecast::InitialSnapshot& arg) {
@@ -86,6 +91,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "playServicesState"), JSIConverter<margelo::nitro::googlecast::PlayServicesState>::toJSI(runtime, arg.playServicesState));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "devices"), JSIConverter<std::vector<margelo::nitro::googlecast::Device>>::toJSI(runtime, arg.devices));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "currentSession"), JSIConverter<std::optional<margelo::nitro::googlecast::SessionInfo>>::toJSI(runtime, arg.currentSession));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "mediaStatus"), JSIConverter<std::optional<margelo::nitro::googlecast::MediaStatus>>::toJSI(runtime, arg.mediaStatus));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -100,6 +106,7 @@ namespace margelo::nitro {
       if (!JSIConverter<margelo::nitro::googlecast::PlayServicesState>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "playServicesState")))) return false;
       if (!JSIConverter<std::vector<margelo::nitro::googlecast::Device>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "devices")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::googlecast::SessionInfo>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "currentSession")))) return false;
+      if (!JSIConverter<std::optional<margelo::nitro::googlecast::MediaStatus>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "mediaStatus")))) return false;
       return true;
     }
   };

--- a/src/state/__tests__/media.slice.test.ts
+++ b/src/state/__tests__/media.slice.test.ts
@@ -82,6 +82,52 @@ describe('media slice', () => {
     expect(mediaState(store).currentStatus).toMatchObject({ streamPosition: 5 })
   })
 
+  it('seeds the status from a cold-start snapshot carrying mediaStatus (v5-az2)', async () => {
+    // App relaunch into active playback (or GCK auto-resume before JS init):
+    // the snapshot carries both the live session and its media status, so
+    // useMediaStatus consumers see playback state immediately on mount.
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status(42),
+      },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+
+    expect(mediaState(store)).toMatchObject({
+      currentStatus: { streamPosition: 42 },
+      live: true,
+    })
+  })
+
+  it('seeds an empty live slice when the cold-start snapshot has no mediaStatus', async () => {
+    // Session live at init but native had no GCKMediaStatus yet (the field is
+    // omitted, never null): the slice stays empty until the first push.
+    const transport = new FakeCastTransport({
+      initialSnapshot: { currentSession: session('s1') },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+
+    expect(mediaState(store)).toMatchObject({ currentStatus: null, live: true })
+  })
+
+  it('drops a seeded mediaStatus that arrives without a session', async () => {
+    // Defensive: media exists only with a live session — same rule the reducer
+    // applies to pushes. A snapshot status without a session is dropped.
+    const transport = new FakeCastTransport({
+      initialSnapshot: { mediaStatus: status(42) },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+
+    expect(mediaState(store)).toMatchObject({
+      currentStatus: null,
+      live: false,
+    })
+  })
+
   it('notifies subscribers when media status changes', async () => {
     const { store, transport } = await makeStore()
     transport.emitLifecycle({ type: 'started', session: session('s1') })

--- a/src/state/__tests__/media.slice.test.ts
+++ b/src/state/__tests__/media.slice.test.ts
@@ -113,6 +113,63 @@ describe('media slice', () => {
     expect(mediaState(store)).toMatchObject({ currentStatus: null, live: true })
   })
 
+  it('keeps a seeded status across the delayed resumed for the SAME session', async () => {
+    // GCK delivers the auto-resume `resumed` callback after initAndSubscribe
+    // already seeded the session + status (both platforms). Native does not
+    // re-push (the media client was already observed at init), so the slice
+    // must not clear on this re-announcement — that would re-break v5-az2.
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status(42),
+      },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+    const before = mediaState(store)
+
+    transport.emitLifecycle({ type: 'resumed', session: session('s1') })
+    // Retained — and ref-stable (no spurious churn for the media slice).
+    expect(mediaState(store)).toBe(before)
+    expect(mediaState(store).currentStatus).toMatchObject({
+      streamPosition: 42,
+    })
+  })
+
+  it('clears a seeded status when a DIFFERENT session establishes', async () => {
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status(42),
+      },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+
+    // A real replacement: s1's status must not bleed into s2.
+    transport.emitLifecycle({ type: 'resumed', session: session('s2') })
+    expect(mediaState(store)).toMatchObject({ currentStatus: null, live: true })
+  })
+
+  it('clears a seeded status on an establish without a usable sessionId', async () => {
+    // Safe default: if the establish payload has no id to compare, treat it
+    // as a replacement rather than risk retaining another session's status.
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status(42),
+      },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+
+    transport.emitLifecycle({
+      type: 'resumed',
+      session: { sessionId: '', device: device('s1') },
+    })
+    expect(mediaState(store)).toMatchObject({ currentStatus: null, live: true })
+  })
+
   it('drops a seeded mediaStatus that arrives without a session', async () => {
     // Defensive: media exists only with a live session — same rule the reducer
     // applies to pushes. A snapshot status without a session is dropped.

--- a/src/state/__tests__/progressTicker.test.ts
+++ b/src/state/__tests__/progressTicker.test.ts
@@ -205,6 +205,72 @@ describe('ProgressTicker — derivation', () => {
   })
 })
 
+describe('ProgressTicker — cold-start seeded status (v5-az2)', () => {
+  it('anchors from a snapshot-seeded status (ticker built after ready)', async () => {
+    const clock = makeClock()
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status({ streamPosition: 10, playerState: 'playing' }),
+      },
+    })
+    const store = new CastStore(transport)
+    await store.ready
+    const ticker = new ProgressTicker(store, clock.now, () =>
+      transport.requestMediaStatus()
+    )
+
+    // The constructor re-anchor picks up the seeded status directly.
+    clock.advance(2000)
+    expect(ticker.getPosition()).toBe(12)
+  })
+
+  it('anchors from the seed when built before init resolves (singleton wiring)', async () => {
+    const clock = makeClock()
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status({ streamPosition: 10, playerState: 'playing' }),
+      },
+    })
+    const store = new CastStore(transport)
+    // Real wiring: progressTicker.singleton constructs at module import,
+    // before `store.ready` resolves. The seedAll notify re-anchors it.
+    const ticker = new ProgressTicker(store, clock.now, () =>
+      transport.requestMediaStatus()
+    )
+    await store.ready
+
+    clock.advance(3000)
+    expect(ticker.getPosition()).toBe(13)
+  })
+
+  it('seeding does not consume the first-subscriber one-shot request', async () => {
+    const clock = makeClock()
+    const transport = new FakeCastTransport({
+      initialSnapshot: {
+        currentSession: session('s1'),
+        mediaStatus: status({ streamPosition: 10, playerState: 'playing' }),
+      },
+    })
+    const store = new CastStore(transport)
+    const ticker = new ProgressTicker(store, clock.now, () =>
+      transport.requestMediaStatus()
+    )
+    await store.ready
+    // Seeding itself never requests a fresh status…
+    expect(statusRequests(transport)).toBe(0)
+
+    // …and the first subscriber still fires exactly one, with the seeded
+    // anchor intact until the (event-driven) fresh push lands.
+    const off = ticker.subscribe(() => {})
+    expect(statusRequests(transport)).toBe(1)
+    clock.advance(1000)
+    expect(ticker.getPosition()).toBe(11)
+    off()
+  })
+})
+
 describe('ProgressTicker — fresh status on first subscriber', () => {
   it('the first subscriber triggers a one-shot requestMediaStatus', async () => {
     const clock = makeClock()

--- a/src/state/media.slice.ts
+++ b/src/state/media.slice.ts
@@ -24,10 +24,32 @@ export interface MediaState {
    * is dropped rather than allowed to resurrect stale media (Invariant 3).
    */
   readonly live: boolean
+  /**
+   * The `sessionId` of the live session this status belongs to (`null` when
+   * none is live or the establish payload carried no usable id). Lets the
+   * reducer tell a *re-announcement* of the session it already tracks — GCK's
+   * delayed `started`/`resumed` for the session that was already current at
+   * cold start, delivered after the snapshot seeded a status (native does not
+   * re-emit: the media client is already observed) — from a real replacement:
+   * the former keeps the seeded status (v5-az2), the latter clears it.
+   */
+  readonly sessionId: string | null
 }
 
-const EMPTY_IDLE: MediaState = { currentStatus: null, live: false }
-const EMPTY_LIVE: MediaState = { currentStatus: null, live: true }
+const EMPTY_IDLE: MediaState = {
+  currentStatus: null,
+  live: false,
+  sessionId: null,
+}
+const emptyLive = (sessionId: string | null): MediaState => ({
+  currentStatus: null,
+  live: true,
+  sessionId,
+})
+
+/** A non-empty sessionId from an establish payload, else `null` (unusable). */
+const usableId = (sessionId: string | undefined): string | null =>
+  sessionId ? sessionId : null
 
 /**
  * Core P4 slice: the streamed media status, bound to live-session presence.
@@ -35,8 +57,11 @@ const EMPTY_LIVE: MediaState = { currentStatus: null, live: true }
  * Status exists only while a session is live, so the slice:
  * - **accepts** a `mediaStatus` push only when `live` — a push arriving after
  *   teardown is dropped, never relying on a later lifecycle event to clean up;
- * - **clears** on session *establishment* (`started` / `resumed`) so a prior
- *   session's status can't bleed into the new generation; and
+ * - **clears** on session *establishment* (`started` / `resumed`) of a
+ *   **different** session so a prior session's status can't bleed into the new
+ *   generation — but **keeps** it when the establish re-announces the same
+ *   live session (the delayed cold-start `resumed`, see
+ *   {@link MediaState.sessionId}); and
  * - **clears** on session *teardown* (`ended` / `startFailed` / `suspended` /
  *   `resumeFailed`) so a status can never outlive its session.
  *
@@ -55,9 +80,11 @@ export const mediaSlice: Slice<MediaState> = {
   // dropped — same "no session, no media" rule the reducer applies (v5-az2).
   seed: (snapshot) =>
     snapshot.currentSession
-      ? snapshot.mediaStatus != null
-        ? { currentStatus: snapshot.mediaStatus, live: true }
-        : EMPTY_LIVE
+      ? {
+          currentStatus: snapshot.mediaStatus ?? null,
+          live: true,
+          sessionId: usableId(snapshot.currentSession.sessionId),
+        }
       : EMPTY_IDLE,
 
   reduce: (state, event) => {
@@ -65,23 +92,47 @@ export const mediaSlice: Slice<MediaState> = {
       // Drop a status that arrives while no session is live — it would
       // otherwise resurrect media the session slice has already let go.
       if (!state.live) return state
-      return { currentStatus: event.status, live: true }
+      return {
+        currentStatus: event.status,
+        live: true,
+        sessionId: state.sessionId,
+      }
     }
 
     if (event.kind === 'lifecycle') {
       const { type } = event.event
       if (SESSION_ESTABLISH_TYPES.has(type)) {
-        // A new (or replacement) session: the prior status must not leak into
-        // the new generation. `live` mirrors the session slice — an establish
-        // event without a session payload yields no live session.
+        // `live` mirrors the session slice — an establish event without a
+        // session payload yields no live session.
         const live = event.event.session != null
-        const next = live ? EMPTY_LIVE : EMPTY_IDLE
-        return state.currentStatus === null && state.live === live
+        const sessionId = usableId(event.event.session?.sessionId)
+        // Re-announcement of the session already tracked (GCK's delayed
+        // `resumed` after the cold-start seed, on both platforms): keep the
+        // held status — clearing here would re-break v5-az2, and native will
+        // not re-push (the media client was already observed at init).
+        if (
+          live &&
+          state.live &&
+          sessionId !== null &&
+          sessionId === state.sessionId
+        ) {
+          return state
+        }
+        // A new (or replacement) session: the prior status must not leak into
+        // the new generation.
+        const next = live ? emptyLive(sessionId) : EMPTY_IDLE
+        return state.currentStatus === null &&
+          state.live === live &&
+          state.sessionId === sessionId
           ? state
           : next
       }
       if (SESSION_TEARDOWN_TYPES.has(type)) {
-        return state.currentStatus === null && !state.live ? state : EMPTY_IDLE
+        return state.currentStatus === null &&
+          !state.live &&
+          state.sessionId === null
+          ? state
+          : EMPTY_IDLE
       }
     }
 

--- a/src/state/media.slice.ts
+++ b/src/state/media.slice.ts
@@ -48,9 +48,17 @@ const EMPTY_LIVE: MediaState = { currentStatus: null, live: true }
 export const mediaSlice: Slice<MediaState> = {
   key: MEDIA_SLICE_KEY,
 
-  // A fresh init never carries media status (cold-start status is a separate
-  // deferred concern); only liveness is known up front.
-  seed: (snapshot) => (snapshot.currentSession ? EMPTY_LIVE : EMPTY_IDLE),
+  // Cold start into an active cast (app relaunch during playback, or GCK
+  // auto-resume completing before JS init): the snapshot may carry the live
+  // session's media status, so hooks render playback state on mount instead
+  // of waiting for the next native push. A status without a session is
+  // dropped — same "no session, no media" rule the reducer applies (v5-az2).
+  seed: (snapshot) =>
+    snapshot.currentSession
+      ? snapshot.mediaStatus != null
+        ? { currentStatus: snapshot.mediaStatus, live: true }
+        : EMPTY_LIVE
+      : EMPTY_IDLE,
 
   reduce: (state, event) => {
     if (event.kind === 'mediaStatus') {

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -141,6 +141,13 @@ export interface InitialSnapshot {
   devices: Device[]
   /** A session already live at cold start (already-casting); omitted otherwise. */
   currentSession?: SessionInfo
+  /**
+   * The media status of {@link currentSession}'s RemoteMediaClient at cold
+   * start (app relaunch into active playback, or GCK auto-resume completing
+   * before JS init). Mirrors the push convention: a nil native status is
+   * omitted, never delivered as null. Only meaningful with `currentSession`.
+   */
+  mediaStatus?: MediaStatus
 }
 
 /**


### PR DESCRIPTION
## Problem (v5-az2)

When JS `initAndSubscribe` runs while a session already exists (cold start into active cast — app relaunch during playback, or GCK auto-resume completing before JS init), the initial seed carried no MediaStatus: the media slice stayed empty until the next native push, so `useMediaStatus` / `useStreamPosition` rendered empty on mount despite active playback.

## Fix — end-to-end mediaStatus flow

- **Spec/types**: optional `mediaStatus?: MediaStatus` on `InitialSnapshot` (`src/transport/types.ts`, shared with `src/specs/CastTransport.nitro.ts`); `yarn nitrogen` output committed.
- **iOS** (`ios/NitroGoogleCast/HybridCastTransport.swift`): snapshot build reads `currentCastSession?.remoteMediaClient?.mediaStatus?.toMediaStatus()` on the main thread. Existing converter reused; nil GCKMediaStatus is omitted, never delivered as nil (mirrors the push convention).
- **Android** (`android/.../HybridCastTransport.kt`): same read at both resolve sites (unavailable path seeds null), inside the existing `runOnMain` block.
- **TS state** (`src/state/media.slice.ts`): `seed` populates `currentStatus` from `snapshot.mediaStatus` only when `currentSession` is present — same "no session, no media" rule the reducer applies. Lifecycle clear semantics unchanged.

## ProgressTicker interaction

No changes needed: the ticker re-anchors via its lifetime-bound store subscription (or its constructor re-anchor when built after `ready`). Seeding fires no `requestMediaStatus`; the first-subscriber one-shot (#613) still fires exactly once. Covered by new tests for both construction orders.

## Tests & gates (post-rebase on #620)

- `yarn test`: 313/313 (6 new: seed populates / stays empty / drops status-without-session; ticker anchors from seed in both orders; no double-request)
- `yarn typescript`: clean
- Android `:react-native-google-cast:compileDebugKotlin`: BUILD SUCCESSFUL
- iOS `NitroGoogleCast` pod target (iphonesimulator, Debug): BUILD SUCCEEDED
- `yarn nitrogen` post-rebase: zero diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cold starts now enrich the initial snapshot with the current session’s media status when available.
  * Media playback state and progress can initialize immediately from this seeded status.

* **Bug Fixes**
  * Media state is now tied to the active session via a session identifier, preventing stale status when sessions change or are invalid.
  * Correctly handles cases where media status is missing (drops seeding and sets idle/not-live as appropriate).

* **Tests**
  * Added coverage for cold-start seeding and ticker anchoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->