### PR TITLE
docs(v5): clarify MediaStatus.queueItems is a window, not the full queue

### DIFF
--- a/docs/guides/queueing.md
+++ b/docs/guides/queueing.md
@@ -60,12 +60,14 @@ client.loadMedia({
 
 ## Receive media queue status update
 
-When the receiver loads a media queue item, it assigns a unique ID to the item which persists for the duration of the session (and the life of the queue). You can learn the status of the queue indicating which item is currently loaded (it might not be playing), loading, or preloaded. You can also get an ordered list of all the items in the queue. The [MediaStatus](../api/interfaces/mediastatus) class provides this status information:
+When the receiver loads a media queue item, it assigns a unique ID to the item which persists for the duration of the session (and the life of the queue). You can learn the status of the queue indicating which item is currently loaded (it might not be playing), loading, or preloaded. The [MediaStatus](../api/interfaces/mediastatus) class provides this status information:
 
 - [preloadedItemId](../api/interfaces/mediastatus#optional-preloadeditemid) - The ID of the item that is currently preloaded, if any.
 - [loadingItemId](../api/interfaces/mediastatus#optional-loadingitemid) - The ID of the item that is currently loading.
 - [currentItemId](../api/interfaces/mediastatus#optional-currentitemid) - The ID of the current queue item, if any.
-- [queueItems](../api/interfaces/mediastatus#queueitems) - Returns the items in the playback queue.
+- [queueItems](../api/interfaces/mediastatus#queueitems) - The items the receiver reported in this status update. Note that this is only a limited window around the current item (typically the previous, current, and next items) — not the full queue.
+
+> Note: **Full queue access.** `queueItems` does not contain the entire queue — the receiver only reports a small window of it in each media status update. A paged `MediaQueue` API for accessing the full queue is planned for v5.x; follow [#618](https://github.com/react-native-google-cast/react-native-google-cast/issues/618) for progress.
 
 <!-- Use these members together with the other media status members to inform your app about the status of the queue and the items in the queue. In addition to media status updates from the receiver, you can listen for changes to the queue by implementing GCKRemoteMediaClientListener.remoteMediaClientDidUpdateQueue. -->
 

--- a/src/types/MediaStatus.ts
+++ b/src/types/MediaStatus.ts
@@ -51,7 +51,14 @@ export interface MediaStatus {
   /** The seekable range of a live media stream. Absent if the current media is not a seekable live stream. */
   liveSeekableRange?: MediaLiveSeekableRange
 
-  /** The list of items in the queue. */
+  /**
+   * The queue items the receiver reported in this status update.
+   *
+   * Note that this is only a limited window of the queue around the current item (typically the
+   * previous, current, and next items) — not the full queue. Full-queue access via a paged
+   * `MediaQueue` API is planned for v5.x; see
+   * [#618](https://github.com/react-native-google-cast/react-native-google-cast/issues/618).
+   */
   queueItems: MediaQueueItem[]
 
   /** The `itemId` of the {@linkcode MediaQueueItem} currently active in the queue (it may not be playing). */


### PR DESCRIPTION
## Summary

The docs overstated what `MediaStatus.queueItems` contains. Per Google's Cast SDK behavior, the receiver reports only a limited **window** of the queue in each media status update (typically the previous, current, and next items) — not the full queue. (Android's `MediaStatus.getQueueItems()` is deprecated in favor of the paged `MediaQueue` API for the same reason.)

This corrects the docs; no API or behavior changes:

- `docs/guides/queueing.md` — no longer claims `queueItems` is "an ordered list of all the items in the queue"; describes the window and adds a **Full queue access** note pointing at #618.
- `src/types/MediaStatus.ts` — `queueItems` doc-comment gets the same caveat + link to #618.

Full-queue paged `MediaQueue`/`useQueue` access is deferred to v5.x, tracked in #618 (see the decision comment there; closes out bead v5-mc9.3's honest-deferral follow-up).

## Gates

- `yarn typescript` — pass
- `yarn test` — 18 suites / 316 tests pass
- `yarn prettier --check` on touched files — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that queue status updates include only a limited window around the currently playing item.
  * Documented persistent queue item identifiers for the session or queue lifetime.
  * Clarified that full queue access is not available through queue status updates; a paged full-queue API is planned for a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->