### PR TITLE
fix(v5): T6 threading policy + async request ownership — audit, gap fixes, codified policy (v5-pk0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,42 @@ yarn bootstrap       # set up example + playground apps (incl. pods)
 - Run `yarn typescript`, `yarn lint`, and `yarn test` before opening a PR.
 - Follow existing patterns in `src/`; match surrounding style.
 
+## Native threading & async-request policy (v5)
+
+Binding rules for all native code in `ios/NitroGoogleCast/` and
+`android/src/main/java/com/margelo/nitro/googlecast/`. The two transports
+(`HybridCastTransport.swift` / `HybridCastTransport.kt`) are the reference implementations.
+
+1. **All GCK/MediaRouter access on the main thread.** Every SDK call, every listener
+   add/remove, and every session/client resolution happens inside a main-thread hop
+   (`DispatchQueue.main.async` / `runOnMain`) — Nitro methods are entered on the JS thread and
+   must hop before touching the SDK. Enforced mechanically where cheap:
+   `dispatchPrecondition(.onQueue(.main))` (iOS) and `MainThread.assertMainThread` (Android,
+   debuggable hosts only) guard the listener registries and attach/detach/flush helpers.
+2. **Never cache a session handle for later use (Invariant 1).** Re-resolve
+   `currentCastSession` / `remoteMediaClient` from the GCK singletons inside the hop on every
+   call. The only stored handles are the _listener-attachment_ trackers
+   (`attachedMediaClient` / `observedClient`, etc.), which exist solely so detach targets the
+   exact instance attach used — never for issuing operations.
+3. **Async requests settle exactly once and never outlive their session.** Copy the canonical
+   pattern — `CastRequestDelegate` + `track()` (iOS), `TrackedCastRequest` + `track()`
+   (Android): every `GCKRequest` / `PendingResult` is retained in the transport's
+   `pendingRequests` registry until settled; the first of {result, failure, abort, external
+   cancel} wins and later callbacks are no-ops; the transport flushes stragglers (reject
+   `interrupted` + GCK-cancel) on session end, session suspend, and `dispose()` (RN reload),
+   so a JS promise can never hang on a dead session. Never fire-and-forget a request.
+4. **JS callbacks: main thread, no locks, no dead contexts.** The stored `initAndSubscribe`
+   callbacks are invoked from the main thread only and never while any lock is held;
+   `dispose()` nulls them (and detaches the debug seam) so nothing fires into a torn-down JS
+   runtime. Any state read synchronously from the JS thread but written on main must be
+   `@Volatile` (Android) / lock-boxed (iOS `AtomicFlag`); everything else stays
+   single-thread-affine.
+
+Teardown invariants — all must hold after session end/suspend AND after `dispose()`: every
+listener detached from the exact instance it attached to (attach/detach symmetric), channel
+registries cleared, pending requests flushed, and (dispose only, with a strong self-capture so
+cleanup cannot be skipped) callbacks nulled.
+
 ## Task tracking (maintainers — optional)
 
 Maintainers coordinate v5 work with **beads** (`bd`), a local dependency-aware task graph. This is

--- a/android/src/main/java/com/margelo/nitro/googlecast/CastButtonRegistry.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/CastButtonRegistry.kt
@@ -21,18 +21,21 @@ internal object CastButtonRegistry {
 
   /** Called on attach-to-window. Re-registering moves [button] to the end (last-attached wins). */
   fun register(button: MediaRouteButton) {
+    MainThread.assertMainThread("CastButtonRegistry.register")
     remove(button)
     buttons.add(WeakReference(button))
   }
 
   /** Called on detach-from-window and `onDropView`. Idempotent. */
   fun unregister(button: MediaRouteButton) {
+    MainThread.assertMainThread("CastButtonRegistry.unregister")
     remove(button)
   }
 
   /** The overlay anchor: the last-attached button still attached and visible, else `null`. */
   val current: MediaRouteButton?
     get() {
+      MainThread.assertMainThread("CastButtonRegistry.current")
       val anchor =
         buttons.lastOrNull { ref ->
           val button = ref.get()

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -22,12 +22,10 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.api.PendingResult
-import com.google.android.gms.common.api.Status
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.AnyMap
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.googlecast.converters.CastRejection
-import com.margelo.nitro.googlecast.converters.castErrorCodeFromGckStatusCode
 import com.margelo.nitro.googlecast.converters.castErrorFromStatusCode
 import com.margelo.nitro.googlecast.converters.castRejectionJson
 import com.margelo.nitro.googlecast.converters.fromGckConnectionResult
@@ -75,11 +73,6 @@ class HybridCastTransport : HybridCastTransportSpec() {
   // session before starting its replacement). Main thread only.
   private val channels = mutableMapOf<String, Cast.MessageReceivedCallback>()
 
-  // In-flight sendMessage results, so dispose can cancel them (mirrors
-  // `pendingResults`; sendMessage returns PendingResult<Status>, not
-  // MediaChannelResult, hence the separate set).
-  private val pendingChannelResults = mutableSetOf<PendingResult<Status>>()
-
   private var castStateListener: CastStateListener? = null
   private var sessionListener: SessionManagerListener<CastSession>? = null
   private var routerCallback: MediaRouter.Callback? = null
@@ -98,9 +91,11 @@ class HybridCastTransport : HybridCastTransportSpec() {
   private var castListener: Cast.Listener? = null
   private var observedCastSession: CastSession? = null
 
-  // In-flight media `PendingResult`s, so teardown can cancel them (and drop our settlement
-  // closures). Main-thread only — no extra synchronization needed.
-  private val pendingResults = mutableSetOf<PendingResult<RemoteMediaClient.MediaChannelResult>>()
+  // Every in-flight GCK request (media calls AND channel sendMessage), retained as a
+  // [TrackedCastRequest] until it settles, so session end/suspend/dispose can flush the
+  // stragglers with an `interrupted` rejection (T6 — mirrors the iOS `pendingRequests`
+  // set of `CastRequestDelegate`s). Main-thread only — no extra synchronization needed.
+  private val pendingRequests = mutableSetOf<TrackedCastRequest>()
 
   @Volatile private var cachedCastState: CastState = CastState.NOTCONNECTED
   @Volatile private var cachedDiscovering = false
@@ -247,11 +242,10 @@ class HybridCastTransport : HybridCastTransportSpec() {
       detachMediaCallback()
       detachCastListener()
       clearChannels(sharedCastContextOrNull()?.sessionManager?.currentCastSession)
-      // Cancel any in-flight media requests; JS is going away so the promises need not settle.
-      pendingResults.forEach { it.cancel() }
-      pendingResults.clear()
-      pendingChannelResults.forEach { it.cancel() }
-      pendingChannelResults.clear()
+      // Reject + cancel any in-flight requests so no promise outlives the transport
+      // (same `interrupted` contract as iOS; the JS side of a reload is going away,
+      // but settling is free and keeps the exactly-once invariant unconditional).
+      flushPendingRequests("interrupted", "The Cast transport was disposed.")
       onState = null
       onDevices = null
       onLifecycle = null
@@ -436,24 +430,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
           return@runOnMain
         }
       // A2-minor: await the PendingResult — never fire-and-forget a send.
-      pendingChannelResults.add(pending)
-      pending.setResultCallback { result ->
-        pendingChannelResults.remove(pending)
-        val status = result.status
-        if (status.isSuccess) {
-          promise.resolve(Unit)
-        } else {
-          promise.reject(
-            CastRejection(
-              castRejectionJson(
-                castErrorCodeFromGckStatusCode(status.statusCode),
-                status.statusMessage,
-                status.statusCode
-              )
-            )
-          )
-        }
-      }
+      track(pending, promise)
     }
     return promise
   }
@@ -791,26 +768,42 @@ class HybridCastTransport : HybridCastTransportSpec() {
           promise.reject(CastRejection(castRejectionJson("failed", e.message, null)))
           return@runOnMain
         }
-      pendingResults.add(pending)
-      pending.setResultCallback { result ->
-        pendingResults.remove(pending)
-        val status = result.status
-        if (status.isSuccess) {
-          promise.resolve(Unit)
-        } else {
-          promise.reject(
-            CastRejection(
-              castRejectionJson(
-                castErrorCodeFromGckStatusCode(status.statusCode),
-                status.statusMessage,
-                status.statusCode
-              )
-            )
-          )
-        }
-      }
+      track(pending, promise)
     }
     return promise
+  }
+
+  /**
+   * Retain [pending] in the [pendingRequests] registry (via a [TrackedCastRequest]) until its
+   * single result callback settles [promise] exactly once — or until [flushPendingRequests]
+   * rejects it on session end/suspend/dispose. Main thread.
+   */
+  private fun <R : com.google.android.gms.common.api.Result> track(
+    pending: PendingResult<R>,
+    promise: Promise<Unit>
+  ) {
+    MainThread.assertMainThread("track")
+    val tracked =
+      TrackedCastRequest(
+        resolve = { promise.resolve(Unit) },
+        reject = promise::reject,
+        onSettled = { pendingRequests.remove(it) },
+      )
+    pendingRequests.add(tracked)
+    tracked.track(pending)
+  }
+
+  /**
+   * Reject (and GCK-cancel) every still-pending request. Called on session end/suspend and on
+   * dispose so a caller's promise never hangs after the session/client it targeted is gone
+   * (T6 — mirrors the iOS `flushPendingRequests`). Main thread.
+   */
+  private fun flushPendingRequests(code: String, message: String) {
+    MainThread.assertMainThread("flushPendingRequests")
+    if (pendingRequests.isEmpty()) return
+    val flushed = pendingRequests.toList()
+    pendingRequests.clear()
+    flushed.forEach { it.cancel(code, message) }
   }
 
   private fun remoteMediaClientOrNull(): RemoteMediaClient? =
@@ -818,6 +811,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
 
   /** Register the media-status listener on [client], replacing any previous registration. */
   private fun attachMediaCallback(client: RemoteMediaClient?) {
+    MainThread.assertMainThread("attachMediaCallback")
     if (client == null || observedClient === client) return
     detachMediaCallback()
     val callback =
@@ -877,6 +871,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
   }
 
   private fun detachMediaCallback() {
+    MainThread.assertMainThread("detachMediaCallback")
     val callback = mediaCallback ?: return
     observedClient?.unregisterCallback(callback)
     mediaCallback = null
@@ -893,6 +888,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
    * Mirrors [attachMediaCallback]: nullable session + `observedCastSession` idempotency guard.
    */
   private fun attachCastListener(session: CastSession?) {
+    MainThread.assertMainThread("attachCastListener")
     if (session == null || observedCastSession === session) return
     detachCastListener()
     val listener =
@@ -918,6 +914,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
   }
 
   private fun detachCastListener() {
+    MainThread.assertMainThread("detachCastListener")
     val listener = castListener ?: return
     observedCastSession?.removeCastListener(listener)
     castListener = null
@@ -931,6 +928,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
    * next session, per the guide.
    */
   private fun clearChannels(session: CastSession?) {
+    MainThread.assertMainThread("clearChannels")
     if (channels.isEmpty()) return
     channels.keys.forEach { namespace ->
       try {
@@ -1023,6 +1021,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
         detachMediaCallback()
         detachCastListener()
         clearChannels(session)
+        flushPendingRequests("interrupted", "The Cast session ended.")
         emit(
           SessionEventType.ENDED,
           error = if (error != 0) castErrorFromStatusCode(error, null) else null
@@ -1038,9 +1037,13 @@ class HybridCastTransport : HybridCastTransportSpec() {
       override fun onSessionResumeFailed(session: CastSession, error: Int) =
         emit(SessionEventType.RESUMEFAILED, error = castErrorFromStatusCode(error, null))
       override fun onSessionSuspended(session: CastSession, reason: Int) {
+        // TS treats `suspended` as a teardown (see `session.slice`), so flush pending
+        // requests here too — a suspended session's requests would otherwise hang until
+        // (if ever) GCK settles them. Listeners re-attach on `onSessionResumed`.
         detachMediaCallback()
         detachCastListener()
         clearChannels(session)
+        flushPendingRequests("interrupted", "The Cast session ended.")
         emit(SessionEventType.SUSPENDED, reason = suspendReason(reason))
       }
     }

--- a/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/HybridCastTransport.kt
@@ -1043,7 +1043,7 @@ class HybridCastTransport : HybridCastTransportSpec() {
         detachMediaCallback()
         detachCastListener()
         clearChannels(session)
-        flushPendingRequests("interrupted", "The Cast session ended.")
+        flushPendingRequests("interrupted", "The Cast session was suspended.")
         emit(SessionEventType.SUSPENDED, reason = suspendReason(reason))
       }
     }

--- a/android/src/main/java/com/margelo/nitro/googlecast/MainThread.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/MainThread.kt
@@ -1,0 +1,39 @@
+package com.margelo.nitro.googlecast
+
+import android.content.pm.ApplicationInfo
+import android.os.Looper
+import com.margelo.nitro.NitroModules
+
+/**
+ * Debug-only main-thread assertion — the Android analogue of the iOS
+ * `dispatchPrecondition(condition: .onQueue(.main))` calls (threading policy:
+ * all GCK access and every listener-registry mutation is main-thread-only).
+ *
+ * Armed only when the *host app* is debuggable (same gating as
+ * [CastDebugEventSink] — a source-built library has no compile-time debug
+ * split of its own): a debug app crashes loudly on a violation, a release app
+ * skips the check entirely.
+ */
+internal object MainThread {
+  // `Throwable` (not `Exception`): touching `NitroModules` class-loads Nitro's
+  // native library, which throws `UnsatisfiedLinkError` in a JVM unit test —
+  // an assertion helper must never be the thing that crashes a test host.
+  private val isHostDebuggable: Boolean
+    get() =
+      try {
+        val context = NitroModules.applicationContext
+        context != null &&
+          (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+      } catch (t: Throwable) {
+        false
+      }
+
+  /** Asserts [what] is running on the main thread (debuggable hosts only). */
+  fun assertMainThread(what: String) {
+    val mainLooper = Looper.getMainLooper() ?: return // JVM test host — no looper
+    if (!isHostDebuggable) return
+    check(Looper.myLooper() == mainLooper) {
+      "$what must run on the main thread (was: ${Thread.currentThread().name})"
+    }
+  }
+}

--- a/android/src/main/java/com/margelo/nitro/googlecast/TrackedCastRequest.kt
+++ b/android/src/main/java/com/margelo/nitro/googlecast/TrackedCastRequest.kt
@@ -1,0 +1,86 @@
+package com.margelo.nitro.googlecast
+
+import com.google.android.gms.common.api.PendingResult
+import com.google.android.gms.common.api.Result
+import com.google.android.gms.common.api.Status
+import com.margelo.nitro.googlecast.converters.CastRejection
+import com.margelo.nitro.googlecast.converters.castErrorCodeFromGckStatusCode
+import com.margelo.nitro.googlecast.converters.castRejectionJson
+
+/**
+ * Bridges a single in-flight GCK [PendingResult] to one promise, settling it
+ * **exactly once** (T6 async-request ownership). Android mirror of the iOS
+ * `CastRequestDelegate`.
+ *
+ * Ownership model:
+ * - The transport retains this object in its `pendingRequests` registry until it
+ *   settles; [onSettled] releases the registry slot the instant it does.
+ * - The first of {result callback, external cancel} wins; every later call is a
+ *   no-op thanks to the `settled` guard.
+ * - [cancel] lets the transport reject still-pending requests on session
+ *   end/suspend and on `dispose()` (RN reload). It also cancels the GCK
+ *   [PendingResult], which per the SDK contract suppresses a later result
+ *   callback — but the `settled` guard alone already makes one harmless.
+ *
+ * All access is main-thread (every request here is issued on the main thread and
+ * GMS delivers result callbacks on the main thread), so the mutable
+ * `settled`/`pending` state needs no locking.
+ *
+ * The promise is injected as [resolve]/[reject] lambdas (not a Nitro `Promise`)
+ * solely so the exactly-once contract is JVM-unit-testable — Nitro's `Promise`
+ * is JNI-backed and cannot be constructed off-device.
+ */
+internal class TrackedCastRequest(
+  private val resolve: () -> Unit,
+  private val reject: (Throwable) -> Unit,
+  private val onSettled: (TrackedCastRequest) -> Unit,
+) {
+  private var pending: PendingResult<*>? = null
+  private var settled = false
+
+  /** Retain [pending] and subscribe its single result callback. Main thread. */
+  fun <R : Result> track(pending: PendingResult<R>) {
+    this.pending = pending
+    pending.setResultCallback { result -> onResult(result.status) }
+  }
+
+  /**
+   * Reject a still-pending request from outside (session teardown / dispose)
+   * and cancel the underlying GCK request. No-op once settled. Main thread.
+   */
+  fun cancel(code: String, message: String) {
+    settle {
+      pending?.cancel()
+      reject(CastRejection(castRejectionJson(code, message, null)))
+    }
+  }
+
+  private fun onResult(status: Status) {
+    settle {
+      if (status.isSuccess) {
+        resolve()
+      } else {
+        reject(
+          CastRejection(
+            castRejectionJson(
+              castErrorCodeFromGckStatusCode(status.statusCode),
+              status.statusMessage,
+              status.statusCode
+            )
+          )
+        )
+      }
+    }
+  }
+
+  private inline fun settle(body: () -> Unit) {
+    if (settled) return
+    settled = true
+    try {
+      body()
+    } finally {
+      pending = null
+      onSettled(this)
+    }
+  }
+}

--- a/android/src/test/java/com/margelo/nitro/googlecast/TrackedCastRequestTest.kt
+++ b/android/src/test/java/com/margelo/nitro/googlecast/TrackedCastRequestTest.kt
@@ -1,0 +1,115 @@
+package com.margelo.nitro.googlecast
+
+import com.google.android.gms.common.api.PendingResult
+import com.google.android.gms.common.api.ResultCallback
+import com.google.android.gms.common.api.Status
+import com.margelo.nitro.googlecast.converters.CastRejection
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the exactly-once settlement contract of [TrackedCastRequest] (T6 async-request
+ * ownership): first of {result, cancel} wins, later calls are no-ops, the GCK
+ * [PendingResult] is cancelled only by an external cancel, and the registry slot
+ * ([onSettled]) is released exactly once. Plain JUnit — the class is main-thread-affine
+ * but has no Looper/Handler dependency.
+ */
+class TrackedCastRequestTest {
+
+  private class FakePendingResult : PendingResult<Status>() {
+    var callback: ResultCallback<in Status>? = null
+    var cancelled = false
+
+    override fun await(): Status = throw UnsupportedOperationException()
+    override fun await(time: Long, units: TimeUnit): Status = throw UnsupportedOperationException()
+    override fun cancel() {
+      cancelled = true
+    }
+    override fun isCanceled(): Boolean = cancelled
+    override fun setResultCallback(callback: ResultCallback<in Status>) {
+      this.callback = callback
+    }
+    override fun setResultCallback(
+      callback: ResultCallback<in Status>,
+      time: Long,
+      units: TimeUnit
+    ) {
+      this.callback = callback
+    }
+  }
+
+  private class Harness {
+    var resolves = 0
+    val rejections = mutableListOf<Throwable>()
+    val settled = mutableListOf<TrackedCastRequest>()
+    val pending = FakePendingResult()
+    val request =
+      TrackedCastRequest(
+        resolve = { resolves++ },
+        reject = { rejections.add(it) },
+        onSettled = { settled.add(it) },
+      )
+
+    init {
+      request.track(pending)
+    }
+
+    fun deliver(status: Status) {
+      pending.callback!!.onResult(status)
+    }
+  }
+
+  @Test
+  fun `success resolves exactly once`() {
+    val h = Harness()
+    h.deliver(Status(0))
+    h.deliver(Status(0)) // duplicate delivery must be a no-op
+    assertEquals(1, h.resolves)
+    assertEquals(0, h.rejections.size)
+    assertEquals(listOf(h.request), h.settled)
+  }
+
+  @Test
+  fun `failure rejects exactly once with the GCK status code`() {
+    val h = Harness()
+    h.deliver(Status(2103, "interrupted by new request"))
+    assertEquals(0, h.resolves)
+    assertEquals(1, h.rejections.size)
+    val rejection = h.rejections.single()
+    assertTrue(rejection is CastRejection)
+    assertNotNull(rejection.message)
+    assertTrue("carries nativeCode", rejection.message!!.contains("2103"))
+    assertEquals(listOf(h.request), h.settled)
+  }
+
+  @Test
+  fun `external cancel rejects the promise and cancels the GCK request`() {
+    val h = Harness()
+    h.request.cancel("interrupted", "The Cast session ended.")
+    assertTrue(h.pending.cancelled)
+    assertEquals(0, h.resolves)
+    assertEquals(1, h.rejections.size)
+    assertTrue(h.rejections.single().message!!.contains("interrupted"))
+    assertEquals(listOf(h.request), h.settled)
+    // A straggler result after cancel must be swallowed (settled guard).
+    h.deliver(Status(0))
+    assertEquals(0, h.resolves)
+    assertEquals(1, h.rejections.size)
+    assertEquals(1, h.settled.size)
+  }
+
+  @Test
+  fun `cancel after settlement is a no-op and does not cancel the GCK request`() {
+    val h = Harness()
+    h.deliver(Status(0))
+    h.request.cancel("interrupted", "The Cast transport was disposed.")
+    assertFalse(h.pending.cancelled)
+    assertEquals(1, h.resolves)
+    assertEquals(0, h.rejections.size)
+    assertEquals(1, h.settled.size)
+  }
+}

--- a/ios/NitroGoogleCast/HybridCastTransport.swift
+++ b/ios/NitroGoogleCast/HybridCastTransport.swift
@@ -62,17 +62,21 @@ final class HybridCastTransport: HybridCastTransportSpec {
   private var deviceStatusListener: CastDeviceStatusListener?
   private weak var attachedStatusSession: GCKCastSession?
 
+  // Main-thread-only cache (written and read exclusively inside main-queue hops).
   private var cachedCastState: CastState = .notconnected
-  private var cachedDiscovering = false
-  private var cachedPassiveScan = false
+  // Cross-thread cached flags: written on the main thread inside the GCK hops,
+  // read synchronously from the JS thread by the `is*` accessors below — so they
+  // are lock-boxed (the Swift analogue of the Android transport's `@Volatile`).
+  private let cachedDiscovering = AtomicFlag(false)
+  private let cachedPassiveScan = AtomicFlag(false)
 
   override init() { super.init() }
 
   // iOS has no Play-Services gating; casting is available once GCKCastContext is
   // configured at launch (the v5 SDK-init step).
   var isAvailable: Bool { true }
-  var isDiscovering: Bool { cachedDiscovering }
-  var isPassiveScan: Bool { cachedPassiveScan }
+  var isDiscovering: Bool { cachedDiscovering.load() }
+  var isPassiveScan: Bool { cachedPassiveScan.load() }
 
   // MARK: - init + subscribe (atomic, main thread)
 
@@ -124,7 +128,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
       self.attachDeviceStatusListener()
 
       self.cachedCastState = Self.mapState(context.castState)
-      self.cachedPassiveScan = context.discoveryManager.passiveScan
+      self.cachedPassiveScan.store(context.discoveryManager.passiveScan)
       let devices = self.readDevices(context.discoveryManager)
       let currentCastSession = context.sessionManager.currentCastSession
       let current = Self.sessionInfo(currentCastSession)
@@ -147,6 +151,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   }
 
   private func attachObservers(_ context: GCKCastContext) {
+    dispatchPrecondition(condition: .onQueue(.main))
     guard !listenersAttached else { return }
     listenersAttached = true
 
@@ -180,6 +185,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   }
 
   private func detachObservers() {
+    dispatchPrecondition(condition: .onQueue(.main))
     guard listenersAttached else { return }
     listenersAttached = false
     let context = GCKCastContext.sharedInstance()
@@ -198,10 +204,16 @@ final class HybridCastTransport: HybridCastTransportSpec {
   }
 
   /// Override of `HybridObject.dispose()` — detach every GCK observer.
+  ///
+  /// Deliberate STRONG capture: `dispose()` is Nitro's final call before it
+  /// releases this object, so a `[weak self]` hop could find the transport
+  /// already deallocated and silently skip teardown — leaking the
+  /// NotificationCenter observer and stranding selfRetained
+  /// `CastRequestDelegate`s whose promises then never settle. The block keeps
+  /// `self` alive exactly until cleanup completes on the main thread.
   func dispose() {
     CastDebugEventSink.detach()
-    DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
+    DispatchQueue.main.async {
       self.detachObservers()
       self.detachMediaListener()
       self.detachDeviceStatusListener()
@@ -598,6 +610,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   }
 
   private func track(_ request: GCKRequest, _ promise: Promise<Void>) {
+    dispatchPrecondition(condition: .onQueue(.main))
     let delegate = CastRequestDelegate(promise: promise) { [weak self] settled in
       self?.pendingRequests.remove(settled)
     }
@@ -623,6 +636,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   /// Bind the media-status listener to the current session's media client. Idempotent
   /// for a given client; re-resolves the client per call. Main thread.
   private func attachMediaListener() {
+    dispatchPrecondition(condition: .onQueue(.main))
     guard
       let client = GCKCastContext.sharedInstance().sessionManager.currentCastSession?
         .remoteMediaClient
@@ -644,6 +658,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   }
 
   private func detachMediaListener() {
+    dispatchPrecondition(condition: .onQueue(.main))
     if let client = attachedMediaClient, let listener = mediaStatusListener {
       client.remove(listener)
     }
@@ -654,6 +669,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   /// a given session; re-resolves the session per call (Invariant 1). Main thread.
   /// Mirrors `attachMediaListener`.
   private func attachDeviceStatusListener() {
+    dispatchPrecondition(condition: .onQueue(.main))
     guard let session = GCKCastContext.sharedInstance().sessionManager.currentCastSession
     else { return }
     guard attachedStatusSession !== session else { return }
@@ -669,6 +685,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   }
 
   private func detachDeviceStatusListener() {
+    dispatchPrecondition(condition: .onQueue(.main))
     if let session = attachedStatusSession, let listener = deviceStatusListener {
       session.remove(listener)
     }
@@ -680,6 +697,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   /// (`willEnd` fires while it does); otherwise GCK already dropped the channel
   /// with the session and we only release our strong refs.
   private func clearChannels() {
+    dispatchPrecondition(condition: .onQueue(.main))
     guard !channels.isEmpty else { return }
     let session = GCKCastContext.sharedInstance().sessionManager.currentCastSession
     for channel in channels.values { session?.remove(channel) }
@@ -689,6 +707,7 @@ final class HybridCastTransport: HybridCastTransportSpec {
   /// Reject every still-pending media request. Used on session end / teardown so a
   /// caller's promise never hangs after the client it targeted is gone (T6). Main thread.
   private func flushPendingRequests(code: String, message: String) {
+    dispatchPrecondition(condition: .onQueue(.main))
     let pending = pendingRequests
     pendingRequests.removeAll()
     for delegate in pending { delegate.cancel(code: code, message: message) }
@@ -699,21 +718,21 @@ final class HybridCastTransport: HybridCastTransportSpec {
   func startDiscovery() throws {
     DispatchQueue.main.async { [weak self] in
       GCKCastContext.sharedInstance().discoveryManager.startDiscovery()
-      self?.cachedDiscovering = true
+      self?.cachedDiscovering.store(true)
     }
   }
 
   func stopDiscovery() throws {
     DispatchQueue.main.async { [weak self] in
       GCKCastContext.sharedInstance().discoveryManager.stopDiscovery()
-      self?.cachedDiscovering = false
+      self?.cachedDiscovering.store(false)
     }
   }
 
   func setPassiveScan(passive: Bool) throws {
     DispatchQueue.main.async { [weak self] in
       GCKCastContext.sharedInstance().discoveryManager.passiveScan = passive
-      self?.cachedPassiveScan = passive
+      self?.cachedPassiveScan.store(passive)
     }
   }
 
@@ -845,6 +864,32 @@ final class HybridCastTransport: HybridCastTransportSpec {
     case .networkError: return "networkError"
     default: return "other"
     }
+  }
+}
+
+// MARK: - cross-thread flag box
+
+/// Lock-boxed `Bool` — the Swift analogue of the Android transport's `@Volatile`
+/// cached flags. Written on the main thread inside the GCK hops; read
+/// synchronously from the JS thread by the Nitro property accessors. Never hold
+/// the lock while calling out (the box only stores/loads the raw value), so no
+/// JS callback can ever run with a lock held.
+private final class AtomicFlag {
+  private let lock = NSLock()
+  private var value: Bool
+
+  init(_ value: Bool) { self.value = value }
+
+  func load() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+
+  func store(_ newValue: Bool) {
+    lock.lock()
+    defer { lock.unlock() }
+    value = newValue
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the Phase 0/1 bead **v5-pk0 / T6** (threading policy + async request ownership): audited both native transports against the policy, fixed the three concrete violations found, and codified the policy in AGENTS.md with mechanical main-thread assertions on both platforms.

Fixes #605

## Audit findings (surface → verdict)

| Surface | iOS | Android |
|---|---|---|
| Session lifecycle listeners (attach/detach symmetry) | OK | OK |
| Media calls incl. new customData / queueInsertAndPlay (main-thread hop, per-call re-resolution) | OK | OK |
| GCKRequest retention + exactly-once settle | OK (CastRequestDelegate) | OK (result callback), **fixed**: no teardown flush |
| Pending-request flush on session end/suspend | OK (`flushPendingRequests` in onSessionInactive) | **Fixed** — was missing entirely; promises could hang on a dead session |
| Pending-request flush on dispose (RN reload) | OK | **Fixed** — PendingResults were cancelled but promises never settled |
| dispose() teardown reachability | **Fixed** — `[weak self]` hop could skip teardown (leaked NSNotificationCenter observer, stranded selfRetained delegates) | OK (strong `this` capture) |
| `isDiscovering`/`isPassiveScan` cross-thread reads | **Fixed** — unsynchronized main-write/JS-read; now lock-boxed (`AtomicFlag`) | OK (`@Volatile`) |
| Channels (registry cleared on end/suspend/dispose; sends awaited) | OK | OK (sendMessage now flows through the same tracked-request registry) |
| Discovery / volume / Cast UI methods / debug seam | OK | OK |
| JS callbacks (main thread only, never under a lock, nulled on dispose) | OK | OK |
| CastButtonRegistry main-thread affinity | OK (asserted already) | OK — assertion added |

## Changes

- **Android `TrackedCastRequest`** (mirror of iOS `CastRequestDelegate`): one unified `pendingRequests` registry for media + channel requests; exactly-once settle (first of {result, external cancel} wins); flush (`interrupted` rejection + GCK cancel) on `onSessionEnded`, `onSessionSuspended`, `dispose()`. JVM unit test pins the contract (4 tests).
- **iOS `dispose()`**: deliberate strong self-capture in the main-queue cleanup hop.
- **iOS `AtomicFlag`**: lock-boxed cached discovery flags (Swift analogue of `@Volatile`).
- **Mechanical enforcement**: `dispatchPrecondition(.onQueue(.main))` in all iOS listener/request helpers; new debug-gated `MainThread.assertMainThread` (armed only for debuggable host apps) in Android registry + listener/request helpers.
- **Policy codified**: "Native threading & async-request policy (v5)" section in AGENTS.md — the four rules, canonical patterns to copy, teardown invariants.

## Gates

- `yarn test` 316/316, `yarn typescript` clean
- `:react-native-google-cast:compileDebugKotlin` + `testDebugUnitTest` green (new `TrackedCastRequestTest` 4/4)
- `NitroGoogleCast` pod target compiles for iphonesimulator (BUILD SUCCEEDED)
- No Podfile.lock churn committed

## Device-gated follow-up (not blocking)

Real-hardware verification that GMS delivers `PendingResult` callbacks strictly on the main looper (assumed by the whole existing design, unchanged here) and that the new session-end flush rejections surface to JS in order — belongs to the Phase 6 device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a8e3UUediVEbMVa5414tr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Google Cast operations during session interruption, suspend, and disposal.
  * Pending Cast requests are now always settled exactly once, and unresolved requests are cancelled on teardown (“interrupted” behavior).
  * Strengthened main-thread execution guarantees for Cast controls and listener/discovery lifecycle, improving thread-safety and preventing duplicate completions.

* **Tests**
  * Added unit tests validating success, failure, cancellation, and duplicate result-delivery semantics for tracked Cast requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->