### PR TITLE
feat(web): CastButton via <google-cast-launcher> (v5-86p)

### DIFF
--- a/docs/components/CastButton.md
+++ b/docs/components/CastButton.md
@@ -36,7 +36,27 @@ Besides being the standard way to start casting, a mounted, visible `CastButton`
 
 Note that unlike v4, [`showCastDialog`](../api/classes/castcontext) no longer requires a mounted `CastButton` — it presents the dialog directly.
 
-On web, `CastButton` renders nothing (web sender support comes in a later phase).
+## Web
+
+On web, `CastButton` renders the Cast Web Sender framework's
+[`<google-cast-launcher>` element](https://developers.google.com/cast/docs/web_sender/integrate#add_a_cast_button),
+whose appearance, visibility, and click handling (opening the browser's Cast
+picker) are managed entirely by the CAF framework:
+
+- `tintColor` maps to the launcher's documented `--connected-color` **and**
+  `--disconnected-color` CSS custom properties (the single native tint
+  applies to both states). Omit it for the SDK's default colors.
+- `style` and the other `View` props apply to a wrapping react-native-web
+  `View`; the launcher fills it. Give it an explicit size (e.g.
+  `style={{ width: 24, height: 24 }}`) — the element has no intrinsic size.
+- Until the [Web Sender SDK](../getting-started/web) is loaded (and in
+  browsers/environments without Cast support, or before the SDK script
+  loads), it renders nothing — a graceful no-op.
+
+The ["Why keep a CastButton mounted"](#why-keep-a-castbutton-mounted) notes
+are native-only: on web the browser owns discovery and the device picker, so
+no mounted button is needed to scan (and `showIntroductoryOverlay` resolves
+`false` on web).
 
 ## Custom Cast Button and Cast Dialog
 

--- a/docs/getting-started/web.md
+++ b/docs/getting-started/web.md
@@ -77,9 +77,14 @@ The user picks a device there;
 is what runs underneath. Session lifecycle events, media status, volume, and
 custom channels then stream through the same hooks and listeners as on native.
 
-The built-in `<CastButton>` renders `null` on web for now — call
-`showCastDialog()` from your own button, or render the SDK's
-`<google-cast-launcher>` element yourself.
+Or just render the built-in [`<CastButton>`](../components/CastButton#web):
+on web it renders the SDK's
+[`<google-cast-launcher>` element](https://developers.google.com/cast/docs/web_sender/integrate#add_a_cast_button)
+(appearance, visibility, and clicks are handled by the CAF framework), maps
+`tintColor` to the launcher's `--connected-color`/`--disconnected-color` CSS
+custom properties, and renders nothing until the SDK loads (or forever, in
+browsers without Cast support). Give it an explicit size — the element has
+no intrinsic one.
 
 ## What works on web
 
@@ -91,6 +96,7 @@ The built-in `<CastButton>` renders `null` on web for now — call
 | `useDevices` / `DiscoveryManager`                                                 | ⚠️ device list is always empty; discovery controls are no-ops                                                                                      |
 | `SessionManager.startSession(deviceId)`                                           | ⚠️ web ignores `deviceId` — the browser owns the picker, which opens instead (dev-only `console.warn` flags it)                                    |
 | `showCastDialog()`                                                                | ✅ browser Cast picker                                                                                                                             |
+| `<CastButton>`                                                                    | ✅ renders the SDK's `<google-cast-launcher>`; `tintColor` → `--connected-color`/`--disconnected-color`; renders nothing until the SDK is loaded   |
 | `showExpandedControls()` / `showIntroductoryOverlay()`                            | ❌ resolves `false` (no such UI in the web SDK)                                                                                                    |
 | `showPlayServicesErrorDialog()`                                                   | ❌ resolves `false` (Android-only)                                                                                                                 |
 | `CastSession` volume / mute / app metadata / status / active input                | ✅                                                                                                                                                 |

--- a/src/components/CastButton.web.tsx
+++ b/src/components/CastButton.web.tsx
@@ -1,4 +1,11 @@
-import type { ColorValue, ViewProps } from 'react-native'
+import * as React from 'react'
+import {
+  processColor,
+  View,
+  type ColorValue,
+  type ViewProps,
+} from 'react-native'
+import { isSdkPresent, subscribeSdkAvailability } from '../transport/webSdk'
 
 export interface CastButtonProps extends ViewProps {
   /** Tint color of the Cast icon (any RN `ColorValue`). Omit for the platform default. */
@@ -6,16 +13,82 @@ export interface CastButtonProps extends ViewProps {
 }
 
 /**
- * Web build of {@link CastButton}: renders nothing (E3).
- *
- * The native wrapper's `getHostComponent` deep-imports React Native
- * internals that react-native-web does not provide, so this split keeps the
- * import out of web *bundles* entirely. The web transport itself is real
- * (Cast Web Sender SDK) — trigger the browser's Cast picker with
- * `CastContext.showCastDialog()` (or render the SDK's
- * `<google-cast-launcher>` element yourself); a first-party web button is
- * tracked separately.
+ * Convert an RN `ColorValue` to a CSS color string for the launcher's
+ * `--connected-color` / `--disconnected-color` custom properties. String
+ * colors pass through (RN's color syntax — names, hex incl. #rrggbbaa,
+ * rgb()/rgba()/hsl() — is CSS-compatible); anything else (`PlatformColor`,
+ * numeric colors) goes through `processColor` and its 0xAARRGGBB int is
+ * rendered as `rgba()`.
  */
-export function CastButton(_props: CastButtonProps): null {
-  return null
+function toCssColor(color: ColorValue | undefined): string | undefined {
+  if (color == null) return undefined
+  if (typeof color === 'string') return color
+  const processed = processColor(color)
+  if (typeof processed !== 'number') return undefined
+  /* eslint-disable no-bitwise -- unpacking the processed 0xAARRGGBB color int */
+  const argb = processed >>> 0
+  const a = (argb >>> 24) & 0xff
+  const r = (argb >>> 16) & 0xff
+  const g = (argb >>> 8) & 0xff
+  const b = argb & 0xff
+  /* eslint-enable no-bitwise */
+  return `rgba(${r}, ${g}, ${b}, ${Math.round((a / 255) * 1000) / 1000})`
+}
+
+/**
+ * Web build of {@link CastButton}: renders the Cast Web Sender framework's
+ * `<google-cast-launcher>` custom element
+ * (https://developers.google.com/cast/docs/web_sender/integrate#add_a_cast_button),
+ * whose appearance, visibility, and click handling (opening the browser's
+ * Cast picker) are managed entirely by the CAF framework.
+ *
+ * Matches the native prop surface where the web SDK allows:
+ * - `tintColor` maps to the launcher's documented `--connected-color` and
+ *   `--disconnected-color` CSS custom properties (both, so the single native
+ *   tint semantic carries over).
+ * - `style` + remaining `ViewProps` go to a react-native-web `View` wrapper;
+ *   the launcher fills it (size it like on native, e.g.
+ *   `style={{ width: 24, height: 24 }}` — it has no intrinsic size).
+ *
+ * Until the SDK announces readiness through the `__onGCastApiAvailable`
+ * handshake (see `transport/webSdk.ts`) it renders nothing, and if the page
+ * never loads the sender script — or the browser is not Chromium-based — it
+ * stays `null` forever: graceful no-op, nothing crashes (also under
+ * jest/jsdom, where no SDK globals exist).
+ *
+ * This file is resolved via the `.web.tsx` extension, so `react-native`
+ * imports resolve to react-native-web and the native wrapper's
+ * `getHostComponent` (which deep-imports RN internals react-native-web does
+ * not provide) never enters web bundles.
+ */
+export function CastButton({ tintColor, ...props }: CastButtonProps) {
+  const sdkReady = React.useSyncExternalStore(
+    subscribeSdkAvailability,
+    isSdkPresent,
+    // Server snapshot: the SDK can never be present during SSR.
+    () => false
+  )
+  if (!sdkReady) return null
+
+  const css = toCssColor(tintColor)
+  const launcherStyle: Record<string, string> = {
+    display: 'block',
+    width: '100%',
+    height: '100%',
+    cursor: 'pointer',
+  }
+  if (css !== undefined) {
+    launcherStyle['--connected-color'] = css
+    launcherStyle['--disconnected-color'] = css
+  }
+  return (
+    <View {...props}>
+      {
+        // createElement (not JSX) so the custom element needs no global
+        // IntrinsicElements augmentation, which would leak into the
+        // published .d.ts.
+        React.createElement('google-cast-launcher', { style: launcherStyle })
+      }
+    </View>
+  )
 }

--- a/src/components/__tests__/CastButton.test.tsx
+++ b/src/components/__tests__/CastButton.test.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 import TestRenderer, { act } from 'react-test-renderer'
-import { processColor } from 'react-native'
+import { processColor, View, type ColorValue } from 'react-native'
 import { getHostComponent } from 'react-native-nitro-modules'
 import GeneratedCastButtonConfig from '../../../nitrogen/generated/shared/json/CastButtonConfig.json'
 import { CastButton } from '../CastButton'
 import { CastButton as CastButtonWeb } from '../CastButton.web'
+import {
+  clearWebSdkGlobals,
+  installFakeWebSdk,
+} from '../../transport/__fakes__/fakeWebCastSdk'
 
 // The real getHostComponent deep-imports RN internals
 // (react-native/Libraries/NativeComponent/NativeComponentRegistry), which
@@ -91,12 +95,94 @@ describe('CastButton', () => {
   })
 })
 
-describe('CastButton.web (E3)', () => {
-  it('renders null (graceful degradation; native wrapper never imported)', () => {
+describe('CastButton.web (v5-86p)', () => {
+  afterEach(() => {
+    clearWebSdkGlobals()
+  })
+
+  function launcher(
+    renderer: TestRenderer.ReactTestRenderer
+  ): TestRenderer.ReactTestInstance {
+    return renderer.root.findByType(
+      'google-cast-launcher' as unknown as React.ElementType
+    )
+  }
+
+  it('renders null when the SDK is absent (graceful; native wrapper never imported)', () => {
     const renderer = render(
       <CastButtonWeb tintColor="red" style={{ width: 24 }} />
     )
     expect(renderer.toJSON()).toBeNull()
+    act(() => renderer.unmount())
+  })
+
+  it('renders the <google-cast-launcher> element when the SDK is present', () => {
+    installFakeWebSdk()
+    const renderer = render(<CastButtonWeb />)
+    const element = launcher(renderer)
+    // Framework owns appearance/clicks; the launcher just fills the wrapper.
+    expect(element.props.style).toMatchObject({
+      display: 'block',
+      width: '100%',
+      height: '100%',
+    })
+    // No tintColor → no color custom properties (SDK defaults apply).
+    expect(element.props.style['--connected-color']).toBeUndefined()
+    expect(element.props.style['--disconnected-color']).toBeUndefined()
+    act(() => renderer.unmount())
+  })
+
+  it('maps tintColor to both --connected-color and --disconnected-color', () => {
+    installFakeWebSdk()
+    const renderer = render(<CastButtonWeb tintColor="#ff0000" />)
+    const style = launcher(renderer).props.style
+    expect(style['--connected-color']).toBe('#ff0000')
+    expect(style['--disconnected-color']).toBe('#ff0000')
+    act(() => renderer.unmount())
+  })
+
+  it('converts non-string ColorValues via processColor to rgba()', () => {
+    installFakeWebSdk()
+    // A numeric ColorValue exercises the processColor branch: 0xff0000ff is
+    // RRGGBBAA (opaque red) which processColor rotates to 0xffff0000.
+    expect(processColor(0xff0000ff)).toBe(0xffff0000)
+    const renderer = render(
+      <CastButtonWeb tintColor={0xff0000ff as unknown as ColorValue} />
+    )
+    const style = launcher(renderer).props.style
+    expect(style['--connected-color']).toBe('rgba(255, 0, 0, 1)')
+    expect(style['--disconnected-color']).toBe('rgba(255, 0, 0, 1)')
+    act(() => renderer.unmount())
+  })
+
+  it('passes style and other ViewProps to the wrapper View', () => {
+    installFakeWebSdk()
+    const style = { width: 24, height: 24 }
+    const renderer = render(
+      <CastButtonWeb style={style} testID="cast" accessibilityLabel="Cast" />
+    )
+    const view = renderer.root.findByType(View)
+    expect(view.props.style).toBe(style)
+    expect(view.props.testID).toBe('cast')
+    expect(view.props.accessibilityLabel).toBe('Cast')
+    // tintColor is consumed by the wrapper, not leaked onto the View.
+    expect('tintColor' in view.props).toBe(false)
+    act(() => renderer.unmount())
+  })
+
+  it('appears once the SDK announces readiness via __onGCastApiAvailable', () => {
+    const renderer = render(<CastButtonWeb />)
+    expect(renderer.toJSON()).toBeNull()
+
+    installFakeWebSdk()
+    act(() => {
+      ;(
+        globalThis as {
+          __onGCastApiAvailable?: (available: boolean) => void
+        }
+      ).__onGCastApiAvailable?.(true)
+    })
+    expect(launcher(renderer)).toBeDefined()
     act(() => renderer.unmount())
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ export { useCastSession } from './api/useCastSession'
 export { useCastDevice } from './api/useCastDevice'
 export type { UseCastSessionOptions } from './api/useCastSession'
 
-// Components (CastButton resolves to CastButton.web on web — renders null).
+// Components (CastButton resolves to CastButton.web on web — renders the
+// Cast Web Sender's <google-cast-launcher> once the SDK loads).
 export { CastButton } from './components/CastButton'
 export type { CastButtonProps } from './components/CastButton'
 export type { SessionEventHandler } from './api/SessionManager'

--- a/src/transport/webSdk.ts
+++ b/src/transport/webSdk.ts
@@ -101,6 +101,34 @@ export function onSdkAvailable(callback: (available: boolean) => void): void {
   }
 }
 
+const availabilityListeners = new Set<() => void>()
+let availabilityHookInstalled = false
+
+/**
+ * Subscribe to SDK-availability changes (a `useSyncExternalStore`-shaped
+ * seam for UI like `CastButton.web`). Returns an unsubscribe function, so —
+ * unlike raw {@link onSdkAvailable}, whose handler chain only ever grows —
+ * mounting/unmounting components does not accumulate handlers: one shared
+ * hook fans out to a Set. If the global hook slot was cleared after install
+ * (tests), the next subscribe reinstalls it; a duplicate chained hook only
+ * causes redundant notifications, which snapshot reads make harmless.
+ */
+export function subscribeSdkAvailability(listener: () => void): () => void {
+  if (
+    !availabilityHookInstalled ||
+    castGlobal().__onGCastApiAvailable === undefined
+  ) {
+    availabilityHookInstalled = true
+    onSdkAvailable(() => {
+      for (const l of [...availabilityListeners]) l()
+    })
+  }
+  availabilityListeners.add(listener)
+  return () => {
+    availabilityListeners.delete(listener)
+  }
+}
+
 /** The app-provided {@link WebCastOptions}, if any. */
 export function getWebCastOptions(): WebCastOptions {
   return castGlobal().__RNGoogleCastOptions ?? {}


### PR DESCRIPTION
Wires `src/components/CastButton.web.tsx` — previously a stub rendering `null` — to the Cast Web Sender framework's [`<google-cast-launcher>` custom element](https://developers.google.com/cast/docs/web_sender/integrate#add_a_cast_button), matching native `CastButton` semantics where the web SDK allows. Builds on the web transport from #629.

## What it does

- **Renders the SDK's launcher element**: per [Google's Web Sender integration guide](https://developers.google.com/cast/docs/web_sender/integrate#add_a_cast_button), the button's appearance, visibility, and click handling (opening the browser's Cast picker) are "handled entirely by the framework".
- **`tintColor` → `--connected-color` + `--disconnected-color`**: the launcher's two documented CSS custom properties. Native has a single tint, so it applies to both states. String `ColorValue`s pass through as CSS (RN's color string syntax is CSS-compatible); non-string values go through `processColor` and its `0xAARRGGBB` int renders as `rgba()`.
- **`style` + remaining `ViewProps`** go to a react-native-web `View` wrapper (full RN style semantics: arrays, `testID`, accessibility props); the launcher fills it at 100%/100%. Like the docs' native example, it needs an explicit size — the custom element has no intrinsic one.
- **Graceful no-op without the SDK**: availability rides the transport's existing `__onGCastApiAvailable` handshake seam (`transport/webSdk.ts`). New `subscribeSdkAvailability()` export — a Set-based fan-out over one chained hook, so mount/unmount cycles don't grow the raw handler chain — feeds `useSyncExternalStore` (server snapshot `false`, so SSR-safe). The button renders `null` until the SDK announces readiness, and forever if the page never loads the sender script or the browser isn't Chromium-based. Nothing crashes under jest.
- The custom element is created via `React.createElement`, not JSX, so no global `IntrinsicElements` augmentation leaks into the published `.d.ts`.

## Tests

Extends `src/components/__tests__/CastButton.test.tsx` using the `fakeWebCastSdk` seam from #629:
- SDK absent → renders `null`
- SDK present → `<google-cast-launcher>` rendered; no color properties when `tintColor` omitted
- `tintColor` string + numeric (`processColor`) mapping to both custom properties
- `style`/`testID`/`accessibilityLabel` passthrough to the wrapper `View` (and `tintColor` not leaked)
- late `__onGCastApiAvailable(true)` handshake → button appears after mount

## Docs

- `docs/components/CastButton.md`: new **Web** section (prop mapping, sizing, graceful no-op; notes the "why keep a button mounted" discovery reasons are native-only).
- `docs/getting-started/web.md`: "Starting a session" now points at the built-in `<CastButton>`; new `<CastButton>` row in the "What works on web" table.

## Gates

- `yarn typescript` ✅
- `yarn test` ✅ 19 suites / 379 tests
- `yarn lint` ✅ 0 errors / 0 warnings
- `prettier --check "src/**/*.{ts,tsx}"` ✅ (edited docs kept prettier-clean where they already were)

No native or example/ios changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web support for `CastButton` using the Google Cast launcher.
  * The button appears once the Cast Web Sender SDK is available.
  * Supports custom tint colors for connected and disconnected states.
  * Supports standard styling, sizing, accessibility, and view properties.

* **Documentation**
  * Updated web and component documentation to describe CastButton behavior, styling, sizing, and SDK availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->