### PR TITLE
chore(v5): repair lint gate + fix bob types path (v5-hsr, v5-ohe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,24 @@
       "@react-native",
       "prettier"
     ],
+    "plugins": [
+      "prettier"
+    ],
     "rules": {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "destructuredArrayIgnorePattern": "^_",
+          "ignoreRestSiblings": true
+        }
+      ],
+      "no-void": [
+        "warn",
+        {
+          "allowAsStatement": true
+        }
+      ],
       "prettier/prettier": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index",
   "react-native": "src/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "source": "src/index",
   "workspaces": [
     "example"

--- a/scripts/docsWatch.js
+++ b/scripts/docsWatch.js
@@ -8,7 +8,7 @@ chokidar
   })
   .on(
     'change',
-    debounce((path, stats) => {
+    debounce((path) => {
       if (!path) return
 
       compileDocs('--disableOutputCheck')

--- a/src/api/CastSession.ts
+++ b/src/api/CastSession.ts
@@ -107,9 +107,8 @@ export class CastSession {
    * @internal — not part of the public façade surface.
    */
   refreshDeviceFromStore(): void {
-    const current = this.store.getSliceState<SessionState>(
-      SESSION_SLICE_KEY
-    ).current
+    const current =
+      this.store.getSliceState<SessionState>(SESSION_SLICE_KEY).current
     if (current && current.generation === this.generation) {
       this.lastKnownDevice = current.device
     }

--- a/src/api/__tests__/RemoteMediaClient.test.ts
+++ b/src/api/__tests__/RemoteMediaClient.test.ts
@@ -19,9 +19,9 @@ import { RemoteMediaClient } from '../RemoteMediaClient'
 jest.mock('../../state/castStore.singleton', () => {
   const { CastStore: Store } = require('../../state/CastStore')
   const {
-    FakeCastTransport,
+    FakeCastTransport: Transport,
   } = require('../../transport/__fakes__/FakeCastTransport')
-  const transport = new FakeCastTransport()
+  const transport = new Transport()
   const store = new Store(transport)
   return { castStore: store, castTransport: transport }
 })

--- a/src/api/__tests__/channels.test.ts
+++ b/src/api/__tests__/channels.test.ts
@@ -6,12 +6,12 @@ import { SessionManager } from '../SessionManager'
 // CastSession → RemoteMediaClient transitively pulls the native singleton;
 // swap it for a fake-backed one (same pattern as facades.test.ts).
 jest.mock('../../state/castStore.singleton', () => {
-  const { CastStore } = require('../../state/CastStore')
+  const { CastStore: Store } = require('../../state/CastStore')
   const {
-    FakeCastTransport,
+    FakeCastTransport: Transport,
   } = require('../../transport/__fakes__/FakeCastTransport')
-  const transport = new FakeCastTransport()
-  const store = new CastStore(transport)
+  const transport = new Transport()
+  const store = new Store(transport)
   return { castStore: store, castTransport: transport }
 })
 

--- a/src/api/__tests__/facades.test.ts
+++ b/src/api/__tests__/facades.test.ts
@@ -11,12 +11,12 @@ import { RemoteMediaClient } from '../RemoteMediaClient'
 // these tests drive their own `setup()` store, not this singleton. Mirrors
 // `RemoteMediaClient.test.ts` / `mediaHooks.test.ts`.
 jest.mock('../../state/castStore.singleton', () => {
-  const { CastStore } = require('../../state/CastStore')
+  const { CastStore: Store } = require('../../state/CastStore')
   const {
-    FakeCastTransport,
+    FakeCastTransport: Transport,
   } = require('../../transport/__fakes__/FakeCastTransport')
-  const transport = new FakeCastTransport()
-  const store = new CastStore(transport)
+  const transport = new Transport()
+  const store = new Store(transport)
   return { castStore: store, castTransport: transport }
 })
 

--- a/src/api/__tests__/mediaHooks.test.ts
+++ b/src/api/__tests__/mediaHooks.test.ts
@@ -29,8 +29,8 @@ jest.mock('../../state/castStore.singleton', () => {
 let mockNow = 0
 jest.mock('../../state/progressTicker.singleton', () => {
   const { ProgressTicker } = require('../../state/progressTicker')
-  const { castStore } = require('../../state/castStore.singleton')
-  return { progressTicker: new ProgressTicker(castStore, () => mockNow) }
+  const { castStore: store } = require('../../state/castStore.singleton')
+  return { progressTicker: new ProgressTicker(store, () => mockNow) }
 })
 
 const transport = castTransport as unknown as FakeCastTransport
@@ -177,14 +177,14 @@ describe('useStreamPosition — ticking', () => {
     })
 
     const observed: (number | null)[] = []
-    function Probe(): null {
+    function PositionProbe(): null {
       observed.push(useStreamPosition(1))
       return null
     }
 
     let root!: TestRenderer.ReactTestRenderer
     await act(async () => {
-      root = TestRenderer.create(React.createElement(Probe))
+      root = TestRenderer.create(React.createElement(PositionProbe))
     })
 
     expect(observed[observed.length - 1]).toBeNull()
@@ -199,14 +199,16 @@ describe('useStreamPosition — ticking', () => {
     jest.useFakeTimers()
     mockNow = 0
     const observed: (number | null)[] = []
-    function Probe({ interval }: { interval: number }): null {
+    function IntervalProbe({ interval }: { interval: number }): null {
       observed.push(useStreamPosition(interval))
       return null
     }
 
     let root!: TestRenderer.ReactTestRenderer
     await act(async () => {
-      root = TestRenderer.create(React.createElement(Probe, { interval: 1 }))
+      root = TestRenderer.create(
+        React.createElement(IntervalProbe, { interval: 1 })
+      )
     })
     act(() => {
       transport.emitLifecycle({ type: 'started', session: session('ivl') })
@@ -216,7 +218,7 @@ describe('useStreamPosition — ticking', () => {
     // Re-render with a new interval → the effect deps change, so it must tear
     // down the old subscription and re-subscribe (not stay torn down).
     await act(async () => {
-      root.update(React.createElement(Probe, { interval: 2 }))
+      root.update(React.createElement(IntervalProbe, { interval: 2 }))
     })
 
     // Advance the ticker's clock + fire the timer; the position must still be a

--- a/src/components/__tests__/CastButton.test.tsx
+++ b/src/components/__tests__/CastButton.test.tsx
@@ -11,9 +11,9 @@ import { CastButton as CastButtonWeb } from '../CastButton.web'
 // jest cannot provide — stub it with a recording host component.
 jest.mock('react-native-nitro-modules', () => ({
   getHostComponent: jest.fn(() => {
-    const React = require('react')
+    const ReactLocal = require('react')
     return (props: Record<string, unknown>) =>
-      React.createElement('NativeCastButton', props)
+      ReactLocal.createElement('NativeCastButton', props)
   }),
 }))
 


### PR DESCRIPTION
Toolchain-repair lane covering beads **v5-hsr** (lint gate) and **v5-ohe** (bob types path).

## Task A (v5-hsr): `yarn lint` was dead as a gate

**Root cause:** the repo's `eslintConfig` configures the `prettier/prettier` rule but relied on the community RN config to register the plugin — `@react-native/eslint-config@0.86` no longer bundles `eslint-plugin-prettier` (it only extends `eslint-config-prettier`, which merely *disables* conflicting rules). Result: "Definition for rule 'prettier/prettier' was not found" on every file (~115 problems), so the gate reported noise and caught nothing.

**Fix:** register the already-installed plugin explicitly (`"plugins": ["prettier"]`). With rule resolution restored, real lint surfaced 2 errors + 18 warnings, all addressed:

- `src/api/CastSession.ts` — pre-existing prettier drift (reformat only)
- `src/state/channel.slice.ts` `_removed` — rest-sibling omit-a-key pattern; extended `@typescript-eslint/no-unused-vars` with `ignoreRestSiblings: true` (mirrors the base config's own JS-side rule), keeping the RN config's `argsIgnorePattern`/`destructuredArrayIgnorePattern`
- `no-void` (9 warnings) — all intentional statement-position discards (fire-and-forget promises, `void _var` markers); configured `allowAsStatement: true` so expression-position `void` stays flagged
- `@typescript-eslint/no-shadow` in tests (9 warnings) — aliased re-required classes inside `jest.mock` factories (matching the existing `CastStore: Store` convention) and renamed shadowing local `Probe` components
- `scripts/docsWatch.js` — dropped unused `stats` callback arg

`yarn lint` is now **0 errors, 0 warnings**, and provably meaningful: a stdin negative test (`const x = "double-quoted";`) is flagged by `prettier/prettier` again.

## Task B (v5-ohe): bob `types` path mismatch — real bug

`yarn prepare` failed outright: bob's typescript target validates the `types` field and errored — `types` pointed at `lib/typescript/index.d.ts` while tsc emits `lib/typescript/src/index.d.ts`. The `src/` nesting is intrinsic: `src/components/CastButton.tsx` imports JSON from `nitrogen/generated/` (outside `src/`), widening tsc's inferred `rootDir` to the package root.

**Fix:** point `types` at the emitted path (bob's own suggestion; matches current create-react-native-library convention). Verified: `yarn prepare` succeeds; `main`/`module`/`types` targets all exist on disk; `npx @arethetypeswrong/cli --pack` resolves types green in node10/node16 modes (its only note is the long-standing babel-CJS default-export interop quirk, unrelated to the types path).

## Gates

- `yarn typescript` — clean
- `yarn test` — 18 suites, 316 tests passing
- `yarn lint` — 0 errors, 0 warnings
- `yarn prettier --check` — clean
- `yarn prepare` — succeeds, output paths verified

No native (ios/android) or example changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the package’s TypeScript declaration entrypoint for improved compatibility.
  * Refined development tooling and linting rules for clearer code quality checks.
  * Simplified internal documentation watch behavior without changing its output.
  * Applied minor code-formatting and test-mock maintenance updates.

* **Tests**
  * Improved test setup consistency across casting, media, and component test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->