### PR TITLE
fix(ios): preserve customData booleans in GCK→AnyMap conversion (v5-mc9.4)

### DIFF
--- a/example/ios/NitroGoogleCastTests/ConverterAssertions.swift
+++ b/example/ios/NitroGoogleCastTests/ConverterAssertions.swift
@@ -27,9 +27,16 @@ enum ConverterAssertions {
           actual.getString(key: key), expected.getString(key: key),
           "\(ctx) customData[\(key)]", file: file, line: line)
       } else if expected.isBool(key: key) {
-        XCTAssertEqual(
-          actual.getBoolean(key: key), expected.getBoolean(key: key),
-          "\(ctx) customData[\(key)]", file: file, line: line)
+        // Assert the type tag first: a bool that collapsed to 1.0/0.0 (#617) must fail
+        // with a clear message instead of trapping inside getBoolean on a double value.
+        XCTAssertTrue(
+          actual.isBool(key: key),
+          "\(ctx) customData[\(key)] should be Bool", file: file, line: line)
+        if actual.isBool(key: key) {
+          XCTAssertEqual(
+            actual.getBoolean(key: key), expected.getBoolean(key: key),
+            "\(ctx) customData[\(key)]", file: file, line: line)
+        }
       } else if expected.isDouble(key: key) {
         XCTAssertEqual(
           actual.getDouble(key: key), expected.getDouble(key: key), accuracy: 1e-9,

--- a/example/ios/NitroGoogleCastTests/ConverterFixtures.swift
+++ b/example/ios/NitroGoogleCastTests/ConverterFixtures.swift
@@ -272,7 +272,7 @@ enum ConverterFixtures {
     return (value as? NSNumber)?.doubleValue
   }
 
-  /// Builds an `AnyMap` from a JSON object (string → string, number → double).
+  /// Builds an `AnyMap` from a JSON object (string → string, bool → bool, number → double).
   static func anyMap(_ value: Any?) -> AnyMap? {
     guard let dict = value as? [String: Any] else {
       return nil
@@ -282,7 +282,12 @@ enum ConverterFixtures {
       if let string = raw as? String {
         map.setString(key: key, value: string)
       } else if let n = raw as? NSNumber {
-        map.setDouble(key: key, value: n.doubleValue)
+        // CFBoolean IS an NSNumber; detect it first so fixture booleans stay booleans.
+        if CFGetTypeID(n) == CFBooleanGetTypeID() {
+          map.setBoolean(key: key, value: n.boolValue)
+        } else {
+          map.setDouble(key: key, value: n.doubleValue)
+        }
       }
     }
     return map

--- a/fixtures/converters/mediaInfo.json
+++ b/fixtures/converters/mediaInfo.json
@@ -15,7 +15,7 @@
         ],
         "hlsSegmentFormat": "AAC",
         "hlsVideoSegmentFormat": "FMP4",
-        "customData": { "drm": "widevine" }
+        "customData": { "drm": "widevine", "isLive": false, "requiresAuth": true }
       },
       "expectedRoundTrip": {
         "contentUrl": "https://example.com/video.m3u8",
@@ -30,7 +30,7 @@
         ],
         "hlsSegmentFormat": "AAC",
         "hlsVideoSegmentFormat": "FMP4",
-        "customData": { "drm": "widevine" }
+        "customData": { "drm": "widevine", "isLive": false, "requiresAuth": true }
       }
     },
     {

--- a/fixtures/converters/mediaTrack.json
+++ b/fixtures/converters/mediaTrack.json
@@ -9,7 +9,7 @@
         "contentType": "audio/mp4",
         "language": "en-US",
         "name": "English",
-        "customData": { "bitrate": 256, "label": "stereo" }
+        "customData": { "bitrate": 256, "label": "stereo", "default": true, "forced": false }
       },
       "expectedRoundTrip": {
         "id": 1,
@@ -18,7 +18,7 @@
         "contentType": "audio/mp4",
         "language": "en-US",
         "name": "English",
-        "customData": { "bitrate": 256, "label": "stereo" }
+        "customData": { "bitrate": 256, "label": "stereo", "default": true, "forced": false }
       }
     },
     {

--- a/ios/NitroGoogleCast/Converters/AnyMap+GckCustomData.swift
+++ b/ios/NitroGoogleCast/Converters/AnyMap+GckCustomData.swift
@@ -42,7 +42,14 @@ extension AnyMap {
       if let string = raw as? String {
         map.setString(key: key, value: string)
       } else if let number = raw as? NSNumber {
-        map.setDouble(key: key, value: number.doubleValue)
+        // JSON booleans arrive as CFBoolean, which IS an NSNumber — check its CFTypeID
+        // before the generic number branch, or `true`/`false` would collapse to 1.0/0.0
+        // (Android's converter preserves Boolean, so this keeps the platforms symmetric).
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+          map.setBoolean(key: key, value: number.boolValue)
+        } else {
+          map.setDouble(key: key, value: number.doubleValue)
+        }
       }
     }
     return map.getAllKeys().isEmpty ? nil : map


### PR DESCRIPTION
## Root cause

`AnyMap.fromGckCustomData` (`ios/NitroGoogleCast/Converters/AnyMap+GckCustomData.swift`) is the single reverse-path funnel for every GCK `customData` carrier (MediaInfo, MediaTrack, MediaQueueItem, MediaStatus, MediaLoadRequest, MediaSeekOptions, TextTrackStyle). Its scalar partition was `String` → string, `NSNumber` → double — but JSON booleans arrive as **CFBoolean, which IS an NSNumber**, so `true`/`false` collapsed to `1.0`/`0.0` on the native→JS leg. The JS→native leg (`toGckCustomData`) was already bool-correct, which is why booleans "survived" one way and came back numeric.

## Fix

Check `CFGetTypeID(number) == CFBooleanGetTypeID()` before the generic number branch and write the value with `setBoolean`. No other reverse-path sites exist (all seven carriers call this one function; the `GCKMediaMetadata` keyed bag is a separate, symmetric-by-design surface — neither platform's bag has a boolean type, both drop bools identically, unchanged here).

**Android needed no fix**: `JSONObject+toAnyMap.kt` matches `is Boolean` before `is Number`, so booleans were already preserved — the platforms are now symmetric.

## Tests

- Shared corpus: bool cases (one `true`, one `false`) added to `fixtures/converters/mediaTrack.json` and `mediaInfo.json` `customData` (input + expectedRoundTrip), so the iOS XCTest suite and Android **instrumented** suite (AnyMap is JNI-backed; runs in CI) both pin the round-trip. No new test files → no `project.pbxproj` churn.
- `ConverterFixtures.anyMap` (iOS test fixture builder) had the same CFBoolean blind spot — without fixing it the corpus case would have passed vacuously (bool collapsed identically on both sides of the assertion). Fixed.
- `ConverterAssertions` now asserts the bool type tag before comparing, so a future collapse fails with a clear message instead of trapping inside `getBoolean` on a double.

## Verification

- iOS: `NitroGoogleCastTests` **27/27 pass** on iphonesimulator (iPhone 17), rebased on latest `v5` (385301f). Red check: with only the production converter change reverted, `MediaTrackConverterTests` + `MediaInfoConverterTests` **fail** — the corpus cases genuinely pin the bug.
- Android: `:react-native-google-cast:compileDebugKotlin` green.
- `yarn test` 307/307, `yarn typescript` clean. (Repo-wide `yarn lint` baseline is broken pre-existing; untouched.)

Tracked internally as v5-mc9.4.

Fixes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean values in custom media data are now preserved correctly during conversion instead of being changed to numeric values.
  * Round-tripping media information and tracks now retains boolean fields such as live status, authentication requirements, default status, and forced status.

* **Tests**
  * Added coverage for boolean custom data to prevent type mismatches and conversion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->