### PR TITLE
fix(v5): Android CastButton taps swallowed by JS responder views (v5-mc9.2)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
@@ -29,19 +29,32 @@ internal class TintableMediaRouteButton(context: Context) : MediaRouteButton(con
    * own ScrollView/DrawerLayout under Fabric) notifies the React root view,
    * which cancels the JS responder for this gesture and leaves the stream with
    * the button.
+   *
+   * The started call MUST be paired with `notifyNativeGestureEnded` on the
+   * terminal event (UP/CANCEL — the ScrollView pattern): `JSPointerDispatcher`
+   * drops every pointer event while a child holds the native gesture and only
+   * `onChildEndedNativeGesture` releases it, so without the ended call one tap
+   * would silence `onPointer*` for the whole surface.
    */
   override fun onTouchEvent(event: MotionEvent): Boolean {
-    if (event.actionMasked == MotionEvent.ACTION_DOWN) {
-      try {
-        NativeGestureUtil.notifyNativeGestureStarted(this, event)
-      } catch (_: AssertionError) {
-        // Outside a React hierarchy (plain Android window, Robolectric host
-        // activity) RootViewUtil's parent walk can reach a non-View parent
-        // (ViewRootImpl) before any RootView and trip RN's assertion. There is
-        // no JS responder to cancel there — swallow and let the button work.
-      }
+    when (event.actionMasked) {
+      MotionEvent.ACTION_DOWN ->
+        notifyReactRoot { NativeGestureUtil.notifyNativeGestureStarted(this, event) }
+      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+        notifyReactRoot { NativeGestureUtil.notifyNativeGestureEnded(this, event) }
     }
     return super.onTouchEvent(event)
+  }
+
+  private inline fun notifyReactRoot(notify: () -> Unit) {
+    try {
+      notify()
+    } catch (_: AssertionError) {
+      // Outside a React hierarchy (plain Android window, Robolectric host
+      // activity) RootViewUtil's parent walk can reach a non-View parent
+      // (ViewRootImpl) before any RootView and trip RN's assertion. There is
+      // no JS responder to cancel there — swallow and let the button work.
+    }
   }
 
   override fun setRemoteIndicatorDrawable(d: Drawable?) {

--- a/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/TintableMediaRouteButton.kt
@@ -2,8 +2,10 @@ package com.margelo.nitro.googlecast
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.view.MotionEvent
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.mediarouter.app.MediaRouteButton
+import com.facebook.react.uimanager.events.NativeGestureUtil
 
 /**
  * [MediaRouteButton] whose remote-indicator drawable can be tinted (the v4
@@ -17,6 +19,30 @@ import androidx.mediarouter.app.MediaRouteButton
 internal class TintableMediaRouteButton(context: Context) : MediaRouteButton(context) {
   private var indicatorDrawable: Drawable? = null
   private var tintColor: Int? = null
+
+  /**
+   * Claim the gesture for this native button before the JS responder can steal
+   * it (#616, port of v4 PR #582). When an ancestor claims the JS responder
+   * (`onStartShouldSetResponder`), Fabric's `ReactViewGroup` intercepts the
+   * rest of the touch stream, so the button receives ACTION_DOWN but never the
+   * ACTION_UP that completes the click. `NativeGestureUtil` (also used by RN's
+   * own ScrollView/DrawerLayout under Fabric) notifies the React root view,
+   * which cancels the JS responder for this gesture and leaves the stream with
+   * the button.
+   */
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+      try {
+        NativeGestureUtil.notifyNativeGestureStarted(this, event)
+      } catch (_: AssertionError) {
+        // Outside a React hierarchy (plain Android window, Robolectric host
+        // activity) RootViewUtil's parent walk can reach a non-View parent
+        // (ViewRootImpl) before any RootView and trip RN's assertion. There is
+        // no JS responder to cancel there — swallow and let the button work.
+      }
+    }
+    return super.onTouchEvent(event)
+  }
 
   override fun setRemoteIndicatorDrawable(d: Drawable?) {
     indicatorDrawable = d

--- a/android/src/test/java/com/margelo/nitro/googlecast/TintableMediaRouteButtonTouchTest.kt
+++ b/android/src/test/java/com/margelo/nitro/googlecast/TintableMediaRouteButtonTouchTest.kt
@@ -1,0 +1,109 @@
+package com.margelo.nitro.googlecast
+
+import android.app.Activity
+import android.content.Context
+import android.os.SystemClock
+import android.view.ContextThemeWrapper
+import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
+import com.facebook.react.uimanager.RootView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * JS-responder interception fix (#616, port of v4 PR #582): ACTION_DOWN on the
+ * button must notify the React [RootView] via `NativeGestureUtil` so Fabric
+ * cancels the JS responder instead of stealing the touch stream, and the
+ * notification must be safe outside a React view hierarchy.
+ *
+ * Runs on the JVM with a fake [RootView] parent — no Fabric runtime needed:
+ * `NativeGestureUtil.notifyNativeGestureStarted` only walks up the view tree
+ * to the first [RootView] and calls `onChildStartedNativeGesture` on it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TintableMediaRouteButtonTouchTest {
+
+  /** Fake React root that records native-gesture notifications. */
+  private class RecordingRootView(context: Context) : FrameLayout(context), RootView {
+    var startedCount = 0
+    var lastChild: View? = null
+
+    override fun onChildStartedNativeGesture(childView: View?, ev: MotionEvent) {
+      startedCount++
+      lastChild = childView
+    }
+
+    override fun onChildEndedNativeGesture(childView: View, ev: MotionEvent) = Unit
+
+    override fun handleException(t: Throwable) = throw t
+  }
+
+  /**
+   * `MediaRouteButton`'s constructor runs `MediaRouterThemeHelper` contrast
+   * math against the theme's `colorPrimary`; Robolectric's default theme
+   * resolves it to transparent, so wrap in a theme with a solid one.
+   */
+  private fun themed(base: Context): Context =
+    ContextThemeWrapper(base, androidx.appcompat.R.style.Theme_AppCompat)
+
+  private val context: Context get() = themed(RuntimeEnvironment.getApplication())
+
+  private fun motionEvent(action: Int): MotionEvent {
+    val now = SystemClock.uptimeMillis()
+    return MotionEvent.obtain(now, now, action, 10f, 10f, 0)
+  }
+
+  @Test
+  fun actionDownNotifiesReactRootOfNativeGesture() {
+    val root = RecordingRootView(context)
+    val button = TintableMediaRouteButton(context)
+    root.addView(button)
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
+
+    assertEquals(1, root.startedCount)
+    assertSame(button, root.lastChild)
+  }
+
+  @Test
+  fun onlyActionDownNotifies() {
+    val root = RecordingRootView(context)
+    val button = TintableMediaRouteButton(context)
+    root.addView(button)
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_MOVE))
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_UP))
+
+    assertEquals(0, root.startedCount)
+  }
+
+  @Test
+  fun touchWithoutAnyReactRootDoesNotCrash() {
+    // Detached plain hierarchy: the RootView walk ends at a null parent.
+    val plainParent = FrameLayout(context)
+    val button = TintableMediaRouteButton(context)
+    plainParent.addView(button)
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
+  }
+
+  @Test
+  fun touchInNonReactWindowDoesNotCrash() {
+    // Attached to a real (non-React) window: the RootView walk reaches the
+    // ViewRootImpl — a non-View parent — which trips RN's internal assertion;
+    // the button must swallow it (guard in TintableMediaRouteButton).
+    val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    val button = TintableMediaRouteButton(themed(activity))
+    activity.setContentView(button)
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
+  }
+}

--- a/android/src/test/java/com/margelo/nitro/googlecast/TintableMediaRouteButtonTouchTest.kt
+++ b/android/src/test/java/com/margelo/nitro/googlecast/TintableMediaRouteButtonTouchTest.kt
@@ -20,12 +20,15 @@ import org.robolectric.annotation.Config
 /**
  * JS-responder interception fix (#616, port of v4 PR #582): ACTION_DOWN on the
  * button must notify the React [RootView] via `NativeGestureUtil` so Fabric
- * cancels the JS responder instead of stealing the touch stream, and the
- * notification must be safe outside a React view hierarchy.
+ * cancels the JS responder instead of stealing the touch stream, the terminal
+ * ACTION_UP/ACTION_CANCEL must send the paired gesture-ended notification
+ * (otherwise `JSPointerDispatcher` stays locked and drops every `onPointer*`
+ * event for the surface), and both notifications must be safe outside a React
+ * view hierarchy.
  *
  * Runs on the JVM with a fake [RootView] parent — no Fabric runtime needed:
- * `NativeGestureUtil.notifyNativeGestureStarted` only walks up the view tree
- * to the first [RootView] and calls `onChildStartedNativeGesture` on it.
+ * `NativeGestureUtil` only walks up the view tree to the first [RootView] and
+ * calls `onChildStartedNativeGesture`/`onChildEndedNativeGesture` on it.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -34,14 +37,19 @@ class TintableMediaRouteButtonTouchTest {
   /** Fake React root that records native-gesture notifications. */
   private class RecordingRootView(context: Context) : FrameLayout(context), RootView {
     var startedCount = 0
-    var lastChild: View? = null
+    var endedCount = 0
+    var lastStartedChild: View? = null
+    var lastEndedChild: View? = null
 
     override fun onChildStartedNativeGesture(childView: View?, ev: MotionEvent) {
       startedCount++
-      lastChild = childView
+      lastStartedChild = childView
     }
 
-    override fun onChildEndedNativeGesture(childView: View, ev: MotionEvent) = Unit
+    override fun onChildEndedNativeGesture(childView: View, ev: MotionEvent) {
+      endedCount++
+      lastEndedChild = childView
+    }
 
     override fun handleException(t: Throwable) = throw t
   }
@@ -61,28 +69,66 @@ class TintableMediaRouteButtonTouchTest {
     return MotionEvent.obtain(now, now, action, 10f, 10f, 0)
   }
 
-  @Test
-  fun actionDownNotifiesReactRootOfNativeGesture() {
+  private fun buttonInRoot(): Pair<TintableMediaRouteButton, RecordingRootView> {
     val root = RecordingRootView(context)
     val button = TintableMediaRouteButton(context)
     root.addView(button)
+    return button to root
+  }
+
+  @Test
+  fun actionDownNotifiesGestureStartedOnly() {
+    val (button, root) = buttonInRoot()
 
     button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
 
     assertEquals(1, root.startedCount)
-    assertSame(button, root.lastChild)
+    assertSame(button, root.lastStartedChild)
+    assertEquals(0, root.endedCount)
   }
 
   @Test
-  fun onlyActionDownNotifies() {
-    val root = RecordingRootView(context)
-    val button = TintableMediaRouteButton(context)
-    root.addView(button)
+  fun actionUpNotifiesGestureEndedOnly() {
+    val (button, root) = buttonInRoot()
 
-    button.onTouchEvent(motionEvent(MotionEvent.ACTION_MOVE))
     button.onTouchEvent(motionEvent(MotionEvent.ACTION_UP))
 
     assertEquals(0, root.startedCount)
+    assertEquals(1, root.endedCount)
+    assertSame(button, root.lastEndedChild)
+  }
+
+  @Test
+  fun actionCancelNotifiesGestureEndedOnly() {
+    val (button, root) = buttonInRoot()
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_CANCEL))
+
+    assertEquals(0, root.startedCount)
+    assertEquals(1, root.endedCount)
+    assertSame(button, root.lastEndedChild)
+  }
+
+  @Test
+  fun actionMoveNotifiesNothing() {
+    val (button, root) = buttonInRoot()
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_MOVE))
+
+    assertEquals(0, root.startedCount)
+    assertEquals(0, root.endedCount)
+  }
+
+  @Test
+  fun fullTapPairsStartedWithEnded() {
+    val (button, root) = buttonInRoot()
+
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_MOVE))
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_UP))
+
+    assertEquals(1, root.startedCount)
+    assertEquals(1, root.endedCount)
   }
 
   @Test
@@ -93,6 +139,8 @@ class TintableMediaRouteButtonTouchTest {
     plainParent.addView(button)
 
     button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_UP))
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_CANCEL))
   }
 
   @Test
@@ -105,5 +153,6 @@ class TintableMediaRouteButtonTouchTest {
     activity.setContentView(button)
 
     button.onTouchEvent(motionEvent(MotionEvent.ACTION_DOWN))
+    button.onTouchEvent(motionEvent(MotionEvent.ACTION_UP))
   }
 }


### PR DESCRIPTION
## What

When `<CastButton />` sits inside a parent that claims the JS touch responder (`onStartShouldSetResponder`, e.g. a `Pressable`/`ScrollView` wrapper), the native `MediaRouteButton` receives `ACTION_DOWN` but Fabric's `ReactViewGroup.onInterceptTouchEvent` then steals the rest of the touch stream for the JS responder — the button never sees `ACTION_UP`, so the tap is swallowed and the Cast dialog never opens.

Fix: `TintableMediaRouteButton` now overrides `onTouchEvent` and calls `NativeGestureUtil.notifyNativeGestureStarted(this, event)` on `ACTION_DOWN`. That notifies the React root view (`RootView.onChildStartedNativeGesture`), which cancels the JS responder for the gesture and leaves the touch stream with the native button.

Fixes #616

## Port provenance

Direct port of v4 PR #582 (by @OlegRyz), which applied the same `NativeGestureUtil.notifyNativeGestureStarted` on `ACTION_DOWN` to v4's `ColorableMediaRouteButton`. Verified the mechanism is still the correct one under the New Architecture (RN 0.86.0, which v5 builds against):

- `com.facebook.react.uimanager.events.NativeGestureUtil` is alive and is exactly what RN's own Fabric-era components use for native gesture interception (`ReactScrollView`, `ReactHorizontalScrollView`, `ReactNestedScrollView`, `ReactDrawerLayout`, `ReactSwipeRefreshLayout` all call it in 0.86).
- Fabric's bridgeless root (`ReactSurfaceView`) implements `RootView.onChildStartedNativeGesture` and cancels the JS touch/pointer streams via `JSTouchDispatcher`/`JSPointerDispatcher`, so the util works as-is — no custom mechanism needed.

Two v5 additions over the v4 patch:

- **Non-React guard**: `NativeGestureUtil` is null-safe when the button has no parent, but when attached to a *non-React* window, RN's `RootViewUtil.getRootView` parent walk reaches a non-`View` parent (`ViewRootImpl`) and trips an internal `AssertionError`. The override swallows that specific error so the view can't crash outside a React hierarchy (plain Android windows, Robolectric hosts).
- **Unit test**: Robolectric suite (below) — v4's fix shipped untested.

## iOS analysis (no change needed, by design)

v4 #582 was Android-only, and v5's iOS CastButton is structurally unaffected: `GCKUICastButton` is a `UIControl` that receives touches through UIKit hit-testing directly. RN's Fabric touch handling on iOS is a gesture recognizer on the surface view (`RCTSurfaceTouchHandler`) that explicitly sets `cancelsTouchesInView = NO` (RCTSurfaceTouchHandler.mm:155 in RN 0.86.0), so the JS responder never cancels UIKit's touch delivery to native controls. There is no iOS equivalent of Android's `onInterceptTouchEvent` stealing — hence no iOS change.

## Verification

- `:react-native-google-cast:compileDebugKotlin` — green (JBR/OpenJDK 21).
- New Robolectric suite `TintableMediaRouteButtonTouchTest` (4 tests, JVM, no Fabric runtime needed — `NativeGestureUtil` only walks up to the first `RootView`):
  - `ACTION_DOWN` notifies a fake React `RootView` with the button as child.
  - `ACTION_MOVE`/`ACTION_UP` do not notify.
  - No crash with no React root in the hierarchy (detached plain parent).
  - No crash attached to a real non-React window (Robolectric activity → exercises the `AssertionError` guard path).
- Full `:react-native-google-cast:testDebugUnitTest` — green (converter parity suites + new suite).
- `yarn typescript` and `yarn test` (258 tests / 17 suites) — green; no TS changes.
- `yarn lint` is broken repo-wide (pre-existing prettier rule resolution issue) — not a gate here; touched files are Kotlin only.

End-to-end responder-steal behavior (button inside a `Pressable`/`ScrollView` claiming the responder) needs a real device — Cast buttons can't be exercised on emulators (no Cast discovery) and the interception path needs the full Fabric touch pipeline. Manual path: example app, wrap `<CastButton />` in a `Pressable`/view with `onStartShouldSetResponder={() => true}`, tap the button, Cast dialog should open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native-gesture touch handling for the media route button in React Native hierarchies, ensuring gesture start and end notifications occur at the correct touch phases.
  * Prevented touch interactions from crashing when the button is detached or outside a React Native view tree.
* **Tests**
  * Added expanded automated coverage for gesture start/end notifications across touch events (down, move, up, cancel) and verified safety in non-React configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->