### PR TITLE
ci(v5): skip emulator jobs on docs-only changes + retry flaky emulator boot (v5-74c)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,13 +39,15 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # 'every' = a changed file is android-relevant only if it matches ALL
+          # patterns: inside a runtime tree AND not a Markdown file. Docs-only
+          # changes never boot the emulator. 'every' allows only one positive
+          # pattern per filter, hence the brace-alternation glob.
+          predicate-quantifier: 'every'
           filters: |
             android:
-              - 'android/**'
-              - 'fixtures/converters/**'
-              - 'nitrogen/generated/android/**'
-              - 'example/android/**'
-              - '.github/workflows/android.yml'
+              - '{android/**,fixtures/converters/**,nitrogen/generated/android/**,example/android/**,.github/workflows/android.yml}'
+              - '!**/*.md'
 
   unit-tests:
     name: Robolectric parity (no emulator)
@@ -128,13 +130,36 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       # Build a single ABI matching the x86_64 emulator to keep the native build fast.
+      # Emulator boot on GitHub-hosted runners is flaky ("Timeout waiting for
+      # emulator to boot"), so: a longer boot timeout (900s vs the 600s default)
+      # plus one full retry with a freshly created AVD. Trade-off (accepted): a
+      # genuine test failure also runs twice — one extra emulator cycle on an
+      # already-red PR beats manual re-runs of boot flakes.
       - name: Run instrumented parity suite
+        id: instrumented-run
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
           arch: x86_64
           force-avd-creation: false
+          emulator-boot-timeout: 900
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          working-directory: example/android
+          script: ./gradlew :react-native-google-cast:connectedDebugAndroidTest -PreactNativeArchitectures=x86_64
+
+      - name: Run instrumented parity suite (retry after flaky boot)
+        if: steps.instrumented-run.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
+          arch: x86_64
+          # Recreate the AVD from scratch — the first attempt may have left it wedged.
+          force-avd-creation: true
+          emulator-boot-timeout: 900
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           working-directory: example/android

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,11 +25,21 @@ concurrency:
   group: android-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. The `changes` job re-grants
+# pull-requests: read for itself (paths-filter lists PR files via the API).
+permissions:
+  contents: read
+
 jobs:
   # Decide whether the (expensive) instrumented job needs to run.
   changes:
     name: Detect android changes
     runs-on: ubuntu-latest
+    # Job-level permissions replace the top-level map entirely, so contents:
+    # read must be restated for the checkout.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       android: ${{ steps.filter.outputs.android }}
     steps:

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -23,10 +23,20 @@ concurrency:
   group: e2e-android-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: these jobs only read the repo. The `changes` job re-grants
+# pull-requests: read for itself (paths-filter lists PR files via the API).
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect e2e-relevant changes
     runs-on: ubuntu-latest
+    # Job-level permissions replace the top-level map entirely, so contents:
+    # read must be restated for the checkout.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -36,14 +36,16 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # 'every' = a changed file is e2e-relevant only if it matches ALL
+          # patterns: inside a runtime tree AND not a Markdown file. Docs-only
+          # changes (docs/**, README/*.md anywhere, issue templates, LICENSE, …)
+          # therefore never boot the emulator. 'every' allows only one positive
+          # pattern per filter, hence the brace-alternation glob.
+          predicate-quantifier: 'every'
           filters: |
             e2e:
-              - 'android/**'
-              - 'src/**'
-              - 'example/**'
-              - 'nitrogen/generated/**'
-              - '.maestro/**'
-              - '.github/workflows/e2e-android.yml'
+              - '{android/**,src/**,example/**,nitrogen/generated/**,.maestro/**,.github/workflows/e2e-android.yml}'
+              - '!**/*.md'
 
   maestro:
     name: Tier-1 Maestro (emulator, fake seam)
@@ -96,13 +98,37 @@ jobs:
         working-directory: example/android
         run: ./gradlew :app:assembleDebug -PbundleInDebug=true -PreactNativeArchitectures=x86_64
 
+      # Emulator boot on GitHub-hosted runners is flaky ("Timeout waiting for
+      # emulator to boot"), so: a longer boot timeout (900s vs the 600s default)
+      # plus one full retry with a freshly created AVD. Trade-off (accepted): a
+      # genuine flow failure also runs twice — one extra emulator cycle on an
+      # already-red PR beats manual re-runs of boot flakes.
       - name: Run tier-1 Maestro flow
+        id: maestro-run
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis
           arch: x86_64
           force-avd-creation: false
+          emulator-boot-timeout: 900
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            adb install -r example/android/app/build/outputs/apk/debug/app-debug.apk
+            maestro test .maestro/tier1-fake-session.yml
+
+      - name: Run tier-1 Maestro flow (retry after flaky boot)
+        if: steps.maestro-run.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: google_apis
+          arch: x86_64
+          # Recreate the AVD from scratch — the first attempt may have left it wedged.
+          force-avd-creation: true
+          emulator-boot-timeout: 900
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,6 +23,10 @@ concurrency:
   group: ios-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: checkout + caches + artifact upload only read the repo.
+permissions:
+  contents: read
+
 jobs:
   xctest:
     name: XCTest converter parity


### PR DESCRIPTION
## Problem

PR #628 (docs-only: `docs/guides/queueing.md` + a doc-comment-only change in `src/types/MediaStatus.ts`) still ran the **Tier-1 Maestro (emulator, fake seam)** job and hit *"Timeout waiting for emulator to boot"* twice, needing manual reruns. Two independent issues:

1. The "Detect e2e-relevant changes" gate matched `*.md` files inside the runtime trees (`src/**`, `example/**`, …), so docs edits counted as e2e-relevant.
2. Emulator boot on GitHub-hosted runners is flaky, and there was no retry.

## Changes

### 1. Path filters — Markdown never boots an emulator (`android.yml` + `e2e-android.yml`)

Both `dorny/paths-filter@v3` gates now use `predicate-quantifier: 'every'`: a changed file counts only if it matches **all** patterns — the runtime-path glob AND `!**/*.md`. `'every'` allows a single positive pattern per filter, so the include list becomes one brace-alternation glob (same trees as before, nothing added or removed):

- `e2e-android.yml`: `{android/**,src/**,example/**,nitrogen/generated/**,.maestro/**,.github/workflows/e2e-android.yml}` + `!**/*.md`
- `android.yml` (instrumented): `{android/**,fixtures/converters/**,nitrogen/generated/android/**,example/android/**,.github/workflows/android.yml}` + `!**/*.md`

`docs/**`, `.github/ISSUE_TEMPLATE/**`, `LICENSE`, root `README.md`, etc. were already outside the positive globs and continue not to trigger; the new exclusion covers `*.md` **inside** the runtime trees (`src/README.md`, `example/README.md`, …).

**Considered and rejected:** detecting "comment-only" TS changes via diff parsing — too fragile to trust for gating real e2e coverage. A `src/**/*.ts` change (even doc-comment-only, like the one in #628) intentionally **stays** e2e-relevant.

### 2. Emulator-boot resilience (both `reactivecircus/android-emulator-runner@v2` steps)

- `emulator-boot-timeout: 900` (up from the 600s default; input exists on the pinned `@v2` tag — no version bump needed).
- One full retry: first attempt runs with `continue-on-error: true`; a second identical step runs only `if:` the first failed, with `force-avd-creation: true` so the retry gets a pristine AVD. `nick-fields/retry` was not used because it can only wrap `run:` steps, not a composite action. Trade-off (accepted): a genuinely failing test also runs twice, costing one extra emulator cycle on an already-red PR — better than manual reruns of boot flakes.

### 3. Least-privilege `GITHUB_TOKEN` (all three workflows, incl. `ios.yml`)

Follow-up to a CodeRabbit finding: the workflows inherited default token permissions. All three now set top-level `permissions: contents: read`; `ios.yml` had the same gap and is fixed for consistency. The two paths-filter `changes` jobs re-grant `pull-requests: read` at job level (required by `dorny/paths-filter` on `pull_request` events to list changed files via the REST API; `contents: read` restated since job-level permissions replace the top-level map). No other job needs write scopes — artifact upload/caches use the runtime token, `setup-gradle` only writes job summaries.

## Validation

- `actionlint` (via brew, v1.7.x): clean on all three workflow files (re-run after the permissions change); `js-yaml` parse: clean.
- Simulated the gate with dorny v3's **actual** matcher semantics (`picomatch@2.3.1` — the exact bundled version — with `{dot: true}` and `every`) on 17 representative paths: docs/md paths all skip; every previously-triggering runtime path still triggers; nothing outside the old globs newly triggers (e.g. `package.json`, `ios/**` remain non-matching for these gates). Confirmed `predicate-quantifier` and `emulator-boot-timeout` exist in the pinned actions' `action.yml`.

## CI expectations for THIS PR

This PR touches `.github/workflows/{android,e2e-android}.yml`, which are inside their own filters' positive globs — so the full suite (Maestro + instrumented emulator jobs) **should and will run here**. The docs-only skip can only be observed on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Android automated testing reliability by allowing longer emulator startup times.
  * Added automatic retry behavior that recreates the emulator when the initial test run fails.
  * Refined change detection so Android and end-to-end checks run only for relevant non-documentation updates.
  * These changes help deliver more consistent validation for future releases without changing app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
